### PR TITLE
Chore/msp 13004/style fixes

### DIFF
--- a/.pullreview.yml
+++ b/.pullreview.yml
@@ -4,3 +4,7 @@ notifications:
     comment: verbose
 languages:
   - ruby
+rules:
+  ignore:
+    - avoid_similar_code
+    - refactor_complex_method

--- a/lib/ruby_smb/dispatcher/base.rb
+++ b/lib/ruby_smb/dispatcher/base.rb
@@ -1,3 +1,4 @@
+# Provides the base class for the packet dispatcher.
 class RubySMB::Dispatcher::Base
   # @param packet [#length]
   # @return [Fixnum] NBSS header to go in front of `packet`

--- a/lib/ruby_smb/dispatcher/socket.rb
+++ b/lib/ruby_smb/dispatcher/socket.rb
@@ -1,5 +1,6 @@
 require 'socket'
-
+# This class provides a wrapper around a Socket for the packet Dispatcher.
+# It allows for dependency injection of different Socket implementations.
 class RubySMB::Dispatcher::Socket < Smb2::Dispatcher::Base
 
   # @!attribute [rw] socket

--- a/lib/ruby_smb/smb2.rb
+++ b/lib/ruby_smb/smb2.rb
@@ -8,7 +8,6 @@ module RubySMB::Smb2
   autoload :Packet, 'ruby_smb/smb2/packet'
   autoload :Tree, 'ruby_smb/smb2/tree'
 
