### PR TITLE
Feature/msp 13005/windows error

### DIFF
--- a/lib/ruby_smb/dispatcher/socket.rb
+++ b/lib/ruby_smb/dispatcher/socket.rb
@@ -1,7 +1,7 @@
 require 'socket'
 # This class provides a wrapper around a Socket for the packet Dispatcher.
 # It allows for dependency injection of different Socket implementations.
-class RubySMB::Dispatcher::Socket < Smb2::Dispatcher::Base
+class RubySMB::Dispatcher::Socket < RubySMB::Dispatcher::Base
 
   # @!attribute [rw] socket
   #   @return [IO]
@@ -46,7 +46,7 @@ class RubySMB::Dispatcher::Socket < Smb2::Dispatcher::Base
       data << @socket.read(length - data.length)
     end
 
-    Smb2::Packet.parse(data)
+    RubySMB::Smb2::Packet.parse(data)
   end
 
 end

--- a/lib/ruby_smb/smb2/client.rb
+++ b/lib/ruby_smb/smb2/client.rb
@@ -1,5 +1,7 @@
 require 'net/ntlm'
 require 'net/ntlm/client'
+require 'windows_error'
+require 'windows_error/nt_status'
 
 # A client for holding the state of an SMB2 session.
 #
@@ -143,7 +145,7 @@ class RubySMB::Smb2::Client
       @state = :authentication_failed
     end
 
-    response.nt_status
+    WindowsError::NTStatus.find_by_retval(response.nt_status)
   end
 
   def inspect

--- a/lib/ruby_smb/smb2/client.rb
+++ b/lib/ruby_smb/smb2/client.rb
@@ -196,7 +196,7 @@ class RubySMB::Smb2::Client
 
     # Sign the packet if necessary.
     # THIS MUST BE THE LAST THING WE DO BEFORE SENDING
-    if @session_id && signing_required? && !request.kind_of?(Smb2::Packet::SessionSetupRequest)
+    if @session_id && signing_required? && !request.kind_of?(RubySMB::Smb2::Packet::SessionSetupRequest)
       request.sign!(session_key)
     end
 

--- a/lib/ruby_smb/smb2/client.rb
+++ b/lib/ruby_smb/smb2/client.rb
@@ -139,7 +139,7 @@ class RubySMB::Smb2::Client
     packet.security_blob = gss_type3(type3.serialize)
     response = send_recv(packet)
 
-    if response.nt_status == 0
+    if response.nt_status == WindowsError::NTStatus::STATUS_SUCCESS
       @state = :authenticated
     else
       @state = :authentication_failed

--- a/lib/ruby_smb/smb2/file.rb
+++ b/lib/ruby_smb/smb2/file.rb
@@ -71,7 +71,7 @@ class RubySMB::Smb2::File
   #
   # @return [Boolean]
   def eof?
-    (last_read_response && last_read_response.nt_status == Windows::Error::NTStatus::STATUS_END_OF_FILE) || pos == size
+    (last_read_response && last_read_response.nt_status == WindowsError::NTStatus::STATUS_END_OF_FILE) || pos == size
   end
 
   # @return [String]

--- a/lib/ruby_smb/smb2/file.rb
+++ b/lib/ruby_smb/smb2/file.rb
@@ -2,9 +2,6 @@
 # An open file on the remote filesystem.
 class RubySMB::Smb2::File
 
-  # Some day we'll document all of these in one place
-  STATUS_END_OF_FILE = 0xC0000011
-
   # The server's response from when we {Tree#create created} this File
   #
   # @return [RubySMB::Smb2::Packet::CreateResponse]
@@ -74,7 +71,7 @@ class RubySMB::Smb2::File
   #
   # @return [Boolean]
   def eof?
-    (last_read_response && last_read_response.nt_status == STATUS_END_OF_FILE) || pos == size
+    (last_read_response && last_read_response.nt_status == Windows::Error::NTStatus::STATUS_END_OF_FILE) || pos == size
   end
 
   # @return [String]
