### PR TITLE
Adding specs for structs field sizes

### DIFF
--- a/lib/ruby_smb/version.rb
+++ b/lib/ruby_smb/version.rb
@@ -9,7 +9,6 @@ module RubySMB
     # The patch number, scoped to the {MINOR} version number.
     PATCH = 7
 
-    PRERELEASE = 'smb-field-length-specs'
     # The full version string, including the {MAJOR}, {MINOR}, {PATCH}, and optionally, the `PRERELEASE` in the
     # {http://semver.org/spec/v2.0.0.html semantic versioning v2.0.0} format.
     #

--- a/lib/ruby_smb/version.rb
+++ b/lib/ruby_smb/version.rb
@@ -9,7 +9,7 @@ module RubySMB
     # The patch number, scoped to the {MINOR} version number.
     PATCH = 7
 
-    PRERELEASE = 'smb-capitalize'
+    PRERELEASE = 'smb-field-length-specs'
     # The full version string, including the {MAJOR}, {MINOR}, {PATCH}, and optionally, the `PRERELEASE` in the
     # {http://semver.org/spec/v2.0.0.html semantic versioning v2.0.0} format.
     #

--- a/spec/lib/ruby_smb/smb1/packet/andx_block_spec.rb
+++ b/spec/lib/ruby_smb/smb1/packet/andx_block_spec.rb
@@ -8,16 +8,35 @@ RSpec.describe RubySMB::SMB1::Packet::AndXBlock do
   it { is_expected.to respond_to :andx_reserved }
   it { is_expected.to respond_to :andx_offset }
 
-  describe 'defaults' do
-    it 'sets andx_command to SMB_COM_NO_ANDX_COMMAND by default' do
+  describe 'andx_command' do
+    it 'should be a 8-bit field per the SMB spec' do
+      andx_command_size_field = andx_block.fields.detect { |f| f.name == :andx_command }
+      expect(andx_command_size_field.length).to eq 8
+    end
+
+    it 'should be hardcoded to SMB_COM_NO_ANDX_COMMAND by default per the SMB spec' do
       expect(andx_block.andx_command).to eq RubySMB::SMB1::COMMANDS[:SMB_COM_NO_ANDX_COMMAND]
     end
+  end
 
-    it 'sets andx_reserved to 0 by default' do
-      expect(andx_block.andx_reserved).to eq 0
+  describe 'andx_reserved' do
+    it 'should be a 8-bit field per the SMB spec' do
+      andx_reserved_size_field = andx_block.fields.detect { |f| f.name == :andx_reserved }
+      expect(andx_reserved_size_field.length).to eq 8
     end
 
-    it 'sets andx_offset to 0 by default' do
+    it 'should be hardcoded to 0 by default per the SMB spec' do
+      expect(andx_block.andx_reserved).to eq 0
+    end
+  end
+
+  describe 'andx_offset' do
+    it 'should be a 16-bit field per the SMB spec' do
+      andx_offset_size_field = andx_block.fields.detect { |f| f.name == :andx_offset }
+      expect(andx_offset_size_field.length).to eq 16
+    end
+
+    it 'should be hardcoded to 0 by default per the SMB spec' do
       expect(andx_block.andx_offset).to eq 0
     end
   end

--- a/spec/lib/ruby_smb/smb1/packet/smb_data_block_spec.rb
+++ b/spec/lib/ruby_smb/smb1/packet/smb_data_block_spec.rb
@@ -7,6 +7,13 @@ RSpec.describe RubySMB::SMB1::Packet::SMBDataBlock do
   it { is_expected.to respond_to :byte_count }
   it { is_expected.to respond_to :bytes }
 
+  describe 'byte_count' do
+    it 'should be a 16-bit field per the SMB spec' do
+      byte_count_size_field = data_block.fields.detect { |f| f.name == :byte_count}
+      expect(byte_count_size_field.length).to eq 16
+    end
+  end
+
   describe '#bytes=' do
     context 'with a valid value' do
       let(:bytes_value) { "\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF" }

--- a/spec/lib/ruby_smb/smb1/packet/smb_parameter_block_spec.rb
+++ b/spec/lib/ruby_smb/smb1/packet/smb_parameter_block_spec.rb
@@ -7,6 +7,13 @@ RSpec.describe RubySMB::SMB1::Packet::SMBParameterBlock do
   it { is_expected.to respond_to :word_count }
   it { is_expected.to respond_to :words }
 
+  describe 'word_count' do
+    it 'should be a 8-bit field per the SMB spec' do
+      word_count_size_field = param_block.fields.detect { |f| f.name == :word_count}
+      expect(word_count_size_field.length).to eq 8
+    end
+  end
+
   describe '#words=' do
     context 'with a valid value' do
       let(:words_value) { "\xFF\xFF\xFF\xFF" }


### PR DESCRIPTION
Added specs to each SMB structs to check field size lengths

MSP-13048

- [x] `rake spec`
- [x] VERIFY all specs pass
- [x] Remove the PRERELEASE tag