-
   # [[MS-SMB2] 2.2 Message Syntax](https://msdn.microsoft.com/en-us/library/cc246497.aspx)
   COMMANDS = {
     NEGOTIATE:        0x00,

--- a/lib/ruby_smb/smb2/packet.rb
+++ b/lib/ruby_smb/smb2/packet.rb
@@ -335,51 +335,51 @@ module RubySMB::Smb2
     def self.parse(data)
       generic = Generic.new(data)
 
-      case [ generic.command, generic.response? ]
+      case [generic.command, generic.response?]
 
-      when [ COMMANDS[:NEGOTIATE], true ]
+      when [COMMANDS[:NEGOTIATE], true]
         NegotiateResponse.new(generic)
-      when [ COMMANDS[:NEGOTIATE], false ]
+      when [COMMANDS[:NEGOTIATE], false]
         NegotiateRequest.new(generic)
 
-      when [ COMMANDS[:SESSION_SETUP], true ]
+      when [COMMANDS[:SESSION_SETUP], true]
         SessionSetupResponse.new(generic)
-      when [ COMMANDS[:SESSION_SETUP], false ]
+      when [COMMANDS[:SESSION_SETUP], false]
         SessionSetupRequest.new(generic)
 
-      when [ COMMANDS[:TREE_CONNECT], true ]
+      when [COMMANDS[:TREE_CONNECT], true]
         TreeConnectResponse.new(generic)
-      when [ COMMANDS[:TREE_CONNECT], false ]
+      when [COMMANDS[:TREE_CONNECT], false]
         TreeConnectRequest.new(generic)
 
-      when [ COMMANDS[:CREATE], true ]
+      when [COMMANDS[:CREATE], true]
         CreateResponse.new(generic)
-      when [ COMMANDS[:CREATE], false ]
+      when [COMMANDS[:CREATE], false]
         CreateRequest.new(generic)
 
-      when [ COMMANDS[:CLOSE], true ]
+      when [COMMANDS[:CLOSE], true]
         CloseResponse.new(generic)
-      when [ COMMANDS[:CLOSE], false ]
+      when [COMMANDS[:CLOSE], false]
         CloseRequest.new(generic)
 
-      when [ COMMANDS[:READ], true ]
+      when [COMMANDS[:READ], true]
         ReadResponse.new(generic)
-      when [ COMMANDS[:READ], false ]
+      when [COMMANDS[:READ], false]
         ReadRequest.new(generic)
 
-      when [ COMMANDS[:WRITE], true ]
+      when [COMMANDS[:WRITE], true]
         WriteResponse.new(generic)
-      when [ COMMANDS[:WRITE], false ]
+      when [COMMANDS[:WRITE], false]
         WriteRequest.new(generic)
 
-      when [ COMMANDS[:QUERY_DIRECTORY], true ]
+      when [COMMANDS[:QUERY_DIRECTORY], true]
         QueryDirectoryResponse.new(generic)
-      when [ COMMANDS[:QUERY_DIRECTORY], false ]
+      when [COMMANDS[:QUERY_DIRECTORY], false]
         QueryDirectoryRequest.new(generic)
 
-      when [ COMMANDS[:QUERY_INFO], true ]
+      when [COMMANDS[:QUERY_INFO], true]
         QueryInfoResponse.new(generic)
-      when [ COMMANDS[:QUERY_INFO], false ]
+      when [COMMANDS[:QUERY_INFO], false]
         QueryInfoRequest.new(generic)
 
       else

--- a/lib/ruby_smb/smb2/packet/create_request.rb
+++ b/lib/ruby_smb/smb2/packet/create_request.rb
@@ -1,6 +1,5 @@
 require 'ruby_smb/smb2/packet'
 
-
 # [Section 2.2.13 SMB2 CREATE Request](http://msdn.microsoft.com/en-us/library/cc246502.aspx)
 #
 # [Example 4.4 Executing an Operation on a Named Pipe](http://msdn.microsoft.com/en-us/library/cc246794.aspx)

--- a/lib/ruby_smb/smb2/packet/echo_request.rb
+++ b/lib/ruby_smb/smb2/packet/echo_request.rb
@@ -4,7 +4,7 @@ class RubySMB::Smb2::Packet::EchoRequest < RubySMB::Smb2::Packet::Request
   # A key in {RubySMB::Smb2::COMMANDS}
   COMMAND = :ECHO
 
-  unsigned :structure_size, 16, default:4
+  unsigned :structure_size, 16, default: 4
   unsigned :reserved, 16
 
 end

--- a/lib/ruby_smb/smb2/packet/generic.rb
+++ b/lib/ruby_smb/smb2/packet/generic.rb
@@ -154,7 +154,7 @@ module RubySMB::Smb2::Packet
     # @param session_key [String] the key to sign with
     # @return [void]
     def sign!(session_key)
-      self.signature = "\0"*16
+      self.signature = "\0" * 16
       self.header_flags |= RubySMB::Smb2::Packet::HEADER_FLAGS[:SIGNING]
 
       hmac = OpenSSL::HMAC.digest(OpenSSL::Digest::SHA256.new, session_key, self.to_s)

--- a/lib/ruby_smb/smb2/packet/generic.rb
+++ b/lib/ruby_smb/smb2/packet/generic.rb
@@ -87,7 +87,7 @@ module RubySMB::Smb2::Packet
       # implicitly pass a block if one was given
       super
 
-      if !data_buffer_fields.empty?
+      unless data_buffer_fields.empty?
         data_buffer_fields.each do |buffer_name|
           @data_buffers[buffer_name] = self.send(buffer_name) || ""
         end

--- a/lib/ruby_smb/smb2/packet/generic.rb
+++ b/lib/ruby_smb/smb2/packet/generic.rb
@@ -1,5 +1,5 @@
-
 module RubySMB::Smb2::Packet
+  # Class that represents a generic SMB2 packet.
   class Generic < BitStruct
 
     # Values in SMB are always little endian. Make all fields default to little
@@ -112,7 +112,6 @@ module RubySMB::Smb2::Packet
       raise InvalidFlagError, flag.to_s unless HEADER_FLAG_NAMES.include?(flag)
       (header_flags & HEADER_FLAGS[flag]) == HEADER_FLAGS[flag]
     end
-
 
     # A generic flag checking method. Subclasses should have a field named
     # `flags`, and constants `FLAGS` and `FLAG_NAMES`.

--- a/lib/ruby_smb/smb2/packet/negotiate_request.rb
+++ b/lib/ruby_smb/smb2/packet/negotiate_request.rb
@@ -1,6 +1,5 @@
 require 'ruby_smb/smb2/packet'
 
-
 # [Section 2.2.3 SMB2 NEGOTIATE Request](https://msdn.microsoft.com/en-us/library/cc246543.aspx)
 class RubySMB::Smb2::Packet::NegotiateRequest < RubySMB::Smb2::Packet::Request
 

--- a/lib/ruby_smb/smb2/packet/query.rb
+++ b/lib/ruby_smb/smb2/packet/query.rb
@@ -16,6 +16,12 @@ module RubySMB::Smb2::Packet::Query
     FileNamesInformation: NamesInformation
   }
 