@@ -199,7 +196,7 @@ class RubySMB::Smb2::File
       response_packet = write_chunk(data_chunk, offset: pos)
 
       # @todo raise instead?
-      break if response_packet.nt_status != 0
+      break if response_packet.nt_status != WindowsError::NTStatus::STATUS_SUCCESS
 
       bytes_written += response_packet.byte_count
       seek(offset + bytes_written)

--- a/lib/ruby_smb/smb2/tree.rb
+++ b/lib/ruby_smb/smb2/tree.rb
@@ -1,8 +1,6 @@
 # A connected tree, as returned by a {Smb2::Packet::TreeConnectRequest}.
 class RubySMB::Smb2::Tree
 
-  STATUS_NO_MORE_FILES = 0x80000006
-
   # The {Smb2::Client} on which this Tree is connected.
   #
   # @return [RubySMB::Smb2::Client]
@@ -158,7 +156,7 @@ class RubySMB::Smb2::Tree
     response = send_recv(create_request)
     create_response = RubySMB::Smb2::Packet::CreateResponse.new(response)
 
-    unless create_response.nt_status.zero?
+    unless create_response.nt_status == WindowsError::NTStatus::STATUS_SUCCESS
       raise create_response.inspect
     end
 
@@ -174,9 +172,9 @@ class RubySMB::Smb2::Tree
       response = send_recv(directory_request)
       directory_response = RubySMB::Smb2::Packet::QueryDirectoryResponse.new(response)
 
-      break if directory_response.nt_status == STATUS_NO_MORE_FILES
+      break if directory_response.nt_status == WindowsError::NTStatus::STATUS_NO_MORE_FILES
 
-      unless directory_response.nt_status.zero?
+      unless directory_response.nt_status == WindowsError::NTStatus::STATUS_SUCCESS
         raise directory_response.inspect
       end
 

--- a/lib/ruby_smb/smb2/tree.rb
+++ b/lib/ruby_smb/smb2/tree.rb
@@ -22,7 +22,7 @@ class RubySMB::Smb2::Tree
   # @param share [String] (see {#share})
   # @param tree_connect_response [Smb::Packet::TreeConnectResponse]
   def initialize(client:, share:, tree_connect_response:)
-    unless tree_connect_response.is_a?(Smb2::Packet::TreeConnectResponse)
+    unless tree_connect_response.is_a?(RubySMB::Smb2::Packet::TreeConnectResponse)
       raise TypeError, "tree_connect_response must be a TreeConnectResponse"
     end
 
@@ -211,7 +211,7 @@ class RubySMB::Smb2::Tree
         RubySMB::Smb2::Packet::FILE_ACCESS_MASK[:FILE_WRITE_DATA] |
         RubySMB::Smb2::Packet::FILE_ACCESS_MASK[:FILE_APPEND_DATA] |
         RubySMB::Smb2::Packet::FILE_ACCESS_MASK[:FILE_WRITE_EA] |
-        RubySMB::Smb2::Packet::FILE_ACCESS_MASK[:FILE_WRITE_ATTRIBUTES] |
+        RubySMB::Smb2::Packet::FILE_ACCESS_MASK[:FILE_WRITE_ATTRIBUTES]
     when "r"
       access_mask = base_access_mask
     else

--- a/lib/ruby_smb/smb2/tree.rb
+++ b/lib/ruby_smb/smb2/tree.rb
@@ -18,6 +18,11 @@ class RubySMB::Smb2::Tree
   # @return [RubySMB::Smb2::Packet::TreeConnectResponse]
   attr_accessor :tree_connect_response
 
+  # The NTStatus code received from the {TreeConnectResponse}
+  #
+  # @return [WindowsError::ErrorCode] the NTStatus code object
+  attr_accessor :tree_connect_status
+
   # @param client [Smb::Client] (see {#client})
   # @param share [String] (see {#share})
   # @param tree_connect_response [Smb::Packet::TreeConnectResponse]
@@ -29,6 +34,7 @@ class RubySMB::Smb2::Tree
     self.client = client
     self.share = share
     self.tree_connect_response = tree_connect_response
