### PR TITLE
Chore/msp 13039/meaningful exceptions

### DIFF
--- a/lib/ruby_smb/dispatcher/base.rb
+++ b/lib/ruby_smb/dispatcher/base.rb
@@ -13,6 +13,6 @@ class RubySMB::Dispatcher::Base
 
   # @abstract
   def recv_packet
-    raise NotImplementedError
+    raise NotImlementedError
   end
 end

--- a/lib/ruby_smb/dispatcher/base.rb
+++ b/lib/ruby_smb/dispatcher/base.rb
@@ -13,6 +13,6 @@ class RubySMB::Dispatcher::Base
 
   # @abstract
   def recv_packet
-    raise NotImlementedError
+    raise NotImplementedError
   end
 end

--- a/lib/ruby_smb/dispatcher/socket.rb
+++ b/lib/ruby_smb/dispatcher/socket.rb
@@ -30,13 +30,16 @@ class RubySMB::Dispatcher::Socket < Smb2::Dispatcher::Base
     nil
   end
 
+  # Read a packet off the wire and parse it into a string
+  # Throw Error::NetBiosSessionService if there's an error reading the first 4 bytes,
+  # which are assumed to be the NetBiosSessionService header.
   # @return [String]
   # @todo should return Smb2::Packet
   def recv_packet
     IO.select([@socket])
-    nbss_header = @socket.read(4)
+    nbss_header = @socket.read(4) # Length of NBSS header. TODO: remove to a constant
     if nbss_header.nil?
-      raise "omg"
+      raise RubySmb::Error::NetBiosSessionService
     else
       length = nbss_header.unpack("N").first
     end

--- a/lib/ruby_smb/smb2.rb
+++ b/lib/ruby_smb/smb2.rb
@@ -4,6 +4,7 @@
 module RubySMB::Smb2
   autoload :Client, 'ruby_smb/smb2/client'
   autoload :Dispatcher, 'ruby_smb/smb2/dispatcher'
+  autoload :Error, 'ruby_smb/smb2/error'
   autoload :File, 'ruby_smb/smb2/file'
   autoload :Packet, 'ruby_smb/smb2/packet'
   autoload :Tree, 'ruby_smb/smb2/tree'

--- a/lib/ruby_smb/smb2/client.rb
+++ b/lib/ruby_smb/smb2/client.rb
@@ -242,30 +242,30 @@ class RubySMB::Smb2::Client
   protected
 
   # Cargo culted from Rex
+  # @todo Document these magic numbers
   def asn1encode(str = '')
-    res = ''
-
     # If the high bit of the first byte is 1, it contains the number of
     # length bytes that follow
 
     case str.length
     when 0..0x7F
-      res = [str.length].pack('C') + str
+      encoded_string = [str.length].pack('C') + str
     when 0x80..0xFF
-      res = [0x81, str.length].pack('CC') + str
+      encoded_string = [0x81, str.length].pack('CC') + str
     when 0x100..0xFFFF
-      res = [0x82, str.length].pack('Cn') + str
+      encoded_string = [0x82, str.length].pack('Cn') + str
     when  0x10000..0xffffff
-      res = [0x83, str.length >> 16, str.length & 0xFFFF].pack('CCn') + str
+      encoded_string = [0x83, str.length >> 16, str.length & 0xFFFF].pack('CCn') + str
     when  0x1000000..0xffffffff
-      res = [0x84, str.length].pack('CN') + str
+      encoded_string = [0x84, str.length].pack('CN') + str
     else
-      raise "ASN1 str too long"
+      raise RubySmb::Error::ASN1Encoding, "Source string is too long. Size is #{str.length}"
     end
 
-    res
+    encoded_string
   end
 