+  # Takes a blob of data received from the wire and converts it
+  # into an array of objects for the supplied class.
+  #
+  # @param blob [String] the blob of data taken from the wire.
+  # @param klass [Class] the class of objects to create from the blob
+  # @return [Array] the array of objects parsed from the blob
   def self.class_array_from_blob(blob, klass)
     class_array = []
     offset = 0

--- a/lib/ruby_smb/smb2/packet/query_directory_request.rb
+++ b/lib/ruby_smb/smb2/packet/query_directory_request.rb
@@ -32,7 +32,7 @@ class RubySMB::Smb2::Packet::QueryDirectoryRequest < RubySMB::Smb2::Packet::Requ
 
   data_buffer :file_name, 16
 
-  unsigned :output_buffer_length, 32, default: 65535
+  unsigned :output_buffer_length, 32, default: 65_535
 
   rest :buffer
 

--- a/lib/ruby_smb/smb2/packet/query_info_response.rb
+++ b/lib/ruby_smb/smb2/packet/query_info_response.rb
@@ -1,6 +1,5 @@
 require 'ruby_smb/smb2/packet'
 
-
 # [[MS-SMB2] 2.2.38 SMB2 QUERY_INFO Response](https://msdn.microsoft.com/en-us/library/cc246559.aspx)
 class RubySMB::Smb2::Packet::QueryInfoResponse < RubySMB::Smb2::Packet::Response
   COMMAND = :QUERY_INFO
@@ -11,4 +10,3 @@ class RubySMB::Smb2::Packet::QueryInfoResponse < RubySMB::Smb2::Packet::Response
 
   rest :buffer
 end
-

--- a/lib/ruby_smb/smb2/packet/read_request.rb
+++ b/lib/ruby_smb/smb2/packet/read_request.rb
@@ -13,7 +13,7 @@ class RubySMB::Smb2::Packet::ReadRequest < RubySMB::Smb2::Packet::Request
     READ_UNBUFFERED: 0x01
   }.freeze
 
-  #nest :header, RequestHeader
+  # nest :header, RequestHeader
 
   unsigned :struct_size, 16, default: 49
 

--- a/lib/ruby_smb/smb2/packet/write_response.rb
+++ b/lib/ruby_smb/smb2/packet/write_response.rb
@@ -1,6 +1,5 @@
 require 'ruby_smb/smb2/packet'
 
-
 # [Section 2.2.22 SMB2 Write Response](http://msdn.microsoft.com/en-us/library/cc246533.aspx)
 #
 # [Example 4.4 Executing an Operation on a Named Pipe](http://msdn.microsoft.com/en-us/library/cc246794.aspx)

--- a/lib/ruby_smb/smb2/tree.rb
+++ b/lib/ruby_smb/smb2/tree.rb
@@ -197,29 +197,27 @@ class RubySMB::Smb2::Tree
   private
 
   def desired_access_from_mode(mode)