+    self.tree_connect_status = WindowsError::NTStatus.find_by_retval(tree_connect_response.nt_status).first
   end
 
   # Open a file handle
@@ -115,8 +121,8 @@ class RubySMB::Smb2::Tree
 
   # @return [String]
   def inspect
-    if tree_connect_response.nt_status != 0
-      stuff = "Error: #{tree_connect_response.nt_status.to_s 16}"
+    if tree_connect_response.nt_status != WindowsError::NTStatus::STATUS_SUCCESS
+      stuff = "Error: #{tree_connect_status.name}"
     else
       stuff = share
     end

--- a/lib/ruby_smb/version.rb
+++ b/lib/ruby_smb/version.rb
@@ -9,6 +9,7 @@ module RubySMB
     # The patch number, scoped to the {MINOR} version number.
     PATCH = 7
 
+    PRERELEASE = 'windows-error'
     # The full version string, including the {MAJOR}, {MINOR}, {PATCH}, and optionally, the `PRERELEASE` in the
     # {http://semver.org/spec/v2.0.0.html semantic versioning v2.0.0} format.
     #

--- a/ruby_smb.gemspec
+++ b/ruby_smb.gemspec
@@ -35,5 +35,6 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "rubyntlm", "~> 0.5"
   spec.add_runtime_dependency "bit-struct"
+  spec.add_runtime_dependency "windows_error"
 
 end

--- a/spec/lib/ruby_smb/smb2/client_spec.rb
+++ b/spec/lib/ruby_smb/smb2/client_spec.rb
@@ -12,22 +12,82 @@ RSpec.describe RubySMB::Smb2::Client do
     MockSocketDispatcher.new
   end
 
-  context '#negotiate' do
+  context 'with_negotiation' do
     before do
       expect(dispatcher).to receive(:send_packet).with(kind_of RubySMB::Smb2::Packet::Generic)
-      expect(dispatcher).to receive(:recv_packet).and_return(response)
+      expect(dispatcher).to receive(:recv_packet).and_return(negotiate_response)
     end
 
-    let(:response) { RubySMB::Smb2::Packet::NegotiateResponse.new }
+    let(:negotiate_response) { RubySMB::Smb2::Packet::NegotiateResponse.new }
 
-    specify do
-      expect { client.negotiate }.not_to raise_error
-      expect(client.sequence_number).to eq(0)
+    context '#negotiate' do
+      it 'runs without error' do
+        expect{ client.negotiate }.not_to raise_error
+      end
+
+      it 'sets the sequence number' do
+        expect{ client.negotiate }.to change{client.sequence_number}.to(0)
+      end
+
+      it 'sets the client capabailities' do
+        expect{ client.negotiate }.to change{client.capabilities}.to(negotiate_response.capabilities)
+      end
+
+      it 'sets the state to negotiated' do
+        expect{ client.negotiate }.to change{client.state}.to(:negotiated)
+      end
+
     end
-    specify do
-      expect { client.negotiate }.not_to raise_error
-      expect(client.capabilities).to eq(response.capabilities)
+
+    context '#authenticate' do
+      before do
+        expect{ client.negotiate }.not_to raise_error
+        expect(client).to receive(:ntlmssp_negotiate).and_return(challenge)
+        expect(client).to receive(:ntlmssp_auth).with(challenge).and_return(response)
+      end
+
+      let(:challenge) { RubySMB::Smb2::Packet::SessionSetupResponse.new }
+      let(:response)  { RubySMB::Smb2::Packet::SessionSetupResponse.new }
+
+      context 'with valid credentials' do
+        before do
+          response.nt_status = 0
+        end
+
+        it 'returns WindowsError::NTStatus::STATUS_SUCCESS' do
+          expect(client.authenticate).to eq WindowsError::NTStatus::STATUS_SUCCESS
+        end
+
+        it 'sets state to authenticated' do
+          expect{ client.authenticate }.to change{client.state}.to(:authenticated)
+        end
+      end
+
+      context 'with invalid credentials' do
+        before do
+          response.nt_status = 3221225581
+        end
+
+        it 'returns WindowsError::NTStatus::STATUS_LOGON_FAILURE' do
+          expect(client.authenticate).to eq WindowsError::NTStatus::STATUS_LOGON_FAILURE
+        end
+
+        it 'sets state to authentication_failed' do
+          expect{ client.authenticate }.to change{client.state}.to(:authentication_failed)
+        end
+      end
+    end
+
+    context '#ntlmssp_negotiate' do
+      before do
+        expect{ client.negotiate }.not_to raise_error
+        expect(dispatcher).to receive(:send_packet).with(kind_of RubySMB::Smb2::Packet::SessionSetupRequest)
+        expect(dispatcher).to receive(:recv_packet).and_return(RubySMB::Smb2::Packet::SessionSetupResponse.new)
+      end
+
+      it 'runs without error' do
+        expect{ client.ntlmssp_negotiate }.not_to raise_error
+      end
     end
   end