+  # @todo Document these magic bytes
   def gss_type1(type1)
     "\x60".force_encoding("binary") + self.asn1encode(
       "\x06".force_encoding("binary") + self.asn1encode(

--- a/lib/ruby_smb/smb2/error.rb
+++ b/lib/ruby_smb/smb2/error.rb
@@ -1,5 +1,10 @@
 module RubySmb::Error
-  # Thrown when there is a problem with communication over NetBios Session Service
+  # Raised when there is a length or formatting issue with an ASN1-encoded string
+  # @see https://en.wikipedia.org/wiki/Abstract_Syntax_Notation_One
+  # @todo Find an SMB-specific link for ASN1 above
+  class ASN1Encoding < Exception; end
+
+  # Raised when there is a problem with communication over NetBios Session Service
   # @see https://wiki.wireshark.org/NetBIOS/NBSS
   class NetBiosSessionService < Exception; end
 end

--- a/lib/ruby_smb/smb2/error.rb
+++ b/lib/ruby_smb/smb2/error.rb
@@ -1,0 +1,5 @@
+module RubySmb::Error
+  # Thrown when there is a problem with communication over NetBios Session Service
+  # @see https://wiki.wireshark.org/NetBIOS/NBSS
+  class NetBiosSessionService < Exception; end
+end

--- a/lib/ruby_smb/smb2/tree.rb
+++ b/lib/ruby_smb/smb2/tree.rb
@@ -22,9 +22,7 @@ class RubySMB::Smb2::Tree
   # @param share [String] (see {#share})
   # @param tree_connect_response [Smb::Packet::TreeConnectResponse]
   def initialize(client:, share:, tree_connect_response:)
-    unless tree_connect_response.is_a?(Smb2::Packet::TreeConnectResponse)
-      raise TypeError, "tree_connect_response must be a TreeConnectResponse"
-    end
+    raise TypeError, "tree_connect_response must be a TreeConnectResponse" unless tree_connect_response.is_a?(Smb2::Packet::TreeConnectResponse)
 
     self.client = client
     self.share = share
@@ -215,7 +213,7 @@ class RubySMB::Smb2::Tree
     when "r"
       access_mask = base_access_mask
     else
-      raise ArgumentError
+      raise ArgumentError, "mode is not a valid file mode"
     end
     access_mask
   end
@@ -230,7 +228,7 @@ class RubySMB::Smb2::Tree
     when "a", "a+"
       RubySMB::Smb2::Packet::CREATE_DISPOSITIONS[:FILE_OPEN_IF]
     else
-      raise ArgumentError
+      raise ArgumentError, "mode is not a valid file mode"
     end
   end
 

--- a/lib/ruby_smb/smb2/tree.rb
+++ b/lib/ruby_smb/smb2/tree.rb
@@ -22,7 +22,9 @@ class RubySMB::Smb2::Tree
   # @param share [String] (see {#share})
   # @param tree_connect_response [Smb::Packet::TreeConnectResponse]
   def initialize(client:, share:, tree_connect_response:)
-    raise TypeError, "tree_connect_response must be a TreeConnectResponse" unless tree_connect_response.is_a?(Smb2::Packet::TreeConnectResponse)
+    unless tree_connect_response.is_a?(Smb2::Packet::TreeConnectResponse)
+      raise ArgumentError, "tree_connect_response must be a TreeConnectResponse"
+    end
 
     self.client = client
     self.share = share
@@ -131,6 +133,8 @@ class RubySMB::Smb2::Tree
   # @param pattern [String] search pattern
   # @param type [Symbol] file information class
   # @return [Array] array of directory structures
+  # @todo refactor this method to not rely on exceptions
+  # @todo refactor exception-with-inspect pattern to use logging
   def list(directory: nil, pattern: '*', type: :FileNamesInformation)
     create_request = RubySMB::Smb2::Packet::CreateRequest.new(
       impersonation: RubySMB::Smb2::Packet::IMPERSONATION_LEVELS[:IMPERSONATION],
@@ -140,9 +144,11 @@ class RubySMB::Smb2::Tree
       create_options: RubySMB::Smb2::Packet::CREATE_OPTIONS[:FILE_DIRECTORY_FILE]
     )
 
+    # TODO: add some inline doc for this if block
+    # TODO: change magic format string to be a constant
     if directory
       create_request.filename = directory.encode('utf-16le')
-    else # y u do dis microsoft
+    else
       create_request.filename = "\x00"
       create_request.filename_length = 0
     end
@@ -151,7 +157,7 @@ class RubySMB::Smb2::Tree
     create_response = RubySMB::Smb2::Packet::CreateResponse.new(response)
 
     unless create_response.nt_status.zero?
-      raise create_response.inspect
+      raise create_response.inspect # TODO: log this instead of stopping the world
     end
 
     directory_request = RubySMB::Smb2::Packet::QueryDirectoryRequest.new(
@@ -169,7 +175,7 @@ class RubySMB::Smb2::Tree
       break if directory_response.nt_status == STATUS_NO_MORE_FILES
 
       unless directory_response.nt_status.zero?
-        raise directory_response.inspect
+        raise directory_response.inspect # TODO: log this instead of stopping the world
       end
 
       blob = directory_response.output_buffer
@@ -209,7 +215,7 @@ class RubySMB::Smb2::Tree
         RubySMB::Smb2::Packet::FILE_ACCESS_MASK[:FILE_WRITE_DATA] |
         RubySMB::Smb2::Packet::FILE_ACCESS_MASK[:FILE_APPEND_DATA] |
         RubySMB::Smb2::Packet::FILE_ACCESS_MASK[:FILE_WRITE_EA] |
-        RubySMB::Smb2::Packet::FILE_ACCESS_MASK[:FILE_WRITE_ATTRIBUTES] |
+        RubySMB::Smb2::Packet::FILE_ACCESS_MASK[:FILE_WRITE_ATTRIBUTES]
     when "r"
       access_mask = base_access_mask
     else

--- a/lib/ruby_smb/version.rb
+++ b/lib/ruby_smb/version.rb
@@ -9,6 +9,8 @@ module RubySMB
     # The patch number, scoped to the {MINOR} version number.
     PATCH = 7
 
+    PRERELEASE = "meaningful-exceptions"
+
     # The full version string, including the {MAJOR}, {MINOR}, {PATCH}, and optionally, the `PRERELEASE` in the
     # {http://semver.org/spec/v2.0.0.html semantic versioning v2.0.0} format.
     #


### PR DESCRIPTION
## Verification
- [ ] VERIFY ALL PASS: `rake spec`

Note: I've made an `Error` module that I expect to later break up if/when we create classes/modules for more things in a specific domain. For instance the `NetBiosSessionService` could later be moved into an area of code concerned w/ NetBios in general. For now, this gives us a central place to locate/document exception classes.