+    # Read-only is our base access here.
+    base_access_mask = RubySMB::Smb2::Packet::FILE_ACCESS_MASK[:FILE_READ_DATA] |
+      RubySMB::Smb2::Packet::FILE_ACCESS_MASK[:FILE_READ_EA] |
+      RubySMB::Smb2::Packet::FILE_ACCESS_MASK[:FILE_READ_ATTRIBUTES] |
+      RubySMB::Smb2::Packet::FILE_ACCESS_MASK[:READ_CONTROL] |
+      RubySMB::Smb2::Packet::FILE_ACCESS_MASK[:SYNCHRONIZE]
     case mode
     when "r+", "w+", "a+", "w", "a"
       # read/write and write-only. Samba's smbclient sets all the read flags
       # when writing, so emulate that.
-      RubySMB::Smb2::Packet::FILE_ACCESS_MASK[:FILE_READ_DATA] |
+      access_mask = base_access_mask |
         RubySMB::Smb2::Packet::FILE_ACCESS_MASK[:FILE_WRITE_DATA] |
         RubySMB::Smb2::Packet::FILE_ACCESS_MASK[:FILE_APPEND_DATA] |
-        RubySMB::Smb2::Packet::FILE_ACCESS_MASK[:FILE_READ_EA] |
         RubySMB::Smb2::Packet::FILE_ACCESS_MASK[:FILE_WRITE_EA] |
-        RubySMB::Smb2::Packet::FILE_ACCESS_MASK[:FILE_READ_ATTRIBUTES] |
         RubySMB::Smb2::Packet::FILE_ACCESS_MASK[:FILE_WRITE_ATTRIBUTES] |
-        RubySMB::Smb2::Packet::FILE_ACCESS_MASK[:READ_CONTROL] |
-        RubySMB::Smb2::Packet::FILE_ACCESS_MASK[:SYNCHRONIZE]
     when "r"
-      # read-only
-      RubySMB::Smb2::Packet::FILE_ACCESS_MASK[:FILE_READ_DATA] |
-        RubySMB::Smb2::Packet::FILE_ACCESS_MASK[:FILE_READ_EA] |
-        RubySMB::Smb2::Packet::FILE_ACCESS_MASK[:FILE_READ_ATTRIBUTES] |
-        RubySMB::Smb2::Packet::FILE_ACCESS_MASK[:READ_CONTROL] |
-        RubySMB::Smb2::Packet::FILE_ACCESS_MASK[:SYNCHRONIZE]
+      access_mask = base_access_mask
     else
       raise ArgumentError
     end
+    access_mask
   end
 
   def disposition_from_file_mode(mode)

--- a/lib/ruby_smb/version.rb
+++ b/lib/ruby_smb/version.rb
@@ -9,8 +9,6 @@ module RubySMB
     # The patch number, scoped to the {MINOR} version number.
     PATCH = 7
 
-    PRERELEASE = 'style-fixes'
-
     # The full version string, including the {MAJOR}, {MINOR}, {PATCH}, and optionally, the `PRERELEASE` in the
     # {http://semver.org/spec/v2.0.0.html semantic versioning v2.0.0} format.
     #

--- a/lib/ruby_smb/version.rb
+++ b/lib/ruby_smb/version.rb
@@ -9,7 +9,7 @@ module RubySMB
     # The patch number, scoped to the {MINOR} version number.
     PATCH = 7
 
-    PRERELEASE = 'smb-rename'
+    PRERELEASE = 'style-fixes'
 
     # The full version string, including the {MAJOR}, {MINOR}, {PATCH}, and optionally, the `PRERELEASE` in the
     # {http://semver.org/spec/v2.0.0.html semantic versioning v2.0.0} format.

--- a/spec/lib/ruby_smb/smb2/packet/close_response_spec.rb
+++ b/spec/lib/ruby_smb/smb2/packet/close_response_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe RubySMB::Smb2::Packet::CloseResponse do
     described_class.new(data)
   end
 