-
 end

--- a/spec/lib/ruby_smb/smb2/client_spec.rb
+++ b/spec/lib/ruby_smb/smb2/client_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe RubySMB::Smb2::Client do
 
     let(:negotiate_response) { RubySMB::Smb2::Packet::NegotiateResponse.new }
 
-    context '#negotiate' do
+    describe '#negotiate' do
       it 'runs without error' do
         expect{ client.negotiate }.not_to raise_error
       end
@@ -39,7 +39,7 @@ RSpec.describe RubySMB::Smb2::Client do
 
     end
 
-    context '#authenticate' do
+    describe '#authenticate' do
       before do
         expect{ client.negotiate }.not_to raise_error
         expect(client).to receive(:ntlmssp_negotiate).and_return(challenge)
@@ -65,7 +65,7 @@ RSpec.describe RubySMB::Smb2::Client do
 
       context 'with invalid credentials' do
         before do
-          response.nt_status = 3221225581
+          response.nt_status = 3_221_225_581
         end
 
         it 'returns WindowsError::NTStatus::STATUS_LOGON_FAILURE' do
@@ -78,7 +78,7 @@ RSpec.describe RubySMB::Smb2::Client do
       end
     end
 
-    context '#ntlmssp_negotiate' do
+    describe '#ntlmssp_negotiate' do
       before do
         expect{ client.negotiate }.not_to raise_error
         expect(dispatcher).to receive(:send_packet).with(kind_of RubySMB::Smb2::Packet::SessionSetupRequest)
@@ -90,4 +90,6 @@ RSpec.describe RubySMB::Smb2::Client do
       end
     end
   end
+
+
 end

--- a/spec/lib/ruby_smb/smb2/client_spec.rb
+++ b/spec/lib/ruby_smb/smb2/client_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe RubySMB::Smb2::Client do
 
       context 'with invalid credentials' do
         before do
-          response.nt_status = 3_221_225_581
+          response.nt_status = 0xC000006D
         end
 
         it 'returns WindowsError::NTStatus::STATUS_LOGON_FAILURE' do


### PR DESCRIPTION
Integrates the windows_error gem into ruby_smb

VERIFICATION STEPS
- [x] rake spec
- [x] VERIFY specs pass
- [x] `bundle console`
- [x] `dispatcher = RubySMB::Dispatcher::Socket.connect("192.168.172.169", 445)` (replace with an IP address for your own target
- [x] `client = RubySMB::Smb2::Client.new(
  dispatcher: dispatcher,
  username:"msfadmin",
  password:"P@ssw0rd1!",
  domain:"corp"
)` (replace with proper creds for your target)
- [x] `client.negotiate`
- [x] `client.authenticate`
- [x] VERIFY you get a WindowsError::ErrorCode object of STATUS_SUCCESS
- [x] repeat the process with invalid credentials
- [x] VERIFY you get a WindowsError::ErrorCode object of STATUS_LOGON_FAILURE
- [ ] remove the pre-release tag from Version before merging