### PR TITLE
capitalize all occurences of SMB

### DIFF
--- a/examples/list_tree.rb
+++ b/examples/list_tree.rb
@@ -12,7 +12,7 @@ end
 
 d = RubySMB::Dispatcher::Socket.connect(host, 445)
 
-c = RubySMB::Smb2::Client.new(dispatcher: d, username: "msfadmin", password: "msfadmin")
+c = RubySMB::SMB2::Client.new(dispatcher: d, username: "msfadmin", password: "msfadmin")
 
 c.negotiate
 c.authenticate

--- a/examples/read_file.rb
+++ b/examples/read_file.rb
@@ -12,7 +12,7 @@ end
 
 d = RubySMB::Dispatcher::Socket.connect(host, 445)
 
-c = RubySMB::Smb2::Client.new(dispatcher: d, username: "msfadmin", password: "msfadmin")
+c = RubySMB::SMB2::Client.new(dispatcher: d, username: "msfadmin", password: "msfadmin")
 
 c.negotiate
 c.authenticate

--- a/examples/smoke_test.rb
+++ b/examples/smoke_test.rb
@@ -28,7 +28,7 @@ op.parse!(ARGV)
 d = RubySMB::Dispatcher::Socket.connect(host, 445)
 puts "Connected"
 
-c = RubySMB::Smb2::Client.new(dispatcher: d, username: username, password: password)
+c = RubySMB::SMB2::Client.new(dispatcher: d, username: username, password: password)
 
 c.negotiate
 result = c.authenticate

--- a/lib/ruby_smb.rb
+++ b/lib/ruby_smb.rb
@@ -12,6 +12,6 @@ module RubySMB
   autoload :Error, 'ruby_smb/error'
   autoload :VERSION, 'ruby_smb/version'
   autoload :Version, 'ruby_smb/version'
-  autoload :Smb2, 'ruby_smb/smb2'
-  autoload :Smb1, 'ruby_smb/smb1'
+  autoload :SMB2, 'ruby_smb/smb2'
+  autoload :SMB1, 'ruby_smb/smb1'
 end

--- a/lib/ruby_smb/dispatcher/socket.rb
+++ b/lib/ruby_smb/dispatcher/socket.rb
@@ -18,7 +18,7 @@ class RubySMB::Dispatcher::Socket < RubySMB::Dispatcher::Base
     @socket = socket
   end
 
-  # @param packet [Smb2::Packet,#to_s]
+  # @param packet [SMB2::Packet,#to_s]
   # @return [void]
   def send_packet(packet)
     data = nbss(packet) + packet.to_s
@@ -34,7 +34,7 @@ class RubySMB::Dispatcher::Socket < RubySMB::Dispatcher::Base
   # Throw Error::NetBiosSessionService if there's an error reading the first 4 bytes,
   # which are assumed to be the NetBiosSessionService header.
   # @return [String]
-  # @todo should return Smb2::Packet
+  # @todo should return SMB2::Packet
   def recv_packet
     IO.select([@socket])
     nbss_header = @socket.read(4) # Length of NBSS header. TODO: remove to a constant
@@ -49,7 +49,7 @@ class RubySMB::Dispatcher::Socket < RubySMB::Dispatcher::Base
       data << @socket.read(length - data.length)
     end
 
-    RubySMB::Smb2::Packet.parse(data)
+    RubySMB::SMB2::Packet.parse(data)
   end
 
 end

--- a/lib/ruby_smb/smb1.rb
+++ b/lib/ruby_smb/smb1.rb
@@ -1,6 +1,6 @@
 # This module adds the namespace for version 1 of the SMB Protocol
 # as defined in [MS-SMB](https://msdn.microsoft.com/en-us/library/cc246231.aspx)
-module RubySMB::Smb1
+module RubySMB::SMB1
   autoload :Packet, 'ruby_smb/smb1/packet'
 
 

--- a/lib/ruby_smb/smb1/packet.rb
+++ b/lib/ruby_smb/smb1/packet.rb
@@ -1,10 +1,10 @@
 module RubySMB
-  module Smb1
+  module SMB1
     # This module holds the namespace for all SMB1 packets and related structures.
     module Packet
-      autoload :SmbParameterBlock, 'ruby_smb/smb1/packet/smb_parameter_block'
-      autoload :SmbHeader, 'ruby_smb/smb1/packet/smb_header'
-      autoload :SmbDataBlock, 'ruby_smb/smb1/packet/smb_data_block'
+      autoload :SMBParameterBlock, 'ruby_smb/smb1/packet/smb_parameter_block'
+      autoload :SMBHeader, 'ruby_smb/smb1/packet/smb_header'
+      autoload :SMBDataBlock, 'ruby_smb/smb1/packet/smb_data_block'
       autoload :AndXBlock, 'ruby_smb/smb1/packet/andx_block'
     end
   end

--- a/lib/ruby_smb/smb1/packet/andx_block.rb
+++ b/lib/ruby_smb/smb1/packet/andx_block.rb
@@ -1,12 +1,12 @@
 module RubySMB
-  module Smb1
+  module SMB1
     module Packet
 
       # This class represents an AndX message block that allows the chaining
       # of multiple SMB Commands in a single packet.
       # [2.2.3.4 Batched Messages ("AndX" Messages)](https://msdn.microsoft.com/en-us/library/ee442210.aspx)
       class AndXBlock < BitStruct
-        unsigned :andx_command,      8, 'Next Command Code', default: RubySMB::Smb1::COMMANDS[:SMB_COM_NO_ANDX_COMMAND]
+        unsigned :andx_command,      8, 'Next Command Code', default: RubySMB::SMB1::COMMANDS[:SMB_COM_NO_ANDX_COMMAND]
         unsigned :andx_reserved,     8, 'AndX Reserved Field', default: 0
         unsigned :andx_offset,      16, 'Offset to the next AndX Command', default: 0
       end

--- a/lib/ruby_smb/smb1/packet/smb_data_block.rb
+++ b/lib/ruby_smb/smb1/packet/smb_data_block.rb
@@ -1,9 +1,9 @@
 module RubySMB
-  module Smb1
+  module SMB1
     module Packet
       # This class represents an SMB_Data block structure for SMB1 packets.
       # [Section 2.2.3.3 Data Block](https://msdn.microsoft.com/en-us/library/ee441687.aspx)
-      class SmbDataBlock < BitStruct
+      class SMBDataBlock < BitStruct
         unsigned :byte_count, 16
         rest :bytes
 

--- a/lib/ruby_smb/smb1/packet/smb_header.rb
+++ b/lib/ruby_smb/smb1/packet/smb_header.rb
@@ -1,11 +1,11 @@
 module RubySMB
-  module Smb1
+  module SMB1
     module Packet
 
       # This class represents the Header of an SMB1 Packet.
       # [2.2.3.1 SMB Header Extensions](https://msdn.microsoft.com/en-us/library/cc246254.aspx)
-      class SmbHeader < BitStruct
-        unsigned :protocol,          32, 'Protocol Implementation', default: RubySMB::Smb1::SMB_PROTOCOL_ID
+      class SMBHeader < BitStruct
+        unsigned :protocol,          32, 'Protocol Implementation', default: RubySMB::SMB1::SMB_PROTOCOL_ID
         unsigned :command,            8, 'SMB Command Code'
         unsigned :nt_status,         32, 'NTStatus Error Code'
         unsigned :flags,              8, 'Flags'

--- a/lib/ruby_smb/smb1/packet/smb_parameter_block.rb
+++ b/lib/ruby_smb/smb1/packet/smb_parameter_block.rb
@@ -1,9 +1,9 @@
 module RubySMB
-  module Smb1
+  module SMB1
     module Packet
       # This class represents an SMB_Parameters block structure for SMB1 packets.
       # [Section 2.2.3.2 Parameter Block](https://msdn.microsoft.com/en-us/library/ee442058.aspx)
-      class SmbParameterBlock < BitStruct
+      class SMBParameterBlock < BitStruct
         unsigned :word_count, 8, 'Size of data in Words'
         rest :words, 'Parameter Data'
 

--- a/lib/ruby_smb/smb2.rb
+++ b/lib/ruby_smb/smb2.rb
@@ -1,7 +1,7 @@
 # A packet parsing and manipulation library for the SMB2 protocol
 #
 # [[MS-SMB2] Server Mesage Block (SMB) Protocol Versions 2 and 3](https://msdn.microsoft.com/en-us/library/cc246482.aspx)
-module RubySMB::Smb2
+module RubySMB::SMB2
   autoload :Client, 'ruby_smb/smb2/client'
   autoload :File, 'ruby_smb/smb2/file'
   autoload :Packet, 'ruby_smb/smb2/packet'

--- a/lib/ruby_smb/smb2/client.rb
+++ b/lib/ruby_smb/smb2/client.rb
@@ -4,7 +4,7 @@
 #
 # @example Connect and authenticate
 #   sock = TCPSocket.new("192.168.100.140", 445)
-#   c = RubySMB::Smb2::Client.new(
+#   c = RubySMB::SMB2::Client.new(
 #     socket: sock,
 #     username:"administrator",
 #     password:"P@ssword1",
@@ -14,11 +14,11 @@
 #   c.authenticate
 #
 #
-class RubySMB::Smb2::Client
+class RubySMB::SMB2::Client
 
-  # @see RubySMB::Smb2::Packet::SECURITY_MODES
+  # @see RubySMB::SMB2::Packet::SECURITY_MODES
   # @return [Fixnum]
-  DEFAULT_SECURITY_MODE = RubySMB::Smb2::Packet::SECURITY_MODES[:SIGNING_ENABLED]
+  DEFAULT_SECURITY_MODE = RubySMB::SMB2::Packet::SECURITY_MODES[:SIGNING_ENABLED]
 
   # The client's capabilities
   #
@@ -32,7 +32,7 @@ class RubySMB::Smb2::Client
   # @return [Fixnum]
   attr_accessor :dialect
 
-  # @return [RubySMB::Smb2::Dispatcher,#send_packet,#recv_packet]
+  # @return [RubySMB::SMB2::Dispatcher,#send_packet,#recv_packet]
   attr_accessor :dispatcher
 
   # The ActiveDirectory domain name to associate the client with
@@ -141,7 +141,7 @@ class RubySMB::Smb2::Client
   #
   # @return [void]
   def negotiate