-
   context 'with packet bytes' do
     let(:data) do
       [

--- a/spec/lib/ruby_smb/smb2/packet/create_response_spec.rb
+++ b/spec/lib/ruby_smb/smb2/packet/create_response_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe RubySMB::Smb2::Packet::CreateResponse do
       expect(packet.end_of_file).to eq(0)
       expect(packet.file_attributes).to eq(0x0000_0080)
 
-      #expect(packet.reserved2).to eq(0)
+      # expect(packet.reserved2).to eq(0)
       expect(packet.file_id).to eq(["250000000000000001000000ffffffff"].pack('H*'))
     end
 

--- a/spec/lib/ruby_smb/smb2/packet/echo_request_spec.rb
+++ b/spec/lib/ruby_smb/smb2/packet/echo_request_spec.rb
@@ -16,7 +16,6 @@ RSpec.describe RubySMB::Smb2::Packet::EchoRequest do
       expect(structure_size_field.length).to eq 16
     end
 
-
     it "should be hardcoded to 4 bits per the SMB spec" do
       expect(echo_request_packet.structure_size).to eq 4
     end

--- a/spec/lib/ruby_smb/smb2/packet/echo_request_spec.rb
+++ b/spec/lib/ruby_smb/smb2/packet/echo_request_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.describe RubySMB::Smb2::Packet::EchoRequest do
 
-  subject(:echo_request_packet){ described_class.new }
+  subject(:echo_request_packet) { described_class.new }
 
   context "COMMAND" do
     it 'should be :ECHO' do
@@ -12,7 +12,7 @@ RSpec.describe RubySMB::Smb2::Packet::EchoRequest do
 
   context "structure_size" do
     it 'should be a 16-bit field per the SMB spec' do
-      structure_size_field = echo_request_packet.fields.detect{|f| f.display_name == :structure_size }
+      structure_size_field = echo_request_packet.fields.detect { |f| f.display_name == :structure_size }
       expect(structure_size_field.length).to eq 16
     end
 
@@ -24,7 +24,7 @@ RSpec.describe RubySMB::Smb2::Packet::EchoRequest do
 
   context "reserved" do
     it 'should be a 16-bit field per the SMB spec' do
-      reserved_field = echo_request_packet.fields.detect{|f| f.display_name == :reserved }
+      reserved_field = echo_request_packet.fields.detect { |f| f.display_name == :reserved }
       expect(reserved_field.length).to eq 16
     end
   end

--- a/spec/lib/ruby_smb/smb2/packet/echo_response_spec.rb
+++ b/spec/lib/ruby_smb/smb2/packet/echo_response_spec.rb
@@ -2,11 +2,11 @@ require 'spec_helper'
 
 RSpec.describe RubySMB::Smb2::Packet::EchoResponse do
 
-  subject(:echo_response_packet){ described_class.new }
+  subject(:echo_response_packet) { described_class.new }
 
   context "structure_size" do
     it 'should be a 16-bit field per the SMB spec' do
-      structure_size_field = echo_response_packet.fields.detect{|f| f.display_name == :structure_size }
+      structure_size_field = echo_response_packet.fields.detect { |f| f.display_name == :structure_size }
       expect(structure_size_field.length).to eq 16
     end
 
@@ -17,7 +17,7 @@ RSpec.describe RubySMB::Smb2::Packet::EchoResponse do
 
   context "reserved" do
     it 'should be a 16-bit field per the SMB spec' do
-      reserved_field = echo_response_packet.fields.detect{|f| f.display_name == :reserved }
+      reserved_field = echo_response_packet.fields.detect { |f| f.display_name == :reserved }
       expect(reserved_field.length).to eq 16
     end
   end

--- a/spec/lib/ruby_smb/smb2/packet/generic_spec.rb
+++ b/spec/lib/ruby_smb/smb2/packet/generic_spec.rb
@@ -47,9 +47,7 @@ RSpec.describe RubySMB::Smb2::Packet::Generic do
 
       specify do
         inst = nil
-        expect {
-          inst = klass.new(data: "asdf")
-        }.to_not raise_error
+        expect { inst = klass.new(data: "asdf") }.to_not raise_error
         expect(inst.struct_size).to eq(8)
         expect(inst.data_length).to eq(4)
         expect(inst.data).to eq("asdf")
@@ -61,11 +59,11 @@ RSpec.describe RubySMB::Smb2::Packet::Generic do
 
       specify do
         inst = nil
-        expect {
+        expect do
           inst = klass.new do |packet|
             packet.data = "asdf"
           end
-        }.to_not raise_error
+        end.to_not raise_error
         expect(inst.struct_size).to eq(8)
         expect(inst.data_length).to eq(4)
         expect(inst.data).to eq("asdf")

--- a/spec/lib/ruby_smb/smb2/packet/generic_spec.rb
+++ b/spec/lib/ruby_smb/smb2/packet/generic_spec.rb
@@ -141,16 +141,6 @@ RSpec.describe RubySMB::Smb2::Packet::Generic do
   end
 
   describe '#sign!' do
-    let(:klass) do
-      Class.new(described_class) do
-        # struct_size is part of the API and must be present
-        # 2 bytes for struct_size itself, 2 for data_offset, 4 for data_length
-        unsigned :struct_size, 16, default: 2 + 2 + 4
-        data_buffer :data, 32
-        rest :buffer
-      end
-    end
-
     let(:key) { "0123456789abcdef" }
 
     specify do

--- a/spec/lib/ruby_smb/smb2/packet/negotiate_request_spec.rb
+++ b/spec/lib/ruby_smb/smb2/packet/negotiate_request_spec.rb
@@ -17,18 +17,7 @@ RSpec.describe RubySMB::Smb2::Packet::NegotiateRequest do
 
     it_behaves_like "packet"
     it_behaves_like "request", RubySMB::Smb2::COMMANDS[:NEGOTIATE]
-
-    context 'header' do
-      specify do
-        expect(packet.magic).to eq("\xfeSMB".force_encoding("binary"))
-      end
-      specify do
-        expect(packet.signature).to eq(("\x00" * 16).force_encoding("binary"))
-      end
-      specify do
-        expect(packet.command).to eq(RubySMB::Smb2::COMMANDS[:NEGOTIATE])
-      end
-    end
+    it_behaves_like "smb2_negotiate_packet_header"
 
     context 'body' do
       specify do

--- a/spec/lib/ruby_smb/smb2/packet/negotiate_request_spec.rb
+++ b/spec/lib/ruby_smb/smb2/packet/negotiate_request_spec.rb
@@ -15,9 +15,9 @@ RSpec.describe RubySMB::Smb2::Packet::NegotiateRequest do
       ].pack('H*')
     end
 
