### PR TITLE
Feature/msp 12907/smb header

### DIFF
--- a/spec/lib/ruby_smb/smb1/packet/smb_header_spec.rb
+++ b/spec/lib/ruby_smb/smb1/packet/smb_header_spec.rb
@@ -16,4 +16,88 @@ RSpec.describe RubySMB::Smb1::Packet::SmbHeader do
   it { is_expected.to respond_to :pid_low }
   it { is_expected.to respond_to :uid }
   it { is_expected.to respond_to :mid }
+
+  describe 'protocol' do
+    it 'should be a 32-bit field per the SMB spec' do
+      protocol_size_field = header.fields.detect { |f| f.display_name == :protocol }
+      expect(protocol_size_field.length).to eq 32
+    end
+  end
+
+  describe 'command' do
+    it 'should be a 8-bit field per the SMB spec' do
+      command_size_field = header.fields.detect { |f| f.display_name == :command }
+      expect(command_size_field.length).to eq 8
+    end
+  end
+
+  describe 'nt_status' do
+    it 'should be a 32-bit field per the SMB spec' do
+      nt_status_size_field = header.fields.detect { |f| f.display_name == :nt_status }
+      expect(nt_status_size_field.length).to eq 32
+    end
+  end
+
+  describe 'flags' do
+    it 'should be a 8-bit field per the SMB spec' do
+      flags_size_field = header.fields.detect { |f| f.display_name == :flags }
+      expect(flags_size_field.length).to eq 8
+    end
+  end
+
+  describe 'flags2' do
+    it 'should be a 16-bit field per the SMB spec' do
+      flags2_size_field = header.fields.detect { |f| f.display_name == :flags2 }
+      expect(flags2_size_field.length).to eq 16
+    end
+  end
+
+  describe 'pid_high' do
+    it 'should be a 16-bit field per the SMB spec' do
+      pid_high_size_field = header.fields.detect { |f| f.display_name == :pid_high }
+      expect(pid_high_size_field.length).to eq 16
+    end
+  end
+
+  describe 'security_features' do
+    it 'should be a 64-bit field per the SMB spec' do
+      security_features_size_field = header.fields.detect { |f| f.display_name == :security_features }
+      expect(security_features_size_field.length).to eq 64
+    end
+  end
+
+  describe 'reserved' do
+    it 'should be a 16-bit field per the SMB spec' do
+      reserved_size_field = header.fields.detect { |f| f.display_name == :reserved }
+      expect(reserved_size_field.length).to eq 16
+    end
+  end
+
+  describe 'tid' do
+    it 'should be a 16-bit field per the SMB spec' do
+      tid_size_field = header.fields.detect { |f| f.display_name == :tid }
+      expect(tid_size_field.length).to eq 16
+    end
+  end
+
+  describe 'pid_low' do
+    it 'should be a 16-bit field per the SMB spec' do
+      pid_low_size_field = header.fields.detect { |f| f.display_name == :pid_low}
+      expect(pid_low_size_field.length).to eq 16
+    end
+  end
+
+  describe 'uid' do
+    it 'should be a 16-bit field per the SMB spec' do
+      uid_size_field = header.fields.detect { |f| f.display_name == :uid }
+      expect(uid_size_field.length).to eq 16
+    end
+  end
+
+  describe 'mid' do
+    it 'should be a 16-bit field per the SMB spec' do
+      mid_size_field = header.fields.detect { |f| f.display_name == :mid }
+      expect(mid_size_field.length).to eq 16
+    end
+  end
 end


### PR DESCRIPTION
Adds the basic SMB Header for SMB1 Packets

VERIFICATION STEPS
- [ ] `rake spec`
- [ ] VERIFY all specs pass
- [ ] VERIFY BitStruct structure matches MSDN docs https://msdn.microsoft.com/en-us/library/cc246254.aspx
- [ ] Remove PRERELEASE tag