-    packet = RubySMB::Smb2::Packet::NegotiateRequest.new(
+    packet = RubySMB::SMB2::Packet::NegotiateRequest.new(
       dialects: "\x02\x02".force_encoding('binary'),
       dialect_count: 1,
       client_guid: 0,
@@ -167,10 +167,10 @@ class RubySMB::Smb2::Client
   # Sends a {SessionSetupRequest} packet with the
   # NTLMSSP_AUTH data to complete authentication handshake.
   #
-  # @param challenge [RubySMB::Smb2::Packet::SessionSetupResponse]  the response packet from #ntlmssp_negotiate
-  # @return [RubySMB::Smb2::Packet::SessionSetupResponse] the final SessionSetup Response packet
+  # @param challenge [RubySMB::SMB2::Packet::SessionSetupResponse]  the response packet from #ntlmssp_negotiate
+  # @return [RubySMB::SMB2::Packet::SessionSetupResponse] the final SessionSetup Response packet
   def ntlmssp_auth(challenge)
-    packet = RubySMB::Smb2::Packet::SessionSetupRequest.new(
+    packet = RubySMB::SMB2::Packet::SessionSetupRequest.new(
       security_mode: security_mode,
     )
 
@@ -186,9 +186,9 @@ class RubySMB::Smb2::Client
   # Sends a {SessionSetupRequest} packet with the
   # NTLMSSP_NEGOTIATE data to initiate authentication handshake.
   #
-  # @return [RubySMB::Smb2::Packet::SessionSetupResponse] the first SessionSetup Response packet
+  # @return [RubySMB::SMB2::Packet::SessionSetupResponse] the first SessionSetup Response packet
   def ntlmssp_negotiate
-    packet = RubySMB::Smb2::Packet::SessionSetupRequest.new(
+    packet = RubySMB::SMB2::Packet::SessionSetupRequest.new(
       security_mode: security_mode,
     )
     type1 = @ntlm_client.init_context
@@ -210,7 +210,7 @@ class RubySMB::Smb2::Client
 
     # Sign the packet if necessary.
     # THIS MUST BE THE LAST THING WE DO BEFORE SENDING
-    if @session_id && signing_required? && !request.kind_of?(RubySMB::Smb2::Packet::SessionSetupRequest)
+    if @session_id && signing_required? && !request.kind_of?(RubySMB::SMB2::Packet::SessionSetupRequest)
       request.sign!(session_key)
     end
 
@@ -235,22 +235,22 @@ class RubySMB::Smb2::Client
   #
   # @see http://blogs.technet.com/b/josebda/archive/2010/12/01/the-basics-of-smb-signing-covering-both-smb1-and-smb2.aspx
   def signing_required?
-    RubySMB::Smb2::Packet::SECURITY_MODES[:SIGNING_REQUIRED] ==
-      (security_mode & RubySMB::Smb2::Packet::SECURITY_MODES[:SIGNING_REQUIRED])
+    RubySMB::SMB2::Packet::SECURITY_MODES[:SIGNING_REQUIRED] ==
+      (security_mode & RubySMB::SMB2::Packet::SECURITY_MODES[:SIGNING_REQUIRED])
   end
 
   # Connect to a share
   #
   # @param tree [String] Something like "\\\\hostname\\tree"
-  # @return [RubySMB::Smb2::Tree]
+  # @return [RubySMB::SMB2::Tree]
   def tree_connect(tree)
-    packet = RubySMB::Smb2::Packet::TreeConnectRequest.new(
+    packet = RubySMB::SMB2::Packet::TreeConnectRequest.new(
       tree: tree.encode("utf-16le")
     )
 
     response = send_recv(packet)
 
-    RubySMB::Smb2::Tree.new(client: self, share: tree, tree_connect_response: response)
+    RubySMB::SMB2::Tree.new(client: self, share: tree, tree_connect_response: response)
   end
 
   protected

--- a/lib/ruby_smb/smb2/packet.rb
+++ b/lib/ruby_smb/smb2/packet.rb
@@ -3,7 +3,7 @@ require 'bit-struct'
 # A PDU for the SMB2 protocol
 #
 # [[MS-SMB2] 2.2 Message Syntax](https://msdn.microsoft.com/en-us/library/cc246497.aspx)
-module RubySMB::Smb2
+module RubySMB::SMB2
   module Packet
 
     # Raised when {#has_flag?} is given something that isn't a member of
@@ -331,7 +331,7 @@ module RubySMB::Smb2
     # Take data from the wire and determine the type of packet it is.
     #
     # @param data [String] packet data from the wire
-    # @return [RubySMB::Smb2::Packet::Generic] a subclass of {Generic}
+    # @return [RubySMB::SMB2::Packet::Generic] a subclass of {Generic}
     def self.parse(data)
       generic = Generic.new(data)
 

--- a/lib/ruby_smb/smb2/packet/close_request.rb
+++ b/lib/ruby_smb/smb2/packet/close_request.rb
@@ -1,9 +1,9 @@
 require 'ruby_smb/smb2/packet'
 
 # [Section 2.2.15 SMB2 CLOSE Request](https://msdn.microsoft.com/en-us/library/cc246523.aspx)
-class RubySMB::Smb2::Packet::CloseRequest < RubySMB::Smb2::Packet::Request
+class RubySMB::SMB2::Packet::CloseRequest < RubySMB::SMB2::Packet::Request
 
-  # A key in {RubySMB::Smb2::COMMANDS}
+  # A key in {RubySMB::SMB2::COMMANDS}
   COMMAND = :CLOSE
 
   unsigned :struct_size, 16, default: 24

--- a/lib/ruby_smb/smb2/packet/close_response.rb
+++ b/lib/ruby_smb/smb2/packet/close_response.rb
@@ -1,7 +1,7 @@
 require 'ruby_smb/smb2/packet'
 
 # [Section 2.2.16 SMB2 CLOSE Response](https://msdn.microsoft.com/en-us/library/cc246524.aspx)
-class RubySMB::Smb2::Packet::CloseResponse < RubySMB::Smb2::Packet::Response
+class RubySMB::SMB2::Packet::CloseResponse < RubySMB::SMB2::Packet::Response
   COMMAND = :CLOSE
 
   unsigned :struct_size, 16, default: 60

--- a/lib/ruby_smb/smb2/packet/create_request.rb
+++ b/lib/ruby_smb/smb2/packet/create_request.rb
@@ -3,9 +3,9 @@ require 'ruby_smb/smb2/packet'
 # [Section 2.2.13 SMB2 CREATE Request](http://msdn.microsoft.com/en-us/library/cc246502.aspx)
 #
 # [Example 4.4 Executing an Operation on a Named Pipe](http://msdn.microsoft.com/en-us/library/cc246794.aspx)
-class RubySMB::Smb2::Packet::CreateRequest < RubySMB::Smb2::Packet::Request
+class RubySMB::SMB2::Packet::CreateRequest < RubySMB::SMB2::Packet::Request
 
-  # A key in {RubySMB::Smb2::COMMANDS}
+  # A key in {RubySMB::SMB2::COMMANDS}
   COMMAND = :CREATE
 
   # "The client MUST set this field to 57, indicating the size of the

--- a/lib/ruby_smb/smb2/packet/create_response.rb
+++ b/lib/ruby_smb/smb2/packet/create_response.rb
@@ -3,7 +3,7 @@ require 'ruby_smb/smb2/packet'
 # [Section 2.2.14 SMB2 CREATE Response](http://msdn.microsoft.com/en-us/library/cc246512.aspx)
 #
 # [Example 4.4 Executing an Operation on a Named Pipe](http://msdn.microsoft.com/en-us/library/cc246794.aspx)
-class RubySMB::Smb2::Packet::CreateResponse < RubySMB::Smb2::Packet::Response
+class RubySMB::SMB2::Packet::CreateResponse < RubySMB::SMB2::Packet::Response
   COMMAND = :CREATE
 
   # "The server MUST set this field to 89, indicating the size of the

--- a/lib/ruby_smb/smb2/packet/echo_request.rb
+++ b/lib/ruby_smb/smb2/packet/echo_request.rb
@@ -1,7 +1,7 @@
 # [Section 2.2.28 SMB2 ECHO Request](https://msdn.microsoft.com/en-us/library/cc246540.aspx)
-class RubySMB::Smb2::Packet::EchoRequest < RubySMB::Smb2::Packet::Request
+class RubySMB::SMB2::Packet::EchoRequest < RubySMB::SMB2::Packet::Request
 
-  # A key in {RubySMB::Smb2::COMMANDS}
+  # A key in {RubySMB::SMB2::COMMANDS}
   COMMAND = :ECHO
 
   unsigned :structure_size, 16, default: 4

--- a/lib/ruby_smb/smb2/packet/echo_response.rb
+++ b/lib/ruby_smb/smb2/packet/echo_response.rb
@@ -1,5 +1,5 @@
 # [Section 2.2.29 SMB2 ECHO Response](https://msdn.microsoft.com/en-us/library/cc246541.aspx)
-class RubySMB::Smb2::Packet::EchoResponse < RubySMB::Smb2::Packet::Response
+class RubySMB::SMB2::Packet::EchoResponse < RubySMB::SMB2::Packet::Response
   unsigned :structure_size, 16, default: 4
   unsigned :reserved, 16
 end

--- a/lib/ruby_smb/smb2/packet/generic.rb
+++ b/lib/ruby_smb/smb2/packet/generic.rb
@@ -1,4 +1,4 @@
-module RubySMB::Smb2::Packet
+module RubySMB::SMB2::Packet
   # Class that represents a generic SMB2 packet.
   class Generic < BitStruct
 
@@ -96,7 +96,7 @@ module RubySMB::Smb2::Packet
 
       if self.class.const_defined?(:COMMAND)
         # Set the appropriate {#command} in the header for this packet type
-        self.command = RubySMB::Smb2::COMMANDS[self.class::COMMAND]
+        self.command = RubySMB::SMB2::COMMANDS[self.class::COMMAND]
       end
     end
 
@@ -154,7 +154,7 @@ module RubySMB::Smb2::Packet
     # @return [void]
     def sign!(session_key)
       self.signature = "\0" * 16
-      self.header_flags |= RubySMB::Smb2::Packet::HEADER_FLAGS[:SIGNING]
+      self.header_flags |= RubySMB::SMB2::Packet::HEADER_FLAGS[:SIGNING]
 
       hmac = OpenSSL::HMAC.digest(OpenSSL::Digest::SHA256.new, session_key, self.to_s)
 

--- a/lib/ruby_smb/smb2/packet/ioctl_request.rb
+++ b/lib/ruby_smb/smb2/packet/ioctl_request.rb
@@ -3,9 +3,9 @@ require 'ruby_smb/smb2/packet'
 # [Section 2.2.31 SMB2 IOCTL Request](https://msdn.microsoft.com/en-us/library/cc246545.aspx)
 #
 # [Example 4.4 Executing an Operation on a Named Pipe](http://msdn.microsoft.com/en-us/library/cc246794.aspx)
-class RubySMB::Smb2::Packet::IoctlRequest < RubySMB::Smb2::Packet::Request
+class RubySMB::SMB2::Packet::IoctlRequest < RubySMB::SMB2::Packet::Request
 
-  # A key in {RubySMB::Smb2::COMMANDS}
+  # A key in {RubySMB::SMB2::COMMANDS}
   COMMAND = :IOCTL
 
   # > The client MUST set this field to 57, indicating the size of the

--- a/lib/ruby_smb/smb2/packet/ioctl_response.rb
+++ b/lib/ruby_smb/smb2/packet/ioctl_response.rb
@@ -3,7 +3,7 @@ require 'ruby_smb/smb2/packet'
 # [Section 2.2.31 SMB2 IOCTL Response]()
 #
 # [Example 4.4 Executing an Operation on a Named Pipe](http://msdn.microsoft.com/en-us/library/cc246794.aspx)
-class RubySMB::Smb2::Packet::IoctlResponse < RubySMB::Smb2::Packet::Response
+class RubySMB::SMB2::Packet::IoctlResponse < RubySMB::SMB2::Packet::Response
   COMMAND = :IOCTL
 
 end

--- a/lib/ruby_smb/smb2/packet/negotiate_request.rb
+++ b/lib/ruby_smb/smb2/packet/negotiate_request.rb
@@ -1,9 +1,9 @@
 require 'ruby_smb/smb2/packet'
 
 # [Section 2.2.3 SMB2 NEGOTIATE Request](https://msdn.microsoft.com/en-us/library/cc246543.aspx)
-class RubySMB::Smb2::Packet::NegotiateRequest < RubySMB::Smb2::Packet::Request
+class RubySMB::SMB2::Packet::NegotiateRequest < RubySMB::SMB2::Packet::Request
 
-  # A key in {RubySMB::Smb2::COMMANDS}
+  # A key in {RubySMB::SMB2::COMMANDS}
   COMMAND = :NEGOTIATE
 
   unsigned :struct_size, 16, default: 36

--- a/lib/ruby_smb/smb2/packet/negotiate_response.rb
+++ b/lib/ruby_smb/smb2/packet/negotiate_response.rb
@@ -1,7 +1,7 @@
 require 'ruby_smb/smb2/packet'
 
 # [[MS-SMB2] 2.2.4 SMB2 NEGOTIATE Response](https://msdn.microsoft.com/en-us/library/cc246561.aspx)
-class RubySMB::Smb2::Packet::NegotiateResponse < RubySMB::Smb2::Packet::Response
+class RubySMB::SMB2::Packet::NegotiateResponse < RubySMB::SMB2::Packet::Response
   COMMAND = :NEGOTIATE
 
   unsigned :struct_size, 16, default: 65

--- a/lib/ruby_smb/smb2/packet/query.rb
+++ b/lib/ruby_smb/smb2/packet/query.rb
@@ -1,5 +1,5 @@
 #
-module RubySMB::Smb2::Packet::Query
+module RubySMB::SMB2::Packet::Query
   autoload :NamesInformation, 'ruby_smb/smb2/packet/query/names_information'
   autoload :StandardInformation, 'ruby_smb/smb2/packet/query/standard_information'
 

--- a/lib/ruby_smb/smb2/packet/query/names_information.rb
+++ b/lib/ruby_smb/smb2/packet/query/names_information.rb
@@ -1,5 +1,5 @@
 # [[MS-FSCC] 2.4.26 FileNamesInformation](https://msdn.microsoft.com/en-us/library/cc232077.aspx)
-class RubySMB::Smb2::Packet::Query::NamesInformation < BitStruct
+class RubySMB::SMB2::Packet::Query::NamesInformation < BitStruct
 
   default_options endian: 'little'
 

--- a/lib/ruby_smb/smb2/packet/query/quota_info.rb
+++ b/lib/ruby_smb/smb2/packet/query/quota_info.rb
@@ -1,6 +1,6 @@
 
 # [[MS-SMB2] 2.2.37.1 SMB2_QUERY_QUOTA_INFO](https://msdn.microsoft.com/en-us/library/cc246558.aspx)
-class RubySMB::Smb2::Packet::Query::QuotaInfo < BitStruct
+class RubySMB::SMB2::Packet::Query::QuotaInfo < BitStruct
   default_options endian: 'little'
 
   unsigned :return_single, 8

--- a/lib/ruby_smb/smb2/packet/query/standard_information.rb
+++ b/lib/ruby_smb/smb2/packet/query/standard_information.rb
@@ -1,5 +1,5 @@
 # [[MS-FSCC] 2.4.38 FileStandardInformation](https://msdn.microsoft.com/en-us/library/cc232088.aspx)
-class RubySMB::Smb2::Packet::Query::StandardInformation < BitStruct
+class RubySMB::SMB2::Packet::Query::StandardInformation < BitStruct
   default_options endian: 'little'
 
   unsigned :allocation_size, 64

--- a/lib/ruby_smb/smb2/packet/query_directory_request.rb
+++ b/lib/ruby_smb/smb2/packet/query_directory_request.rb
@@ -1,9 +1,9 @@
 require 'ruby_smb/smb2/packet'
 
-# @see RubySMB::Smb2::Packet::QUERY_DIRECTORY_FLAGS
-class RubySMB::Smb2::Packet::QueryDirectoryRequest < RubySMB::Smb2::Packet::Request
+# @see RubySMB::SMB2::Packet::QUERY_DIRECTORY_FLAGS
+class RubySMB::SMB2::Packet::QueryDirectoryRequest < RubySMB::SMB2::Packet::Request
 
-  # A key in {Smb2::COMMANDS}
+  # A key in {SMB2::COMMANDS}
   COMMAND = :QUERY_DIRECTORY
 
   unsigned :struct_size, 16, default: 33

--- a/lib/ruby_smb/smb2/packet/query_directory_response.rb
+++ b/lib/ruby_smb/smb2/packet/query_directory_response.rb
@@ -1,7 +1,7 @@
 require 'ruby_smb/smb2/packet'
 
 # [[MS-SMB2] 2.2.34 SMB2 QUERY_DIRECTORY Response](https://msdn.microsoft.com/en-us/library/cc246552.aspx)
-class RubySMB::Smb2::Packet::QueryDirectoryResponse < RubySMB::Smb2::Packet::Response
+class RubySMB::SMB2::Packet::QueryDirectoryResponse < RubySMB::SMB2::Packet::Response
   COMMAND = :QUERY_DIRECTORY
 
   unsigned :struct_size, 16, default: 9

--- a/lib/ruby_smb/smb2/packet/query_info_request.rb
+++ b/lib/ruby_smb/smb2/packet/query_info_request.rb
@@ -1,9 +1,9 @@
 require 'ruby_smb/smb2/packet'
 
-# @see RubySMB::Smb2::Packet::QUERY_INFO_TYPES
-class RubySMB::Smb2::Packet::QueryInfoRequest < RubySMB::Smb2::Packet::Request
+# @see RubySMB::SMB2::Packet::QUERY_INFO_TYPES
+class RubySMB::SMB2::Packet::QueryInfoRequest < RubySMB::SMB2::Packet::Request
 
-  # A key in {Smb2::COMMANDS}
+  # A key in {SMB2::COMMANDS}
   COMMAND = :QUERY_INFO
 
   unsigned :struct_size, 16, default: 41

--- a/lib/ruby_smb/smb2/packet/query_info_response.rb
+++ b/lib/ruby_smb/smb2/packet/query_info_response.rb
@@ -1,7 +1,7 @@
 require 'ruby_smb/smb2/packet'
 
 # [[MS-SMB2] 2.2.38 SMB2 QUERY_INFO Response](https://msdn.microsoft.com/en-us/library/cc246559.aspx)
-class RubySMB::Smb2::Packet::QueryInfoResponse < RubySMB::Smb2::Packet::Response
+class RubySMB::SMB2::Packet::QueryInfoResponse < RubySMB::SMB2::Packet::Response
   COMMAND = :QUERY_INFO
 
   unsigned :struct_size, 16, default: 9

--- a/lib/ruby_smb/smb2/packet/read_request.rb
+++ b/lib/ruby_smb/smb2/packet/read_request.rb
@@ -3,9 +3,9 @@ require 'ruby_smb/smb2/packet'
 # [Section 2.2.19 SMB2 Read Request](https://msdn.microsoft.com/en-us/library/cc246527.aspx)
 #
 # [Example 4.4 Executing an Operation on a Named Pipe](http://msdn.microsoft.com/en-us/library/cc246794.aspx)
-class RubySMB::Smb2::Packet::ReadRequest < RubySMB::Smb2::Packet::Request
+class RubySMB::SMB2::Packet::ReadRequest < RubySMB::SMB2::Packet::Request
 
-  # A key in {Smb2::COMMANDS}
+  # A key in {SMB2::COMMANDS}
   COMMAND = :READ
 
   # Values for {#flags}

--- a/lib/ruby_smb/smb2/packet/read_response.rb
+++ b/lib/ruby_smb/smb2/packet/read_response.rb
@@ -3,7 +3,7 @@ require 'ruby_smb/smb2/packet'
 # [Section 2.2.22 SMB2 Read Response](https://msdn.microsoft.com/en-us/library/cc246531.aspx)
 #
 # [Example 4.4 Executing an Operation on a Named Pipe](http://msdn.microsoft.com/en-us/library/cc246794.aspx)
-class RubySMB::Smb2::Packet::ReadResponse < RubySMB::Smb2::Packet::Response
+class RubySMB::SMB2::Packet::ReadResponse < RubySMB::SMB2::Packet::Response
   COMMAND = :READ
 
   unsigned :struct_size, 16, default: 17

--- a/lib/ruby_smb/smb2/packet/request.rb
+++ b/lib/ruby_smb/smb2/packet/request.rb
@@ -32,10 +32,10 @@ require 'ruby_smb/smb2/packet'
 #    *                                                               *
 #    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 # ```
-class RubySMB::Smb2::Packet::Request < RubySMB::Smb2::Packet::Generic
+class RubySMB::SMB2::Packet::Request < RubySMB::SMB2::Packet::Generic
   def initialize(*args)
     super
-    self.header_flags &= ~RubySMB::Smb2::Packet::HEADER_FLAGS[:RESPONSE]
+    self.header_flags &= ~RubySMB::SMB2::Packet::HEADER_FLAGS[:RESPONSE]
   end
 
   def channel_seq

--- a/lib/ruby_smb/smb2/packet/response.rb
+++ b/lib/ruby_smb/smb2/packet/response.rb
@@ -1,11 +1,11 @@
 require 'ruby_smb/smb2/packet'
 
 # A response header, largely copy-pasta'd from the request header.
-class RubySMB::Smb2::Packet::Response < RubySMB::Smb2::Packet::Generic
+class RubySMB::SMB2::Packet::Response < RubySMB::SMB2::Packet::Generic
 
   def initialize(*args)
     super
-    self.header_flags &= RubySMB::Smb2::Packet::HEADER_FLAGS[:RESPONSE]
+    self.header_flags &= RubySMB::SMB2::Packet::HEADER_FLAGS[:RESPONSE]
   end
 
 end

--- a/lib/ruby_smb/smb2/packet/session_setup_request.rb
+++ b/lib/ruby_smb/smb2/packet/session_setup_request.rb
@@ -1,9 +1,9 @@
 require 'ruby_smb/smb2/packet'
 
 # [Section 2.2.5 SMB2 SESSION_SETUP Request](https://msdn.microsoft.com/en-us/library/cc246563.aspx)
-class RubySMB::Smb2::Packet::SessionSetupRequest < RubySMB::Smb2::Packet::Request
+class RubySMB::SMB2::Packet::SessionSetupRequest < RubySMB::SMB2::Packet::Request
 
-  # A key in {Smb2::COMMANDS}
+  # A key in {SMB2::COMMANDS}
   COMMAND = :SESSION_SETUP
 
   unsigned :struct_size,   16, default: 25

--- a/lib/ruby_smb/smb2/packet/session_setup_response.rb
+++ b/lib/ruby_smb/smb2/packet/session_setup_response.rb
@@ -1,7 +1,7 @@
 require 'ruby_smb/smb2/packet'
 
 # [Section 2.2.6 SMB2 SESSION_SETUP Response](https://msdn.microsoft.com/en-us/library/cc246564.aspx)
-class RubySMB::Smb2::Packet::SessionSetupResponse < RubySMB::Smb2::Packet::Response
+class RubySMB::SMB2::Packet::SessionSetupResponse < RubySMB::SMB2::Packet::Response
   COMMAND = :SESSION_SETUP
 
   unsigned :struct_size,          16

--- a/lib/ruby_smb/smb2/packet/tree_connect_request.rb
+++ b/lib/ruby_smb/smb2/packet/tree_connect_request.rb
@@ -1,9 +1,9 @@
 require 'ruby_smb/smb2/packet'
 
 # [Section 2.2.9 SMB2 TREE_CONNECT Request](https://msdn.microsoft.com/en-us/library/cc246567.aspx)
-class RubySMB::Smb2::Packet::TreeConnectRequest < RubySMB::Smb2::Packet::Request
+class RubySMB::SMB2::Packet::TreeConnectRequest < RubySMB::SMB2::Packet::Request
 
-  # A key in {Smb2::COMMANDS}
+  # A key in {SMB2::COMMANDS}
   COMMAND = :TREE_CONNECT
 
   # "The client MUST set this field to 9, indicating the size of the request

--- a/lib/ruby_smb/smb2/packet/tree_connect_response.rb
+++ b/lib/ruby_smb/smb2/packet/tree_connect_response.rb
@@ -1,7 +1,7 @@
 require 'ruby_smb/smb2/packet'
 
 # [Section 2.2.10 SMB2 TREE_CONNECT Response](https://msdn.microsoft.com/en-us/library/cc246499.aspx)
-class RubySMB::Smb2::Packet::TreeConnectResponse < RubySMB::Smb2::Packet::Response
+class RubySMB::SMB2::Packet::TreeConnectResponse < RubySMB::SMB2::Packet::Response
   COMMAND = :TREE_CONNECT
 
   unsigned :struct_size, 16

--- a/lib/ruby_smb/smb2/packet/write_request.rb
+++ b/lib/ruby_smb/smb2/packet/write_request.rb
@@ -3,9 +3,9 @@ require 'ruby_smb/smb2/packet'
 # [Section 2.2.21 SMB2 Write Request](http://msdn.microsoft.com/en-us/library/cc246532.aspx)
 #
 # [Example 4.4 Executing an Operation on a Named Pipe](http://msdn.microsoft.com/en-us/library/cc246794.aspx)
-class RubySMB::Smb2::Packet::WriteRequest < RubySMB::Smb2::Packet::Request
+class RubySMB::SMB2::Packet::WriteRequest < RubySMB::SMB2::Packet::Request
 
-  # A key in {Smb2::COMMANDS}
+  # A key in {SMB2::COMMANDS}
   COMMAND = :WRITE
 
   unsigned :struct_size, 16, default: 49

--- a/lib/ruby_smb/smb2/packet/write_response.rb
+++ b/lib/ruby_smb/smb2/packet/write_response.rb
@@ -3,7 +3,7 @@ require 'ruby_smb/smb2/packet'
 # [Section 2.2.22 SMB2 Write Response](http://msdn.microsoft.com/en-us/library/cc246533.aspx)
 #
 # [Example 4.4 Executing an Operation on a Named Pipe](http://msdn.microsoft.com/en-us/library/cc246794.aspx)
-class RubySMB::Smb2::Packet::WriteResponse < RubySMB::Smb2::Packet::Response
+class RubySMB::SMB2::Packet::WriteResponse < RubySMB::SMB2::Packet::Response
   COMMAND = :WRITE
 
   unsigned :struct_size, 16, default: 17

--- a/lib/ruby_smb/smb2/tree.rb
+++ b/lib/ruby_smb/smb2/tree.rb
@@ -1,9 +1,9 @@
-# A connected tree, as returned by a {Smb2::Packet::TreeConnectRequest}.
-class RubySMB::Smb2::Tree
+# A connected tree, as returned by a {SMB2::Packet::TreeConnectRequest}.
+class RubySMB::SMB2::Tree
 
-  # The {Smb2::Client} on which this Tree is connected.
+  # The {SMB2::Client} on which this Tree is connected.
   #
-  # @return [RubySMB::Smb2::Client]
+  # @return [RubySMB::SMB2::Client]
   attr_accessor :client
 
   # The name of the share this Tree operates on
@@ -13,7 +13,7 @@ class RubySMB::Smb2::Tree
 
   # The response that occasioned the creation of this {Tree}.
   #
-  # @return [RubySMB::Smb2::Packet::TreeConnectResponse]
+  # @return [RubySMB::SMB2::Packet::TreeConnectResponse]
   attr_accessor :tree_connect_response
 
   # The NTStatus code received from the {TreeConnectResponse}
@@ -21,11 +21,11 @@ class RubySMB::Smb2::Tree
   # @return [WindowsError::ErrorCode] the NTStatus code object
   attr_accessor :tree_connect_status
 
-  # @param client [Smb::Client] (see {#client})
+  # @param client [SMB::Client] (see {#client})
   # @param share [String] (see {#share})
-  # @param tree_connect_response [Smb::Packet::TreeConnectResponse]
+  # @param tree_connect_response [SMB::Packet::TreeConnectResponse]
   def initialize(client:, share:, tree_connect_response:)
-    unless tree_connect_response.is_a?(RubySMB::Smb2::Packet::TreeConnectResponse)
+    unless tree_connect_response.is_a?(RubySMB::SMB2::Packet::TreeConnectResponse)
       raise ArgumentError, "tree_connect_response must be a TreeConnectResponse"
     end
 
@@ -47,29 +47,29 @@ class RubySMB::Smb2::Tree
   #
   # @param filename [String,#encode] this will be encoded in utf-16le
   # @param mode [String] See stdlib ::File#mode
-  # @yield [RubySMB::Smb2::File]
-  # @return [RubySMB::Smb2::File] if no block given
+  # @yield [RubySMB::SMB2::File]
+  # @return [RubySMB::SMB2::File] if no block given
   # @return [Object] value of the block if block given
   def create(filename, mode = "r+")
     desired_access = desired_access_from_mode(mode)
-    create_options = RubySMB::Smb2::Packet::CREATE_OPTIONS[:FILE_NON_DIRECTORY_FILE]
+    create_options = RubySMB::SMB2::Packet::CREATE_OPTIONS[:FILE_NON_DIRECTORY_FILE]
     share_access =
-      RubySMB::Smb2::Packet::SHARE_ACCESS[:FILE_SHARE_READ] |
-      RubySMB::Smb2::Packet::SHARE_ACCESS[:FILE_SHARE_WRITE]
+      RubySMB::SMB2::Packet::SHARE_ACCESS[:FILE_SHARE_READ] |
+      RubySMB::SMB2::Packet::SHARE_ACCESS[:FILE_SHARE_WRITE]
 
-    packet = RubySMB::Smb2::Packet::CreateRequest.new(
+    packet = RubySMB::SMB2::Packet::CreateRequest.new(
       create_options: create_options,
       desired_access: desired_access,
       disposition: disposition_from_file_mode(mode),
       filename: filename.encode("utf-16le"),
-      impersonation: RubySMB::Smb2::Packet::IMPERSONATION_LEVELS[:IMPERSONATION],
+      impersonation: RubySMB::SMB2::Packet::IMPERSONATION_LEVELS[:IMPERSONATION],
       share_access: share_access,
     )
 
     response = send_recv(packet)
 
-    create_response = RubySMB::Smb2::Packet::CreateResponse.new(response)
-    file = RubySMB::Smb2::File.new(filename: filename, tree: self, create_response: create_response)
+    create_response = RubySMB::SMB2::Packet::CreateResponse.new(response)
+    file = RubySMB::SMB2::File.new(filename: filename, tree: self, create_response: create_response)
     if mode.start_with?("a")
       file.seek(create_response.end_of_file)
     end
@@ -93,23 +93,23 @@ class RubySMB::Smb2::Tree
   # @return [void]
   def delete(filename)
     share_access =
-      RubySMB::Smb2::Packet::SHARE_ACCESS[:FILE_SHARE_READ] |
-      RubySMB::Smb2::Packet::SHARE_ACCESS[:FILE_SHARE_WRITE] |
-      RubySMB::Smb2::Packet::SHARE_ACCESS[:FILE_SHARE_DELETE]
+      RubySMB::SMB2::Packet::SHARE_ACCESS[:FILE_SHARE_READ] |
+      RubySMB::SMB2::Packet::SHARE_ACCESS[:FILE_SHARE_WRITE] |
+      RubySMB::SMB2::Packet::SHARE_ACCESS[:FILE_SHARE_DELETE]
 
-    packet = RubySMB::Smb2::Packet::CreateRequest.new(
-      create_options: RubySMB::Smb2::Packet::CREATE_OPTIONS[:FILE_DELETE_ON_CLOSE],
-      desired_access: RubySMB::Smb2::Packet::FILE_ACCESS_MASK[:DELETE],
-      disposition: RubySMB::Smb2::Packet::CREATE_DISPOSITIONS[:FILE_OPEN],
+    packet = RubySMB::SMB2::Packet::CreateRequest.new(
+      create_options: RubySMB::SMB2::Packet::CREATE_OPTIONS[:FILE_DELETE_ON_CLOSE],
+      desired_access: RubySMB::SMB2::Packet::FILE_ACCESS_MASK[:DELETE],
+      disposition: RubySMB::SMB2::Packet::CREATE_DISPOSITIONS[:FILE_OPEN],
       filename: filename.encode("utf-16le"),
-      impersonation: RubySMB::Smb2::Packet::IMPERSONATION_LEVELS[:IMPERSONATION],
+      impersonation: RubySMB::SMB2::Packet::IMPERSONATION_LEVELS[:IMPERSONATION],
       share_access: share_access,
     )
 
     response = send_recv(packet)
 
-    create_response = RubySMB::Smb2::Packet::CreateResponse.new(response)
-    file = RubySMB::Smb2::File.new(
+    create_response = RubySMB::SMB2::Packet::CreateResponse.new(response)
+    file = RubySMB::SMB2::File.new(
       filename: filename,
       tree: self,
       create_response: create_response
@@ -140,12 +140,12 @@ class RubySMB::Smb2::Tree
   # @todo refactor this method to not rely on exceptions
   # @todo refactor exception-with-inspect pattern to use logging
   def list(directory: nil, pattern: '*', type: :FileNamesInformation)
-    create_request = RubySMB::Smb2::Packet::CreateRequest.new(
-      impersonation: RubySMB::Smb2::Packet::IMPERSONATION_LEVELS[:IMPERSONATION],
-      desired_access: RubySMB::Smb2::Packet::DIRECTORY_ACCESS_MASK[:FILE_LIST_DIRECTORY],
-      share_access: RubySMB::Smb2::Packet::SHARE_ACCESS[:FILE_SHARE_READ],
-      disposition: RubySMB::Smb2::Packet::CREATE_DISPOSITIONS[:FILE_OPEN],
-      create_options: RubySMB::Smb2::Packet::CREATE_OPTIONS[:FILE_DIRECTORY_FILE]
+    create_request = RubySMB::SMB2::Packet::CreateRequest.new(
+      impersonation: RubySMB::SMB2::Packet::IMPERSONATION_LEVELS[:IMPERSONATION],
+      desired_access: RubySMB::SMB2::Packet::DIRECTORY_ACCESS_MASK[:FILE_LIST_DIRECTORY],
+      share_access: RubySMB::SMB2::Packet::SHARE_ACCESS[:FILE_SHARE_READ],
+      disposition: RubySMB::SMB2::Packet::CREATE_DISPOSITIONS[:FILE_OPEN],
+      create_options: RubySMB::SMB2::Packet::CREATE_OPTIONS[:FILE_DIRECTORY_FILE]
     )
 
     # TODO: add some inline doc for this if block
@@ -158,14 +158,14 @@ class RubySMB::Smb2::Tree
     end
 
     response = send_recv(create_request)
-    create_response = RubySMB::Smb2::Packet::CreateResponse.new(response)
+    create_response = RubySMB::SMB2::Packet::CreateResponse.new(response)
 
     unless create_response.nt_status == WindowsError::NTStatus::STATUS_SUCCESS
       raise create_response.inspect
     end
 
-    directory_request = RubySMB::Smb2::Packet::QueryDirectoryRequest.new(
-      file_info_class: RubySMB::Smb2::Packet::FILE_INFORMATION_CLASSES[type],
+    directory_request = RubySMB::SMB2::Packet::QueryDirectoryRequest.new(
+      file_info_class: RubySMB::SMB2::Packet::FILE_INFORMATION_CLASSES[type],
       file_id: create_response.file_id,
       file_name: pattern.encode('utf-16le')
     )
@@ -174,7 +174,7 @@ class RubySMB::Smb2::Tree
 
     loop do
       response = send_recv(directory_request)
-      directory_response = RubySMB::Smb2::Packet::QueryDirectoryResponse.new(response)
+      directory_response = RubySMB::SMB2::Packet::QueryDirectoryResponse.new(response)
 
       break if directory_response.nt_status == WindowsError::NTStatus::STATUS_NO_MORE_FILES
 
@@ -183,9 +183,9 @@ class RubySMB::Smb2::Tree
       end
 
       blob = directory_response.output_buffer
-      klass = RubySMB::Smb2::Packet::Query::FILE_INFORMATION_CLASSES[type]
+      klass = RubySMB::SMB2::Packet::Query::FILE_INFORMATION_CLASSES[type]
 
-      class_array += RubySMB::Smb2::Packet::Query.class_array_from_blob(blob, klass)
+      class_array += RubySMB::SMB2::Packet::Query.class_array_from_blob(blob, klass)
     end
 
     class_array
@@ -193,7 +193,7 @@ class RubySMB::Smb2::Tree
 
   # Send a packet and return the response
   #
-  # @param request [RubySMB::Smb2::Packet]
+  # @param request [RubySMB::SMB2::Packet]
   # @return (see Client#send_recv)
   def send_recv(request)
     request.tree_id = self.tree_connect_response.tree_id
@@ -206,20 +206,20 @@ class RubySMB::Smb2::Tree
 
   def desired_access_from_mode(mode)
     # Read-only is our base access here.
-    base_access_mask = RubySMB::Smb2::Packet::FILE_ACCESS_MASK[:FILE_READ_DATA] |
-      RubySMB::Smb2::Packet::FILE_ACCESS_MASK[:FILE_READ_EA] |
-      RubySMB::Smb2::Packet::FILE_ACCESS_MASK[:FILE_READ_ATTRIBUTES] |
-      RubySMB::Smb2::Packet::FILE_ACCESS_MASK[:READ_CONTROL] |
-      RubySMB::Smb2::Packet::FILE_ACCESS_MASK[:SYNCHRONIZE]
+    base_access_mask = RubySMB::SMB2::Packet::FILE_ACCESS_MASK[:FILE_READ_DATA] |
+      RubySMB::SMB2::Packet::FILE_ACCESS_MASK[:FILE_READ_EA] |
+      RubySMB::SMB2::Packet::FILE_ACCESS_MASK[:FILE_READ_ATTRIBUTES] |
+      RubySMB::SMB2::Packet::FILE_ACCESS_MASK[:READ_CONTROL] |
+      RubySMB::SMB2::Packet::FILE_ACCESS_MASK[:SYNCHRONIZE]
     case mode
     when "r+", "w+", "a+", "w", "a"
       # read/write and write-only. Samba's smbclient sets all the read flags
       # when writing, so emulate that.
       access_mask = base_access_mask |
-        RubySMB::Smb2::Packet::FILE_ACCESS_MASK[:FILE_WRITE_DATA] |
-        RubySMB::Smb2::Packet::FILE_ACCESS_MASK[:FILE_APPEND_DATA] |
-        RubySMB::Smb2::Packet::FILE_ACCESS_MASK[:FILE_WRITE_EA] |
-        RubySMB::Smb2::Packet::FILE_ACCESS_MASK[:FILE_WRITE_ATTRIBUTES]
+        RubySMB::SMB2::Packet::FILE_ACCESS_MASK[:FILE_WRITE_DATA] |
+        RubySMB::SMB2::Packet::FILE_ACCESS_MASK[:FILE_APPEND_DATA] |
+        RubySMB::SMB2::Packet::FILE_ACCESS_MASK[:FILE_WRITE_EA] |
+        RubySMB::SMB2::Packet::FILE_ACCESS_MASK[:FILE_WRITE_ATTRIBUTES]
     when "r"
       access_mask = base_access_mask
     else
@@ -231,12 +231,12 @@ class RubySMB::Smb2::Tree
   def disposition_from_file_mode(mode)
     case mode
     when "r", "r+"
-      RubySMB::Smb2::Packet::CREATE_DISPOSITIONS[:FILE_OPEN]
+      RubySMB::SMB2::Packet::CREATE_DISPOSITIONS[:FILE_OPEN]
     when "w", "w+"
       # truncate
-      RubySMB::Smb2::Packet::CREATE_DISPOSITIONS[:FILE_OVERWRITE_IF]
+      RubySMB::SMB2::Packet::CREATE_DISPOSITIONS[:FILE_OVERWRITE_IF]
     when "a", "a+"
-      RubySMB::Smb2::Packet::CREATE_DISPOSITIONS[:FILE_OPEN_IF]
+      RubySMB::SMB2::Packet::CREATE_DISPOSITIONS[:FILE_OPEN_IF]
     else
       raise ArgumentError, "mode is not a valid file mode"
     end

--- a/lib/ruby_smb/version.rb
+++ b/lib/ruby_smb/version.rb
@@ -9,6 +9,7 @@ module RubySMB
     # The patch number, scoped to the {MINOR} version number.
     PATCH = 7
 
+    PRERELEASE = 'smb-capitalize'
     # The full version string, including the {MAJOR}, {MINOR}, {PATCH}, and optionally, the `PRERELEASE` in the
     # {http://semver.org/spec/v2.0.0.html semantic versioning v2.0.0} format.
     #

--- a/spec/lib/ruby_smb/smb1/packet/andx_block_spec.rb
+++ b/spec/lib/ruby_smb/smb1/packet/andx_block_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe RubySMB::Smb1::Packet::AndXBlock do
+RSpec.describe RubySMB::SMB1::Packet::AndXBlock do
 
   subject(:andx_block) { described_class.new }
 
@@ -10,7 +10,7 @@ RSpec.describe RubySMB::Smb1::Packet::AndXBlock do
 
   describe 'defaults' do
     it 'sets andx_command to SMB_COM_NO_ANDX_COMMAND by default' do
-      expect(andx_block.andx_command).to eq RubySMB::Smb1::COMMANDS[:SMB_COM_NO_ANDX_COMMAND]
+      expect(andx_block.andx_command).to eq RubySMB::SMB1::COMMANDS[:SMB_COM_NO_ANDX_COMMAND]
     end
 
     it 'sets andx_reserved to 0 by default' do

--- a/spec/lib/ruby_smb/smb1/packet/smb_data_block_spec.rb
+++ b/spec/lib/ruby_smb/smb1/packet/smb_data_block_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe RubySMB::Smb1::Packet::SmbDataBlock do
+RSpec.describe RubySMB::SMB1::Packet::SMBDataBlock do
 
   subject(:data_block) { described_class.new }
 

--- a/spec/lib/ruby_smb/smb1/packet/smb_header_spec.rb
+++ b/spec/lib/ruby_smb/smb1/packet/smb_header_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe RubySMB::Smb1::Packet::SmbHeader do
+RSpec.describe RubySMB::SMB1::Packet::SMBHeader do
 
   subject(:header) { described_class.new }
 
@@ -24,7 +24,7 @@ RSpec.describe RubySMB::Smb1::Packet::SmbHeader do
     end
 
     it 'should be hardcoded to SMB_PROTOCOL_ID by default per the SMB spec' do
-      expect(header.protocol).to eq RubySMB::Smb1::SMB_PROTOCOL_ID
+      expect(header.protocol).to eq RubySMB::SMB1::SMB_PROTOCOL_ID
     end
   end
 

--- a/spec/lib/ruby_smb/smb1/packet/smb_parameter_block_spec.rb
+++ b/spec/lib/ruby_smb/smb1/packet/smb_parameter_block_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe RubySMB::Smb1::Packet::SmbParameterBlock do
+RSpec.describe RubySMB::SMB1::Packet::SMBParameterBlock do
 
   subject(:param_block) { described_class.new }
 

--- a/spec/lib/ruby_smb/smb2/client_spec.rb
+++ b/spec/lib/ruby_smb/smb2/client_spec.rb
@@ -1,6 +1,6 @@
 require 'support/mock_socket_dispatcher'
 
-RSpec.describe RubySMB::Smb2::Client do
+RSpec.describe RubySMB::SMB2::Client do
   subject(:client) do
     described_class.new(dispatcher: dispatcher, username: username, password: password)
   end
@@ -14,11 +14,11 @@ RSpec.describe RubySMB::Smb2::Client do
 
   context 'with_negotiation' do
     before do
-      expect(dispatcher).to receive(:send_packet).with(kind_of RubySMB::Smb2::Packet::Generic)
+      expect(dispatcher).to receive(:send_packet).with(kind_of RubySMB::SMB2::Packet::Generic)
       expect(dispatcher).to receive(:recv_packet).and_return(negotiate_response)
     end
 
-    let(:negotiate_response) { RubySMB::Smb2::Packet::NegotiateResponse.new }
+    let(:negotiate_response) { RubySMB::SMB2::Packet::NegotiateResponse.new }
 
     describe '#negotiate' do
       it 'runs without error' do
@@ -46,8 +46,8 @@ RSpec.describe RubySMB::Smb2::Client do
         expect(client).to receive(:ntlmssp_auth).with(challenge).and_return(response)
       end
 
-      let(:challenge) { RubySMB::Smb2::Packet::SessionSetupResponse.new }
-      let(:response)  { RubySMB::Smb2::Packet::SessionSetupResponse.new }
+      let(:challenge) { RubySMB::SMB2::Packet::SessionSetupResponse.new }
+      let(:response)  { RubySMB::SMB2::Packet::SessionSetupResponse.new }
 
       context 'with valid credentials' do
         before do
@@ -81,8 +81,8 @@ RSpec.describe RubySMB::Smb2::Client do
     describe '#ntlmssp_negotiate' do
       before do
         expect{ client.negotiate }.not_to raise_error
-        expect(dispatcher).to receive(:send_packet).with(kind_of RubySMB::Smb2::Packet::SessionSetupRequest)
-        expect(dispatcher).to receive(:recv_packet).and_return(RubySMB::Smb2::Packet::SessionSetupResponse.new)
+        expect(dispatcher).to receive(:send_packet).with(kind_of RubySMB::SMB2::Packet::SessionSetupRequest)
+        expect(dispatcher).to receive(:recv_packet).and_return(RubySMB::SMB2::Packet::SessionSetupResponse.new)
       end
 
       it 'runs without error' do

--- a/spec/lib/ruby_smb/smb2/file_spec.rb
+++ b/spec/lib/ruby_smb/smb2/file_spec.rb
@@ -1,11 +1,11 @@
 
-RSpec.describe RubySMB::Smb2::File do
+RSpec.describe RubySMB::SMB2::File do
   subject(:file) do
     described_class.new(filename: "test.txt", tree: tree, create_response: create_response)
   end
 
   let(:create_response) do
-    cr = double('Smb2::Packet::CreateResponse')
+    cr = double('SMB2::Packet::CreateResponse')
     allow(cr).to receive(:file_id) { "f" * 16 }
     cr
   end
@@ -18,10 +18,10 @@ RSpec.describe RubySMB::Smb2::File do
 
   context '#read' do
     let(:tree) do
-      t = double('Smb2::Tree')
+      t = double('SMB2::Tree')
       allow(t).to receive_message_chain(:client, :max_read_size) { max_read_size }
       allow(t).to receive(:send_recv) do |packet|
-        RubySMB::Smb2::Packet::ReadResponse.new do |response|
+        RubySMB::SMB2::Packet::ReadResponse.new do |response|
           response.data = data.slice(packet.read_offset, packet.read_length)
         end
       end
@@ -35,7 +35,7 @@ RSpec.describe RubySMB::Smb2::File do
     context 'with data smaller than max read size' do
       let(:data) { "A" * (max_read_size - 1) }
       specify do
-        expect(tree).to receive(:send_recv).once.with(instance_of(RubySMB::Smb2::Packet::ReadRequest))
+        expect(tree).to receive(:send_recv).once.with(instance_of(RubySMB::SMB2::Packet::ReadRequest))
         expect(file.read).to eq(data)
       end
     end
@@ -43,7 +43,7 @@ RSpec.describe RubySMB::Smb2::File do
     context 'with data equal to max read size' do
       let(:data) { "A" * (max_read_size) }
       specify do
-        expect(tree).to receive(:send_recv).once.with(instance_of(RubySMB::Smb2::Packet::ReadRequest))
+        expect(tree).to receive(:send_recv).once.with(instance_of(RubySMB::SMB2::Packet::ReadRequest))
         expect(file.read).to eq(data)
       end
     end
@@ -54,13 +54,13 @@ RSpec.describe RubySMB::Smb2::File do
       specify do
         expect(tree).to receive(:send_recv)
           .exactly(1 + (data.length / max_read_size)).times
-          .with(instance_of(RubySMB::Smb2::Packet::ReadRequest))
+          .with(instance_of(RubySMB::SMB2::Packet::ReadRequest))
         expect(file.read).to eq(data)
       end
 
       context 'with an offset that makes it less than max read size' do
         specify do
-          expect(tree).to receive(:send_recv).once.with(instance_of(RubySMB::Smb2::Packet::ReadRequest))
+          expect(tree).to receive(:send_recv).once.with(instance_of(RubySMB::SMB2::Packet::ReadRequest))
           offset = (data.length - max_read_size / 2)
           file.seek(offset)
           expect(file.read).to eq(data.slice(offset..data.length))
@@ -69,7 +69,7 @@ RSpec.describe RubySMB::Smb2::File do
 
       context 'with an offset in the middle and length less than max_read_size' do
         specify do
-          expect(tree).to receive(:send_recv).once.with(instance_of(RubySMB::Smb2::Packet::ReadRequest))
+          expect(tree).to receive(:send_recv).once.with(instance_of(RubySMB::SMB2::Packet::ReadRequest))
           offset = (data.length / 2 - max_read_size / 2)
           file.seek(offset)
           length = max_read_size - 1
@@ -83,7 +83,7 @@ RSpec.describe RubySMB::Smb2::File do
 
   context '#write' do
     let(:tree) do
-      t = double('Smb2::Tree')
+      t = double('SMB2::Tree')
       allow(t).to receive_message_chain(:client, :max_write_size) { max_write_size }
       t
     end
@@ -94,7 +94,7 @@ RSpec.describe RubySMB::Smb2::File do
 
       specify do
         expected_len = data.length / 2
-        response_packet = RubySMB::Smb2::Packet::WriteResponse.new(byte_count: expected_len)
+        response_packet = RubySMB::SMB2::Packet::WriteResponse.new(byte_count: expected_len)
 
         expect(file).to receive(:write_chunk).
           once.with(data[0, expected_len], offset: 0).
@@ -112,10 +112,10 @@ RSpec.describe RubySMB::Smb2::File do
 
   context '#write_chunk' do
     let(:tree) do
-      t = double('Smb2::Tree')
+      t = double('SMB2::Tree')
       allow(t).to receive_message_chain(:client, :max_write_size) { max_write_size }
       allow(t).to receive(:send_recv) do |packet|
-        response = RubySMB::Smb2::Packet::WriteResponse.new(
+        response = RubySMB::SMB2::Packet::WriteResponse.new(
           byte_count: [packet.data_length, max_write_size].min
         )
         response.nt_status = 0
@@ -133,14 +133,14 @@ RSpec.describe RubySMB::Smb2::File do
       end
 
       specify do
-        expect(tree).to receive(:send_recv).once.with(instance_of(RubySMB::Smb2::Packet::WriteRequest))
-        expect(file.write_chunk(data)).to be_a(RubySMB::Smb2::Packet::WriteResponse)
+        expect(tree).to receive(:send_recv).once.with(instance_of(RubySMB::SMB2::Packet::WriteRequest))
+        expect(file.write_chunk(data)).to be_a(RubySMB::SMB2::Packet::WriteResponse)
       end
 
       specify do
-        expect(tree).to receive(:send_recv).once.with(instance_of(RubySMB::Smb2::Packet::WriteRequest))
+        expect(tree).to receive(:send_recv).once.with(instance_of(RubySMB::SMB2::Packet::WriteRequest))
         packet = file.write_chunk(data)
-        expect(packet).to be_a(RubySMB::Smb2::Packet::WriteResponse)
+        expect(packet).to be_a(RubySMB::SMB2::Packet::WriteResponse)
         expect(packet.byte_count).to eq(data.length)
       end
 

--- a/spec/lib/ruby_smb/smb2/packet/close_request_spec.rb
+++ b/spec/lib/ruby_smb/smb2/packet/close_request_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe RubySMB::Smb2::Packet::CloseRequest do
+RSpec.describe RubySMB::SMB2::Packet::CloseRequest do
   subject(:packet) do
     described_class.new(data)
   end
@@ -13,7 +13,7 @@ RSpec.describe RubySMB::Smb2::Packet::CloseRequest do
     end
 
     it_behaves_like "packet"
-    it_behaves_like "request", RubySMB::Smb2::COMMANDS[:CLOSE]
+    it_behaves_like "request", RubySMB::SMB2::COMMANDS[:CLOSE]
 
     specify do
       expect(packet.to_s).to eq(data)

--- a/spec/lib/ruby_smb/smb2/packet/close_response_spec.rb
+++ b/spec/lib/ruby_smb/smb2/packet/close_response_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe RubySMB::Smb2::Packet::CloseResponse do
+RSpec.describe RubySMB::SMB2::Packet::CloseResponse do
   subject(:packet) do
     described_class.new(data)
   end

--- a/spec/lib/ruby_smb/smb2/packet/create_request_spec.rb
+++ b/spec/lib/ruby_smb/smb2/packet/create_request_spec.rb
@@ -1,7 +1,7 @@
 require 'ruby_smb/smb2'
 require 'support/shared/examples/request'
 
-RSpec.describe RubySMB::Smb2::Packet::CreateRequest do
+RSpec.describe RubySMB::SMB2::Packet::CreateRequest do
   subject(:packet) do
     described_class.new(data)
   end
@@ -18,7 +18,7 @@ RSpec.describe RubySMB::Smb2::Packet::CreateRequest do
     end
 
     it_behaves_like "packet"
-    it_behaves_like "request", RubySMB::Smb2::COMMANDS[:CREATE]
+    it_behaves_like "request", RubySMB::SMB2::COMMANDS[:CREATE]
 
     specify 'body' do
       expect(packet.struct_size).to eq(57)

--- a/spec/lib/ruby_smb/smb2/packet/create_response_spec.rb
+++ b/spec/lib/ruby_smb/smb2/packet/create_response_spec.rb
@@ -1,6 +1,6 @@
 require 'ruby_smb/smb2'
 
-RSpec.describe RubySMB::Smb2::Packet::CreateResponse do
+RSpec.describe RubySMB::SMB2::Packet::CreateResponse do
   subject(:packet) do
     described_class.new(data)
   end
@@ -21,7 +21,7 @@ RSpec.describe RubySMB::Smb2::Packet::CreateResponse do
     specify 'header' do
       expect(packet.magic).to eq("\xfeSMB".force_encoding("binary"))
       expect(packet.signature).to eq(("\x00" * 16).force_encoding("binary"))
-      expect(packet.command).to eq(RubySMB::Smb2::COMMANDS[:CREATE])
+      expect(packet.command).to eq(RubySMB::SMB2::COMMANDS[:CREATE])
     end
 
     specify 'body' do

--- a/spec/lib/ruby_smb/smb2/packet/echo_request_spec.rb
+++ b/spec/lib/ruby_smb/smb2/packet/echo_request_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe RubySMB::Smb2::Packet::EchoRequest do
+RSpec.describe RubySMB::SMB2::Packet::EchoRequest do
 
   subject(:echo_request_packet) { described_class.new }
 

--- a/spec/lib/ruby_smb/smb2/packet/echo_response_spec.rb
+++ b/spec/lib/ruby_smb/smb2/packet/echo_response_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe RubySMB::Smb2::Packet::EchoResponse do
+RSpec.describe RubySMB::SMB2::Packet::EchoResponse do
 
   subject(:echo_response_packet) { described_class.new }
 

--- a/spec/lib/ruby_smb/smb2/packet/generic_spec.rb
+++ b/spec/lib/ruby_smb/smb2/packet/generic_spec.rb
@@ -1,6 +1,6 @@
 require 'ruby_smb/smb2'
 
-RSpec.describe RubySMB::Smb2::Packet::Generic do
+RSpec.describe RubySMB::SMB2::Packet::Generic do
   let(:klass) do
     Class.new(described_class) do
       # struct_size is part of the API and must be present

--- a/spec/lib/ruby_smb/smb2/packet/ioctl_request_spec.rb
+++ b/spec/lib/ruby_smb/smb2/packet/ioctl_request_spec.rb
@@ -1,7 +1,7 @@
 require 'ruby_smb/smb2'
 require 'support/shared/examples/request'
 
-RSpec.describe RubySMB::Smb2::Packet::IoctlRequest do
+RSpec.describe RubySMB::SMB2::Packet::IoctlRequest do
   subject(:packet) do
     described_class.new(data)
   end
@@ -18,7 +18,7 @@ RSpec.describe RubySMB::Smb2::Packet::IoctlRequest do
     end
 
     it_behaves_like "packet"
-    it_behaves_like "request", RubySMB::Smb2::COMMANDS[:IOCTL]
+    it_behaves_like "request", RubySMB::SMB2::COMMANDS[:IOCTL]
 
     specify 'struct_size' do
       expect(packet.struct_size).to eq(57)

--- a/spec/lib/ruby_smb/smb2/packet/negotiate_request_spec.rb
+++ b/spec/lib/ruby_smb/smb2/packet/negotiate_request_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe RubySMB::Smb2::Packet::NegotiateRequest do
+RSpec.describe RubySMB::SMB2::Packet::NegotiateRequest do
   subject(:packet) do
     described_class.new(data)
   end
@@ -16,7 +16,7 @@ RSpec.describe RubySMB::Smb2::Packet::NegotiateRequest do
     end
 
     it_behaves_like 'packet'
-    it_behaves_like 'request', RubySMB::Smb2::COMMANDS[:NEGOTIATE]
+    it_behaves_like 'request', RubySMB::SMB2::COMMANDS[:NEGOTIATE]
     it_behaves_like 'smb2_negotiate_packet_header'
 
     context 'body' do

--- a/spec/lib/ruby_smb/smb2/packet/negotiate_response_spec.rb
+++ b/spec/lib/ruby_smb/smb2/packet/negotiate_response_spec.rb
@@ -1,6 +1,6 @@
 require 'ruby_smb/smb2'
 
-RSpec.describe RubySMB::Smb2::Packet::NegotiateResponse do
+RSpec.describe RubySMB::SMB2::Packet::NegotiateResponse do
   subject(:packet) do
     described_class.new(data)
   end

--- a/spec/lib/ruby_smb/smb2/packet/query_directory_request_spec.rb
+++ b/spec/lib/ruby_smb/smb2/packet/query_directory_request_spec.rb
@@ -1,7 +1,7 @@
 require 'ruby_smb/smb2'
 require 'support/shared/examples/request'
 
-RSpec.describe RubySMB::Smb2::Packet::QueryDirectoryRequest do
+RSpec.describe RubySMB::SMB2::Packet::QueryDirectoryRequest do
   subject(:packet) do
     described_class.new(data)
   end
@@ -17,7 +17,7 @@ RSpec.describe RubySMB::Smb2::Packet::QueryDirectoryRequest do
     end
 
     it_behaves_like "packet"
-    it_behaves_like "request", RubySMB::Smb2::COMMANDS[:QUERY_DIRECTORY]
+    it_behaves_like "request", RubySMB::SMB2::COMMANDS[:QUERY_DIRECTORY]
 
     context 'body' do
       specify 'struct_size' do
@@ -25,7 +25,7 @@ RSpec.describe RubySMB::Smb2::Packet::QueryDirectoryRequest do
       end
       specify 'file_info_class' do
         expect(packet.file_info_class).to eq(
-          RubySMB::Smb2::Packet::FILE_INFORMATION_CLASSES[:FileIdBothDirectoryInformation]
+          RubySMB::SMB2::Packet::FILE_INFORMATION_CLASSES[:FileIdBothDirectoryInformation]
         )
       end
       specify 'flags' do

--- a/spec/lib/ruby_smb/smb2/packet/query_directory_response_spec.rb
+++ b/spec/lib/ruby_smb/smb2/packet/query_directory_response_spec.rb
@@ -1,6 +1,6 @@
 require 'ruby_smb/smb2'
 
-RSpec.describe RubySMB::Smb2::Packet::QueryDirectoryResponse do
+RSpec.describe RubySMB::SMB2::Packet::QueryDirectoryResponse do
   subject(:packet) do
     described_class.new(data)
   end

--- a/spec/lib/ruby_smb/smb2/packet/query_info_request_spec.rb
+++ b/spec/lib/ruby_smb/smb2/packet/query_info_request_spec.rb
@@ -1,7 +1,7 @@
 require 'ruby_smb/smb2'
 require 'support/shared/examples/request'
 
-RSpec.describe RubySMB::Smb2::Packet::QueryInfoRequest do
+RSpec.describe RubySMB::SMB2::Packet::QueryInfoRequest do
   subject(:packet) do
     described_class.new(data)
   end
@@ -17,18 +17,18 @@ RSpec.describe RubySMB::Smb2::Packet::QueryInfoRequest do
     end
 
     it_behaves_like "packet"
-    it_behaves_like "request", RubySMB::Smb2::COMMANDS[:QUERY_INFO]
+    it_behaves_like "request", RubySMB::SMB2::COMMANDS[:QUERY_INFO]
 
     context 'body' do
       specify 'struct_size' do
         expect(packet.struct_size).to eq(41)
       end
       specify 'info_type' do
-        expect(packet.info_type).to eq(RubySMB::Smb2::Packet::QUERY_INFO_TYPES[:FILE])
+        expect(packet.info_type).to eq(RubySMB::SMB2::Packet::QUERY_INFO_TYPES[:FILE])
       end
       specify 'file_info_class' do
         expect(packet.file_info_class).to eq(
-          RubySMB::Smb2::Packet::FILE_INFORMATION_CLASSES[:FileStandardInformation]
+          RubySMB::SMB2::Packet::FILE_INFORMATION_CLASSES[:FileStandardInformation]
         )
       end
       specify 'output_buffer_length' do

--- a/spec/lib/ruby_smb/smb2/packet/query_info_response_spec.rb
+++ b/spec/lib/ruby_smb/smb2/packet/query_info_response_spec.rb
@@ -1,6 +1,6 @@
 require 'ruby_smb/smb2'
 
-RSpec.describe RubySMB::Smb2::Packet::QueryInfoResponse do
+RSpec.describe RubySMB::SMB2::Packet::QueryInfoResponse do
   subject(:packet) do
     described_class.new(data)
   end

--- a/spec/lib/ruby_smb/smb2/packet/read_request_spec.rb
+++ b/spec/lib/ruby_smb/smb2/packet/read_request_spec.rb
@@ -1,7 +1,7 @@
 require 'ruby_smb/smb2'
 require 'support/shared/examples/request'
 
-RSpec.describe RubySMB::Smb2::Packet::ReadRequest do
+RSpec.describe RubySMB::SMB2::Packet::ReadRequest do
   subject(:packet) do
     described_class.new(data)
   end
@@ -17,7 +17,7 @@ RSpec.describe RubySMB::Smb2::Packet::ReadRequest do
     end
 
     it_behaves_like "packet"
-    it_behaves_like "request", RubySMB::Smb2::COMMANDS[:READ]
+    it_behaves_like "request", RubySMB::SMB2::COMMANDS[:READ]
 
     specify 'struct_size' do
       expect(packet.struct_size).to eq(49)

--- a/spec/lib/ruby_smb/smb2/packet/read_response_spec.rb
+++ b/spec/lib/ruby_smb/smb2/packet/read_response_spec.rb
@@ -1,6 +1,6 @@
 require 'ruby_smb/smb2'
 
-RSpec.describe RubySMB::Smb2::Packet::ReadResponse do
+RSpec.describe RubySMB::SMB2::Packet::ReadResponse do
   subject(:packet) do
     described_class.new(data)
   end

--- a/spec/lib/ruby_smb/smb2/packet/request_spec.rb
+++ b/spec/lib/ruby_smb/smb2/packet/request_spec.rb
@@ -1,6 +1,6 @@
 require 'ruby_smb/smb2'
 
-RSpec.describe RubySMB::Smb2::Packet::Request do
+RSpec.describe RubySMB::SMB2::Packet::Request do
   let(:data) { nil }
   subject(:packet) do
     described_class.new(data)
@@ -39,14 +39,14 @@ RSpec.describe RubySMB::Smb2::Packet::Request do
       expect(packet.magic).to eq("\xfeSMB".force_encoding("binary"))
       expect(packet.header_len).to eq(64)
       expect(packet.credit_charge).to eq(1)
-      expect(packet.command).to eq(RubySMB::Smb2::COMMANDS[:SESSION_SETUP])
+      expect(packet.command).to eq(RubySMB::SMB2::COMMANDS[:SESSION_SETUP])
       expect(packet.credits_requested).to eq(31)
       expect(packet.signature).to eq(("\x00" * 16).force_encoding("binary"))
     end
 
     describe '#has_header_flag?' do
       specify do
-        expect { packet.has_header_flag?(:garbage) }.to raise_error(RubySMB::Smb2::Packet::InvalidFlagError)
+        expect { packet.has_header_flag?(:garbage) }.to raise_error(RubySMB::SMB2::Packet::InvalidFlagError)
       end
       specify do
         expect(packet.has_header_flag?(:RESPONSE)).to be_falsey

--- a/spec/lib/ruby_smb/smb2/packet/session_setup_request_spec.rb
+++ b/spec/lib/ruby_smb/smb2/packet/session_setup_request_spec.rb
@@ -2,7 +2,7 @@ require 'ruby_smb/smb2'
 require 'net/ntlm'
 require 'support/shared/examples/request'
 
-RSpec.describe RubySMB::Smb2::Packet::SessionSetupRequest do
+RSpec.describe RubySMB::SMB2::Packet::SessionSetupRequest do
   subject(:packet) do
     described_class.new(data)
   end
@@ -20,7 +20,7 @@ RSpec.describe RubySMB::Smb2::Packet::SessionSetupRequest do
     end
 
     it_behaves_like "packet"
-    it_behaves_like "request", RubySMB::Smb2::COMMANDS[:SESSION_SETUP]
+    it_behaves_like "request", RubySMB::SMB2::COMMANDS[:SESSION_SETUP]
 
     specify 'body' do
       expect(packet.struct_size).to eq(25)
@@ -79,7 +79,7 @@ RSpec.describe RubySMB::Smb2::Packet::SessionSetupRequest do
     specify 'header' do
       expect(packet.magic).to eq("\xfeSMB".force_encoding("binary"))
       expect(packet.signature).to eq(("\x00" * 16).force_encoding("binary"))
-      expect(packet.command).to eq(RubySMB::Smb2::COMMANDS[:SESSION_SETUP])
+      expect(packet.command).to eq(RubySMB::SMB2::COMMANDS[:SESSION_SETUP])
     end
 
     specify 'body' do
@@ -108,7 +108,7 @@ RSpec.describe RubySMB::Smb2::Packet::SessionSetupRequest do
 
     describe '#has_flag?' do
       specify do
-        expect { packet.has_flag?(:garbage) }.to raise_error(RubySMB::Smb2::Packet::InvalidFlagError)
+        expect { packet.has_flag?(:garbage) }.to raise_error(RubySMB::SMB2::Packet::InvalidFlagError)
       end
       specify do
         expect(packet.has_flag?(:SESSION_BINDING_REQUEST)).to be_falsey

--- a/spec/lib/ruby_smb/smb2/packet/session_setup_response_spec.rb
+++ b/spec/lib/ruby_smb/smb2/packet/session_setup_response_spec.rb
@@ -1,7 +1,7 @@
 require 'ruby_smb/smb2'
 require 'net/ntlm'
 
-RSpec.describe RubySMB::Smb2::Packet::SessionSetupResponse do
+RSpec.describe RubySMB::SMB2::Packet::SessionSetupResponse do
   subject(:packet) do
     described_class.new(data)
   end
@@ -28,7 +28,7 @@ RSpec.describe RubySMB::Smb2::Packet::SessionSetupResponse do
     specify 'header' do
       expect(packet.magic).to eq("\xfeSMB".force_encoding("binary"))
       expect(packet.signature).to eq(("\x00" * 16).force_encoding("binary"))
-      expect(packet.command).to eq(RubySMB::Smb2::COMMANDS[:SESSION_SETUP])
+      expect(packet.command).to eq(RubySMB::SMB2::COMMANDS[:SESSION_SETUP])
 
     end
 

--- a/spec/lib/ruby_smb/smb2/packet/tree_connect_request_spec.rb
+++ b/spec/lib/ruby_smb/smb2/packet/tree_connect_request_spec.rb
@@ -1,7 +1,7 @@
 require 'ruby_smb/smb2'
 require 'support/shared/examples/request'
 
-RSpec.describe RubySMB::Smb2::Packet::TreeConnectRequest do
+RSpec.describe RubySMB::SMB2::Packet::TreeConnectRequest do
   subject(:packet) do
     described_class.new(data)
   end
@@ -17,7 +17,7 @@ RSpec.describe RubySMB::Smb2::Packet::TreeConnectRequest do
     end
 
     it_behaves_like "packet"
-    it_behaves_like "request", RubySMB::Smb2::COMMANDS[:TREE_CONNECT]
+    it_behaves_like "request", RubySMB::SMB2::COMMANDS[:TREE_CONNECT]
 
     specify 'body' do
       expect(packet.struct_size).to eq(9)

--- a/spec/lib/ruby_smb/smb2/packet/tree_connect_response_spec.rb
+++ b/spec/lib/ruby_smb/smb2/packet/tree_connect_response_spec.rb
@@ -1,6 +1,6 @@
 require 'ruby_smb/smb2'
 
-RSpec.describe RubySMB::Smb2::Packet::TreeConnectResponse do
+RSpec.describe RubySMB::SMB2::Packet::TreeConnectResponse do
   subject(:packet) do
     described_class.new(data)
   end
@@ -19,7 +19,7 @@ RSpec.describe RubySMB::Smb2::Packet::TreeConnectResponse do
     specify 'header' do
       expect(packet.magic).to eq("\xfeSMB".force_encoding("binary"))
       expect(packet.signature).to eq(("\x00" * 16).force_encoding("binary"))
-      expect(packet.command).to eq(RubySMB::Smb2::COMMANDS[:TREE_CONNECT])
+      expect(packet.command).to eq(RubySMB::SMB2::COMMANDS[:TREE_CONNECT])
       expect(packet).to have_header_flag(:RESPONSE)
     end
 

--- a/spec/lib/ruby_smb/smb2/packet/write_request_spec.rb
+++ b/spec/lib/ruby_smb/smb2/packet/write_request_spec.rb
@@ -1,7 +1,7 @@
 require 'ruby_smb/smb2'
 require 'support/shared/examples/request'
 
-RSpec.describe RubySMB::Smb2::Packet::WriteRequest do
+RSpec.describe RubySMB::SMB2::Packet::WriteRequest do
   subject(:packet) do
     described_class.new(data)
   end
@@ -21,7 +21,7 @@ RSpec.describe RubySMB::Smb2::Packet::WriteRequest do
     end
 
     it_behaves_like "packet"
-    it_behaves_like "request", RubySMB::Smb2::COMMANDS[:WRITE]
+    it_behaves_like "request", RubySMB::SMB2::COMMANDS[:WRITE]
 
     specify 'struct_size' do
       expect(packet.struct_size).to eq(49)

--- a/spec/lib/ruby_smb/smb2/packet/write_response_spec.rb
+++ b/spec/lib/ruby_smb/smb2/packet/write_response_spec.rb
@@ -1,6 +1,6 @@
 require 'ruby_smb/smb2'
 
-RSpec.describe RubySMB::Smb2::Packet::WriteResponse do
+RSpec.describe RubySMB::SMB2::Packet::WriteResponse do
   subject(:packet) do
     described_class.new(data)
   end

--- a/spec/support/shared/examples/packet.rb
+++ b/spec/support/shared/examples/packet.rb
@@ -5,8 +5,8 @@ RSpec.shared_examples 'packet' do
   context 'command' do
 
     specify do
-      expect(RubySMB::Smb2::COMMANDS).to include(subject.class::COMMAND)
-      expect(subject.command).to eq(RubySMB::Smb2::COMMANDS[subject.class::COMMAND])
+      expect(RubySMB::SMB2::COMMANDS).to include(subject.class::COMMAND)
+      expect(subject.command).to eq(RubySMB::SMB2::COMMANDS[subject.class::COMMAND])
     end
 
     it { is_expected.to respond_to(:magic) }

--- a/spec/support/shared/examples/smb2_negotiate_header.rb
+++ b/spec/support/shared/examples/smb2_negotiate_header.rb
@@ -8,6 +8,6 @@ RSpec.shared_examples 'smb2_negotiate_packet_header' do
     expect(packet.signature).to eq(("\x00" * 16).force_encoding('binary'))
   end
   specify do
-    expect(packet.command).to eq(RubySMB::Smb2::COMMANDS[:NEGOTIATE])
+    expect(packet.command).to eq(RubySMB::SMB2::COMMANDS[:NEGOTIATE])
   end
 end


### PR DESCRIPTION
we had mixed casing of SMB in a lot of places
but SMB is an initialism and should be all caps
even if it's slgihtly at odds with standard ruby style.

MSP-13049

VERIFICATION STEPS
- [x] `rake spec`
- [x] VERIFY all specs pass
- [x] run examples/smoke_test.rb against an SMB2 server
- [x] VERIFY the script finishes without errors