-    it_behaves_like "packet"
-    it_behaves_like "request", RubySMB::Smb2::COMMANDS[:NEGOTIATE]
-    it_behaves_like "smb2_negotiate_packet_header"
+    it_behaves_like 'packet'
+    it_behaves_like 'request', RubySMB::Smb2::COMMANDS[:NEGOTIATE]
+    it_behaves_like 'smb2_negotiate_packet_header'
 
     context 'body' do
       specify do

--- a/spec/lib/ruby_smb/smb2/packet/negotiate_response_spec.rb
+++ b/spec/lib/ruby_smb/smb2/packet/negotiate_response_spec.rb
@@ -18,18 +18,7 @@ RSpec.describe RubySMB::Smb2::Packet::NegotiateResponse do
     end
 
     it_behaves_like "packet"
-
-    context 'header' do
-      specify do
-        expect(packet.magic).to eq("\xfeSMB".force_encoding("binary"))
-      end
-      specify do
-        expect(packet.signature).to eq(("\x00" * 16).force_encoding("binary"))
-      end
-      specify do
-        expect(packet.command).to eq(RubySMB::Smb2::COMMANDS[:NEGOTIATE])
-      end
-    end
+    it_behaves_like "smb2_negotiate_packet_header"
 
     context 'body' do
       specify do

--- a/spec/lib/ruby_smb/smb2/packet/negotiate_response_spec.rb
+++ b/spec/lib/ruby_smb/smb2/packet/negotiate_response_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe RubySMB::Smb2::Packet::NegotiateResponse do
       ].pack('H*')
     end
 
-    it_behaves_like "packet"
-    it_behaves_like "smb2_negotiate_packet_header"
+    it_behaves_like 'packet'
+    it_behaves_like 'smb2_negotiate_packet_header'
 
     context 'body' do
       specify do

--- a/spec/lib/ruby_smb/smb2/packet/negotiate_response_spec.rb
+++ b/spec/lib/ruby_smb/smb2/packet/negotiate_response_spec.rb
@@ -30,15 +30,15 @@ RSpec.describe RubySMB::Smb2::Packet::NegotiateResponse do
       end
 
       specify do
-        expect(packet.max_transaction_size).to eq(1048576)
+        expect(packet.max_transaction_size).to eq(1_048_576)
       end
 
       specify do
-        expect(packet.max_read_size).to eq(1048576)
+        expect(packet.max_read_size).to eq(1_048_576)
       end
 
       specify do
-        expect(packet.max_write_size).to eq(1048576)
+        expect(packet.max_write_size).to eq(1_048_576)
       end
 
     end

--- a/spec/lib/ruby_smb/smb2/packet/query_directory_request_spec.rb
+++ b/spec/lib/ruby_smb/smb2/packet/query_directory_request_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe RubySMB::Smb2::Packet::QueryDirectoryRequest do
       end
 
       specify 'output_buffer_length' do
-        expect(packet.output_buffer_length).to eq(65535)
+        expect(packet.output_buffer_length).to eq(65_535)
       end
     end
 

--- a/spec/lib/ruby_smb/smb2/packet/read_response_spec.rb
+++ b/spec/lib/ruby_smb/smb2/packet/read_response_spec.rb
@@ -57,5 +57,4 @@ RSpec.describe RubySMB::Smb2::Packet::ReadResponse do
 
   end
 
-
 end

--- a/spec/lib/ruby_smb/smb2/packet/write_response_spec.rb
+++ b/spec/lib/ruby_smb/smb2/packet/write_response_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe RubySMB::Smb2::Packet::WriteResponse do
     end
 
     it_behaves_like "packet"
+    it_behaves_like "write_response_channel_info"
 
     specify do
       expect(packet.struct_size).to eq(17)
@@ -27,12 +28,6 @@ RSpec.describe RubySMB::Smb2::Packet::WriteResponse do
     end
     specify do
       expect(packet.remaining).to eq(0)
-    end
-
-    specify do
-      expect(packet.channel_info_offset).to eq(0)
-      expect(packet.channel_info_length).to eq(0)
-      expect(packet.channel_info).to eq('')
     end
 
   end
@@ -48,6 +43,8 @@ RSpec.describe RubySMB::Smb2::Packet::WriteResponse do
       )
     end
 
+    it_behaves_like "write_response_channel_info"
+
     specify do
       expect(packet.struct_size).to eq(17)
     end
@@ -60,13 +57,6 @@ RSpec.describe RubySMB::Smb2::Packet::WriteResponse do
     specify do
       expect(packet.remaining).to eq(0)
     end
-
-    specify do
-      expect(packet.channel_info_offset).to eq(0)
-      expect(packet.channel_info_length).to eq(0)
-      expect(packet.channel_info).to eq('')
-    end
-
   end
 
   context 'when configured with a block' do
@@ -80,6 +70,8 @@ RSpec.describe RubySMB::Smb2::Packet::WriteResponse do
       end
     end
 
+    it_behaves_like "write_response_channel_info"
+
     specify do
       expect(packet.struct_size).to eq(17)
     end
@@ -92,13 +84,6 @@ RSpec.describe RubySMB::Smb2::Packet::WriteResponse do
     specify do
       expect(packet.remaining).to eq(0)
     end
-
-    specify do
-      expect(packet.channel_info_offset).to eq(0)
-      expect(packet.channel_info_length).to eq(0)
-      expect(packet.channel_info).to eq('')
-    end
-
   end
 
 end

--- a/spec/lib/ruby_smb/smb2/packet/write_response_spec.rb
+++ b/spec/lib/ruby_smb/smb2/packet/write_response_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe RubySMB::Smb2::Packet::WriteResponse do
       ].pack('H*')
     end
 
-    it_behaves_like "packet"
-    it_behaves_like "write_response_channel_info"
+    it_behaves_like 'packet'
+    it_behaves_like 'write_response_channel_info'
 
     specify do
       expect(packet.struct_size).to eq(17)
@@ -43,7 +43,7 @@ RSpec.describe RubySMB::Smb2::Packet::WriteResponse do
       )
     end
 
-    it_behaves_like "write_response_channel_info"
+    it_behaves_like 'write_response_channel_info'
 
     specify do
       expect(packet.struct_size).to eq(17)
@@ -70,7 +70,7 @@ RSpec.describe RubySMB::Smb2::Packet::WriteResponse do
       end
     end
 
-    it_behaves_like "write_response_channel_info"
+    it_behaves_like 'write_response_channel_info'
 
     specify do
       expect(packet.struct_size).to eq(17)

--- a/spec/support/shared/examples/request.rb
+++ b/spec/support/shared/examples/request.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.shared_examples "request" do |command|
+RSpec.shared_examples 'request' do |command|
   context 'header' do
     specify do
       expect(packet.magic).to eq("\xfeSMB".force_encoding("binary"))

--- a/spec/support/shared/examples/smb2_negotiate_header.rb
+++ b/spec/support/shared/examples/smb2_negotiate_header.rb
@@ -2,10 +2,10 @@ require 'spec_helper'
 
 RSpec.shared_examples 'smb2_negotiate_packet_header' do
   specify do
-    expect(packet.magic).to eq("\xfeSMB".force_encoding("binary"))
+    expect(packet.magic).to eq("\xfeSMB".force_encoding('binary'))
   end
   specify do
-    expect(packet.signature).to eq(("\x00" * 16).force_encoding("binary"))
+    expect(packet.signature).to eq(("\x00" * 16).force_encoding('binary'))
   end
   specify do
     expect(packet.command).to eq(RubySMB::Smb2::COMMANDS[:NEGOTIATE])

--- a/spec/support/shared/examples/smb2_negotiate_header.rb
+++ b/spec/support/shared/examples/smb2_negotiate_header.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.shared_examples "smb2_negotiate_packet_header" do
+RSpec.shared_examples 'smb2_negotiate_packet_header' do
   specify do
     expect(packet.magic).to eq("\xfeSMB".force_encoding("binary"))
   end

--- a/spec/support/shared/examples/smb2_negotiate_header.rb
+++ b/spec/support/shared/examples/smb2_negotiate_header.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+RSpec.shared_examples "smb2_negotiate_packet_header" do
+  specify do
+    expect(packet.magic).to eq("\xfeSMB".force_encoding("binary"))
+  end
+  specify do
+    expect(packet.signature).to eq(("\x00" * 16).force_encoding("binary"))
+  end
+  specify do
+    expect(packet.command).to eq(RubySMB::Smb2::COMMANDS[:NEGOTIATE])
+  end
+end

--- a/spec/support/shared/examples/write_response.rb
+++ b/spec/support/shared/examples/write_response.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+RSpec.shared_examples "write_response_channel_info" do
+
+  specify do
+    expect(packet.channel_info_offset).to eq(0)
+    expect(packet.channel_info_length).to eq(0)
+    expect(packet.channel_info).to eq('')
+  end
+
+end

--- a/spec/support/shared/examples/write_response.rb
+++ b/spec/support/shared/examples/write_response.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.shared_examples "write_response_channel_info" do
+RSpec.shared_examples 'write_response_channel_info' do
 
   specify do
     expect(packet.channel_info_offset).to eq(0)


### PR DESCRIPTION
Fixes a number of various style guide violations as per PullReview results here: https://www.pullreview.com/github/rapid7/ruby_smb/reviews/chore/MSP-13004/style-fixes