### PR TITLE
switch to bin data, negotiate command done

### DIFF
--- a/lib/ruby_smb.rb
+++ b/lib/ruby_smb.rb
@@ -1,4 +1,5 @@
 require 'bit-struct'
+require 'bindata'
 require 'net/ntlm'
 require 'net/ntlm/client'
 require 'windows_error'

--- a/lib/ruby_smb/smb1.rb
+++ b/lib/ruby_smb/smb1.rb
@@ -10,4 +10,8 @@ module RubySMB::SMB1
   }
   # Protocol ID value. Translates to \xFFSMB
   SMB_PROTOCOL_ID = 0xFF534D42
+
+
+  # null terminator string value.
+  NULL_TERMINATOR = "\x00"
 end

--- a/lib/ruby_smb/smb1.rb
+++ b/lib/ruby_smb/smb1.rb
@@ -5,6 +5,7 @@ module RubySMB::SMB1
 
 
   COMMANDS = {
+    SMB_COM_NEGOTIATE: 0x72,
     SMB_COM_NO_ANDX_COMMAND: 0xFF
   }
   # Protocol ID value. Translates to \xFFSMB

--- a/lib/ruby_smb/smb1/packet.rb
+++ b/lib/ruby_smb/smb1/packet.rb
@@ -2,10 +2,13 @@ module RubySMB
   module SMB1
     # This module holds the namespace for all SMB1 packets and related structures.
     module Packet
-      autoload :SMBParameterBlock, 'ruby_smb/smb1/packet/smb_parameter_block'
-      autoload :SMBHeader, 'ruby_smb/smb1/packet/smb_header'
-      autoload :SMBDataBlock, 'ruby_smb/smb1/packet/smb_data_block'
-      autoload :AndXBlock, 'ruby_smb/smb1/packet/andx_block'
+      require 'ruby_smb/smb1/packet/smb_parameter_block.rb'
+      require 'ruby_smb/smb1/packet/smb_header.rb'
+      require 'ruby_smb/smb1/packet/smb_data_block.rb'
+      require 'ruby_smb/smb1/packet/andx_block.rb'
+
+      autoload :NegotiateCommand, 'ruby_smb/smb1/packet/negotiate_command'
+      autoload :ResponseHelper, 'ruby_smb/smb1/packet/response_helper'
     end
   end
 end

--- a/lib/ruby_smb/smb1/packet/negotiate_command.rb
+++ b/lib/ruby_smb/smb1/packet/negotiate_command.rb
@@ -1,0 +1,15 @@
+module RubySMB
+  module SMB1
+    module Packet
+
+      # Namespace for all packets and structures related to the the SMB1
+      # Negotiate command.
+      module NegotiateCommand
+        autoload :Request, 'ruby_smb/smb1/packet/negotiate_command/request'
+        autoload :Response, 'ruby_smb/smb1/packet/negotiate_command/response'
+        autoload :Dialect, 'ruby_smb/smb1/packet/negotiate_command/dialect'
+        autoload :NTLMParameterBlock, 'ruby_smb/smb1/packet/negotiate_command/nt_lm_parameter_block'
+      end
+    end
+  end
+end

--- a/lib/ruby_smb/smb1/packet/negotiate_command/dialect.rb
+++ b/lib/ruby_smb/smb1/packet/negotiate_command/dialect.rb
@@ -1,0 +1,21 @@
+module RubySMB
+  module SMB1
+    module Packet
+      module NegotiateCommand
+        # This class represents the Dialect for a NegotiateRequest.
+        class Dialect < BinData::Record
+          bit8    :buffer_format, :value => 0x2
+          stringz :dialect_string, :assert => lambda { valid_dialect?(dialect_string)}
+
+          def valid_dialect?(dialect)
+            return [
+              "NT LM 0.12",
+              "SMB 2.002",
+              "SMB 2.???"
+            ].include?(dialect)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby_smb/smb1/packet/negotiate_command/nt_lm_parameter_block.rb
+++ b/lib/ruby_smb/smb1/packet/negotiate_command/nt_lm_parameter_block.rb
@@ -1,0 +1,29 @@
+module RubySMB
+  module SMB1
+    module Packet
+      module NegotiateCommand
+
+        # Represents a SMB1 Negotiate nt lm response parameter block.
+        # [2.2.4.52.2 Response](https://msdn.microsoft.com/en-us/library/ee441946.aspx)
+        class NTLMParameterBlock < BinData::Record
+          bit8      :words_count
+          bit16     :dialect_index
+          bit8      :security_mode,     :onlyif => :nt_lm_negotiation?
+          bit16     :max_mpx_count,     :onlyif => :nt_lm_negotiation?
+          bit16     :max_number_vcs,    :onlyif => :nt_lm_negotiation?
+          bit32     :max_buffer_size,   :onlyif => :nt_lm_negotiation?
+          bit32     :max_raw_size,      :onlyif => :nt_lm_negotiation?
+          bit32     :session_key,       :onlyif => :nt_lm_negotiation?
+          bit32     :capabilities,      :onlyif => :nt_lm_negotiation?
+          bit64     :system_time,       :onlyif => :nt_lm_negotiation?
+          bit16     :server_time_zone,  :onlyif => :nt_lm_negotiation?
+          bit8      :challenge_length,  :onlyif => :nt_lm_negotiation?
+
+          def nt_lm_negotiation?
+            words_count > 1
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby_smb/smb1/packet/negotiate_command/request.rb
+++ b/lib/ruby_smb/smb1/packet/negotiate_command/request.rb
@@ -1,0 +1,30 @@
+module RubySMB
+  module SMB1
+    module Packet
+      module NegotiateCommand
+
+        # Represents a SMB1 Negotiate request packet.
+        # [2.2.4.52.1 Request](https://msdn.microsoft.com/en-us/library/ee441572.aspx)
+        class Request < BinData::Record
+          smb_header            :smb_header
+          smb_parameter_block   :smb_parameter_block
+          smb_data_block        :smb_data_block
+
+          def initialize_command
+            smb_header.command = RubySMB::SMB1::COMMANDS[:SMB_COM_NEGOTIATE]
+            self
+          end
+
+          def set_dialects(dialects=[])
+            raise ArgumentError, 'Must be an Array of Dialects' unless dialects.kind_of? Enumerable
+
+            dialects_block = BinData::Array.new(:type => :dialect)
+            dialects_block.assign(dialects)
+            smb_data_block.bytes = dialects_block.to_binary_s
+            self
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby_smb/smb1/packet/negotiate_command/request.rb
+++ b/lib/ruby_smb/smb1/packet/negotiate_command/request.rb
@@ -20,8 +20,13 @@ module RubySMB
 
             dialects_block = BinData::Array.new(:type => :dialect)
             dialects_block.assign(dialects)
-            smb_data_block.bytes = dialects_block.to_binary_s
-            self
+            smb_data_block.set_bytes(dialects_block.to_binary_s)
+          end
+
+          def read_dialects
+            dialect_count = smb_data_block.bytes.count(RubySMB::SMB1::NULL_TERMINATOR)
+            result = BinData::Array.new(:type => :dialect, :initial_length => dialect_count)
+            return result.read(self.smb_data_block.bytes)
           end
         end
       end

--- a/lib/ruby_smb/smb1/packet/negotiate_command/response.rb
+++ b/lib/ruby_smb/smb1/packet/negotiate_command/response.rb
@@ -1,0 +1,39 @@
+module RubySMB
+  module SMB1
+    module Packet
+      module NegotiateCommand
+
+        # Represents a SMB1 Negotiate response packet.
+        # [2.2.4.52.2 Response](https://msdn.microsoft.com/en-us/library/ee441946.aspx)
+        class Response < BinData::Record
+          attr_accessor :nt_lm_response_block
+
+          smb_header            :smb_header
+          smb_parameter_block   :smb_parameter_block
+          smb_data_block        :smb_data_block
+
+          def self.parse(input)
+            parsed_input = ResponseHelper.parse(input)
+
+            response = self.new(
+              :smb_header => parsed_input[:smb_header],
+              :smb_parameter_block => parsed_input[:smb_parameter_block],
+              :smb_data_block => parsed_input[:smb_data_block]
+            )
+
+            if response.smb_parameter_block.word_count > 0
+              response.nt_lm_response_block = NegotiateCommand::NTLMParameterBlock.read(response.smb_parameter_block.to_binary_s)
+            end
+
+            return response
+          end
+
+          # Negotiate response is invalid if word count and byte count are BOTH 0
+          def valid?
+            smb_parameter_block.word_count != 0 || smb_data_block.byte_count != 0
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby_smb/smb1/packet/response_helper.rb
+++ b/lib/ruby_smb/smb1/packet/response_helper.rb
@@ -1,0 +1,38 @@
+module RubySMB
+  module SMB1
+    module Packet
+
+      #Helper for parsing response packets
+      module ResponseHelper
+        def self.parse(string_input)
+          parameter_word_count = BinData::Bit8.
+            read(string_input[SMB1::Packet::SMBParameterBlock::SMB_PARAMETER_BLOCK_OFFSET]).
+            to_i * 2 + SMB1::Packet::SMBParameterBlock::SMB_PARAMETER_WORD_COUNT
+
+          data_byte_size = BinData::Bit16le.
+            read(string_input[SMB1::Packet::SMBParameterBlock::SMB_PARAMETER_BLOCK_OFFSET + parameter_word_count,
+                              SMB1::Packet::SMBDataBlock::SMB_DATA_BYTE_SIZE])
+
+          smb_header = SMB1::Packet::SMBHeader.
+            read(string_input[SMB1::Packet::SMBHeader::SMB_HEADER_BYTES])
+
+          smb_parameter_block = SMB1::Packet::SMBParameterBlock.
+            read(string_input[SMB1::Packet::SMBParameterBlock::SMB_PARAMETER_BLOCK_OFFSET,
+                              parameter_word_count])
+
+          smb_data_block = SMB1::Packet::SMBDataBlock.
+            read(string_input[SMB1::Packet::SMBParameterBlock::SMB_PARAMETER_BLOCK_OFFSET +
+                                parameter_word_count,
+                              data_byte_size +
+                                SMB1::Packet::SMBDataBlock::SMB_DATA_BYTE_SIZE])
+
+          return {
+            smb_header: smb_header,
+            smb_parameter_block: smb_parameter_block,
+            smb_data_block: smb_data_block
+          }
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby_smb/smb1/packet/smb_data_block.rb
+++ b/lib/ruby_smb/smb1/packet/smb_data_block.rb
@@ -3,15 +3,12 @@ module RubySMB
     module Packet
       # This class represents an SMB_Data block structure for SMB1 packets.
       # [Section 2.2.3.3 Data Block](https://msdn.microsoft.com/en-us/library/ee441687.aspx)
-      class SMBDataBlock < BitStruct
-        unsigned :byte_count, 16
-        rest :bytes
+      class SMBDataBlock < BinData::Record
+        endian  :little
+        uint16  :byte_count,  :value => lambda { bytes.length }
+        rest    :bytes,       :assert => lambda { bytes.value.class == String }
 
-        def bytes=(value)
-          raise ArgumentError, "value must be a binary string" unless value.kind_of? String
-          self[2,(2 + value.length)] = value.force_encoding('binary')
-          self.byte_count = self.bytes.size
-        end
+        SMB_DATA_BYTE_SIZE = 2
       end
     end
   end

--- a/lib/ruby_smb/smb1/packet/smb_data_block.rb
+++ b/lib/ruby_smb/smb1/packet/smb_data_block.rb
@@ -6,7 +6,12 @@ module RubySMB
       class SMBDataBlock < BinData::Record
         endian  :little
         uint16  :byte_count,  :value => lambda { bytes.length }
-        rest    :bytes,       :assert => lambda { bytes.value.class == String }
+        string  :bytes,       :read_length => :byte_count,  :assert => lambda { bytes.value.class == String }
+
+        def set_bytes(input)
+          raise "bytes needs to be a string" if input.class != String
+          self.bytes = input
+        end
 
         SMB_DATA_BYTE_SIZE = 2
       end

--- a/lib/ruby_smb/smb1/packet/smb_header.rb
+++ b/lib/ruby_smb/smb1/packet/smb_header.rb
@@ -4,20 +4,21 @@ module RubySMB
 
       # This class represents the Header of an SMB1 Packet.
       # [2.2.3.1 SMB Header Extensions](https://msdn.microsoft.com/en-us/library/cc246254.aspx)
-      class SMBHeader < BitStruct
-        unsigned :protocol,          32, 'Protocol Implementation', default: RubySMB::SMB1::SMB_PROTOCOL_ID
-        unsigned :command,            8, 'SMB Command Code'
-        unsigned :nt_status,         32, 'NTStatus Error Code'
-        unsigned :flags,              8, 'Flags'
-        unsigned :flags2,            16, 'Flags2'
-        unsigned :pid_high,          16, 'Process ID High Bytes'
-        unsigned :security_features, 64, 'Security Features'
-        unsigned :reserved,          16, 'Reserved Field'
-        unsigned :tid,               16, 'Tree ID'
-        unsigned :pid_low,           16, 'Process ID Low Bytes'
-        unsigned :uid,               16, 'User ID'
-        unsigned :mid,               16, 'Multiplex ID'
+      class SMBHeader < BinData::Record
+        bit32   :protocol, :value => RubySMB::SMB1::SMB_PROTOCOL_ID
+        bit8    :command
+        bit32   :nt_status
+        bit8    :flags
+        bit16   :flags2
+        bit16   :pid_high
+        bit64   :security_features
+        bit16   :reserved
+        bit16   :tid
+        bit16   :pid_low
+        bit16   :uid
+        bit16   :mid
 
+        SMB_HEADER_BYTES = 0..31
       end
     end
   end

--- a/lib/ruby_smb/smb1/packet/smb_parameter_block.rb
+++ b/lib/ruby_smb/smb1/packet/smb_parameter_block.rb
@@ -6,7 +6,7 @@ module RubySMB
       class SMBParameterBlock < BinData::Record
         endian  :little
         uint8   :word_count,  :value => lambda { (words.force_encoding('binary').length / 2.0).ceil }
-        rest    :words,       :assert => lambda { words.value.class == String }
+        string  :words,       :read_length => lambda { word_count * 2 }, :assert => lambda { words.value.class == String }
 
         SMB_PARAMETER_BLOCK_OFFSET = 32
         SMB_PARAMETER_WORD_COUNT = 1

--- a/lib/ruby_smb/smb1/packet/smb_parameter_block.rb
+++ b/lib/ruby_smb/smb1/packet/smb_parameter_block.rb
@@ -3,15 +3,13 @@ module RubySMB
     module Packet
       # This class represents an SMB_Parameters block structure for SMB1 packets.
       # [Section 2.2.3.2 Parameter Block](https://msdn.microsoft.com/en-us/library/ee442058.aspx)
-      class SMBParameterBlock < BitStruct
-        unsigned :word_count, 8, 'Size of data in Words'
-        rest :words, 'Parameter Data'
+      class SMBParameterBlock < BinData::Record
+        endian  :little
+        uint8   :word_count,  :value => lambda { (words.force_encoding('binary').length / 2.0).ceil }
+        rest    :words,       :assert => lambda { words.value.class == String }
 
-        def words=(value)
-          raise ArgumentError, "value must be a binary string" unless value.kind_of? String
-          self[1,(1 + value.length)] = value.force_encoding('binary')
-          self.word_count = (self.words.size/2)
-        end
+        SMB_PARAMETER_BLOCK_OFFSET = 32
+        SMB_PARAMETER_WORD_COUNT = 1
       end
     end
   end

--- a/lib/ruby_smb/version.rb
+++ b/lib/ruby_smb/version.rb
@@ -9,7 +9,7 @@ module RubySMB
     # The patch number, scoped to the {MINOR} version number.
     PATCH = 7
 
-    PRERELEASE = 'smb2-in-readme'
+    PRERELEASE = 'smb1-negotiate-request-bindata'
 
     # The full version string, including the {MAJOR}, {MINOR}, {PATCH}, and optionally, the `PRERELEASE` in the
     # {http://semver.org/spec/v2.0.0.html semantic versioning v2.0.0} format.

--- a/ruby_smb.gemspec
+++ b/ruby_smb.gemspec
@@ -36,5 +36,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "rubyntlm", "~> 0.5"
   spec.add_runtime_dependency "bit-struct"
   spec.add_runtime_dependency "windows_error"
+  spec.add_runtime_dependency "bindata"
 
 end

--- a/spec/lib/ruby_smb/smb1/packet/negotiate_command/dialect_spec.rb
+++ b/spec/lib/ruby_smb/smb1/packet/negotiate_command/dialect_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+RSpec.describe RubySMB::SMB1::Packet::NegotiateCommand::Dialect do
+
+  subject(:dialect) { described_class.new }
+
+  it { is_expected.to respond_to :buffer_format }
+  it { is_expected.to respond_to :dialect_string }
+
+  describe 'buffer_format' do
+    it 'should be an 8-bit field per the SMB spec' do
+      expect(dialect.buffer_format.num_bytes).to eq 1
+    end
+
+    it 'should default to 0x2' do
+      expect(dialect.buffer_format).to eq 0x2
+    end
+  end
+
+  describe 'dialect_string' do
+    it 'should add a null terminator to the end of the dialect string' do
+      dialect.dialect_string = 'NT LM 0.12'
+      expect(dialect.dialect_string.num_bytes).to eq 11
+    end
+
+    it 'raises a BinData::ValidityError if dialect_string is not a supported dialect' do
+      expect{ dialect.dialect_string = 'foo'}.
+        to raise_error BinData::ValidityError, "value 'foo' not as expected for obj.dialect_string"
+    end
+  end
+end

--- a/spec/lib/ruby_smb/smb1/packet/negotiate_command/nt_lm_parameter_block_spec.rb
+++ b/spec/lib/ruby_smb/smb1/packet/negotiate_command/nt_lm_parameter_block_spec.rb
@@ -1,0 +1,99 @@
+require 'spec_helper'
+
+RSpec.describe RubySMB::SMB1::Packet::NegotiateCommand::NTLMParameterBlock do
+
+  subject(:nt_lm_response_parameter_block) { described_class.new }
+
+  it { is_expected.to respond_to :words_count }
+  it { is_expected.to respond_to :dialect_index }
+  it { is_expected.to respond_to :security_mode }
+  it { is_expected.to respond_to :max_mpx_count }
+  it { is_expected.to respond_to :max_number_vcs }
+  it { is_expected.to respond_to :max_buffer_size }
+  it { is_expected.to respond_to :max_raw_size }
+  it { is_expected.to respond_to :session_key }
+  it { is_expected.to respond_to :capabilities }
+  it { is_expected.to respond_to :system_time }
+  it { is_expected.to respond_to :server_time_zone }
+  it { is_expected.to respond_to :challenge_length}
+
+  describe 'words_count' do
+    it 'should be an 8-bit field per the SMB spec' do
+      expect(nt_lm_response_parameter_block.words_count.num_bytes).to eq 1
+    end
+  end
+
+  describe 'dialect_index' do
+    it 'should be an 8-bit field per the SMB spec' do
+      expect(nt_lm_response_parameter_block.dialect_index.num_bytes).to eq 2
+    end
+  end
+
+  describe 'security_mode' do
+    it 'should be an 8-bit field per the SMB spec' do
+      expect(nt_lm_response_parameter_block.security_mode.num_bytes).to eq 1
+    end
+  end
+
+  describe 'max_mpx_count' do
+    it 'should be an 8-bit field per the SMB spec' do
+      expect(nt_lm_response_parameter_block.max_mpx_count.num_bytes).to eq 2
+    end
+  end
+
+  describe 'max_number_vcs' do
+    it 'should be an 8-bit field per the SMB spec' do
+      expect(nt_lm_response_parameter_block.max_number_vcs.num_bytes).to eq 2
+    end
+  end
+
+  describe 'max_buffer_size' do
+    it 'should be an 8-bit field per the SMB spec' do
+      expect(nt_lm_response_parameter_block.max_buffer_size.num_bytes).to eq 4
+    end
+  end
+
+  describe 'max_raw_size' do
+    it 'should be an 8-bit field per the SMB spec' do
+      expect(nt_lm_response_parameter_block.max_raw_size.num_bytes).to eq 4
+    end
+  end
+
+  describe 'session_key' do
+    it 'should be an 8-bit field per the SMB spec' do
+      expect(nt_lm_response_parameter_block.session_key.num_bytes).to eq 4
+    end
+  end
+
+  describe 'capabilities' do
+    it 'should be an 8-bit field per the SMB spec' do
+      expect(nt_lm_response_parameter_block.capabilities.num_bytes).to eq 4
+    end
+  end
+
+  describe 'system_time' do
+    it 'should be an 8-bit field per the SMB spec' do
+      expect(nt_lm_response_parameter_block.system_time.num_bytes).to eq 8
+    end
+  end
+
+  describe 'server_time_zone' do
+    it 'should be an 8-bit field per the SMB spec' do
+      expect(nt_lm_response_parameter_block.server_time_zone.num_bytes).to eq 2
+    end
+  end
+
+  describe 'challenge_length' do
+    it 'should be an 8-bit field per the SMB spec' do
+      expect(nt_lm_response_parameter_block.challenge_length.num_bytes).to eq 1
+    end
+  end
+
+  describe '#nt_lm_negotiation?' do
+    it "is true if word count is greater than 1" do
+      expect(nt_lm_response_parameter_block.nt_lm_negotiation?).to be false
+      nt_lm_response_parameter_block.words_count = 17
+      expect(nt_lm_response_parameter_block.nt_lm_negotiation?).to be true
+    end
+  end
+end

--- a/spec/lib/ruby_smb/smb1/packet/negotiate_command/request_spec.rb
+++ b/spec/lib/ruby_smb/smb1/packet/negotiate_command/request_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe RubySMB::SMB1::Packet::NegotiateCommand::Request do
+
+  subject(:negotiate_request) { described_class.new }
+
+  it_behaves_like 'smb1_packet'
+
+  before do
+    subject.initialize_command
+  end
+
+  it 'sets the Command field to SMB_COM_NEGOTIATE' do
+    expect(negotiate_request.smb_header.command).to eq RubySMB::SMB1::COMMANDS[:SMB_COM_NEGOTIATE]
+  end
+
+  describe '#set_dialects' do
+
+    it 'raises an ArgumentError if passed a non-Enumerable parameter' do
+      expect{ negotiate_request.set_dialects('foo') }.to raise_error ArgumentError, 'Must be an Array of Dialects'
+    end
+  end
+end

--- a/spec/lib/ruby_smb/smb1/packet/negotiate_command/response_spec.rb
+++ b/spec/lib/ruby_smb/smb1/packet/negotiate_command/response_spec.rb
@@ -1,0 +1,60 @@
+RSpec.describe RubySMB::SMB1::Packet::NegotiateCommand::Response do
+
+  subject(:negotiate_response) { described_class.new }
+
+  it_behaves_like 'smb1_packet'
+
+  describe '#parse' do
+    context 'core dialect' do
+      let(:input) do
+        "\xFF\x53\x4d\x42\x72\x00\x00\x00" \
+        "\x00\x18\x01H\x00\x00\x00\x00" \
+        "\x00\x00\x00\x00\x00\x00\x00\x00" \
+        "\xFF\xFF\x00\x00\x00\x00\x00\x00" \
+        "\x01\x00\x01\x00\x00"
+      end
+
+      it 'returns a response instance with prepopulated values' do
+        response = RubySMB::SMB1::Packet::NegotiateCommand::Response.parse(input)
+
+        expect(response.smb_header.protocol).to eq(RubySMB::SMB1::SMB_PROTOCOL_ID)
+        expect(response.smb_header.command).to eq(RubySMB::SMB1::COMMANDS[:SMB_COM_NEGOTIATE])
+        expect(response.smb_parameter_block.word_count).to eq(1)
+        expect(response.smb_parameter_block.words).to eq("\x00\x01")
+      end
+    end
+
+    context 'nt lm dialect' do
+      let(:input) do
+        "\xFF\x53\x4d\x42\x72\x00\x00\x00" \
+        "\x00\x18\x01H\x00\x00\x00\x00" \
+        "\x00\x00\x00\x00\x00\x00\x00\x00" \
+        "\xFF\xFF\x00\x00\x00\x00\x00\x00" \
+        "\x11\x00\x02\x01\x00\x06\x00\x07" \
+        "\x00\x00\x00\x00\x00\x00\x00\x00" \
+        "\x00\x00\x00\x00\x00\x00\x00\x00" \
+        "\x00\x00\x00\x00\x00\x00\x00\x00" \
+        "\x00\x00\x00\x00\x00\x00\x00"
+      end
+
+      it 'returns a response instance with prepopulated values' do
+        response = RubySMB::SMB1::Packet::NegotiateCommand::Response.parse(input)
+
+        expect(response.smb_header.protocol).to eq(RubySMB::SMB1::SMB_PROTOCOL_ID)
+        expect(response.smb_header.command).to eq(RubySMB::SMB1::COMMANDS[:SMB_COM_NEGOTIATE])
+        expect(response.smb_parameter_block.word_count).to eq(17)
+        expect(response.nt_lm_response_block.security_mode).to eq(1)
+        expect(response.nt_lm_response_block.max_mpx_count).to eq(6)
+        expect(response.nt_lm_response_block.max_number_vcs).to eq(7)
+      end
+    end
+  end
+
+  describe '#valid' do
+    it 'is is valid if word count or byte count is set' do
+      expect(negotiate_response.valid?).to be false
+      negotiate_response.smb_parameter_block.words = 'dialects?'
+      expect(negotiate_response.valid?).to be true
+    end
+  end
+end

--- a/spec/lib/ruby_smb/smb1/packet/smb_data_block_spec.rb
+++ b/spec/lib/ruby_smb/smb1/packet/smb_data_block_spec.rb
@@ -1,3 +1,5 @@
+require 'spec_helper'
+
 RSpec.describe RubySMB::SMB1::Packet::SMBDataBlock do
 
   subject(:data_block) { described_class.new }
@@ -7,8 +9,7 @@ RSpec.describe RubySMB::SMB1::Packet::SMBDataBlock do
 
   describe 'byte_count' do
     it 'should be a 16-bit field per the SMB spec' do
-      byte_count_size_field = data_block.fields.detect { |f| f.name == :byte_count}
-      expect(byte_count_size_field.length).to eq 16
+      expect(data_block.byte_count.num_bytes).to eq 2
     end
   end
 
@@ -17,7 +18,9 @@ RSpec.describe RubySMB::SMB1::Packet::SMBDataBlock do
       let(:bytes_value) { "\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF" }
 
       it 'sets the byte_count appropriately' do
-        expect{ data_block.bytes = bytes_value }.to change{data_block.byte_count}.to((bytes_value.size))
+        expect(data_block.byte_count).to eq 0
+        data_block.bytes = bytes_value
+        expect(data_block.byte_count).to eq 8
       end
     end
 
@@ -25,7 +28,8 @@ RSpec.describe RubySMB::SMB1::Packet::SMBDataBlock do
       let(:bytes_value) { 0xFFFFFFFF_FFFFFFFF }
 
       it 'raises an ArgumentError' do
-        expect{ data_block.bytes = bytes_value }.to raise_error ArgumentError, 'value must be a binary string'
+        expect{ data_block.bytes = bytes_value }.
+          to raise_error BinData::ValidityError, "value '#{bytes_value}' not as expected for obj.bytes"
       end
     end
   end

--- a/spec/lib/ruby_smb/smb1/packet/smb_header_spec.rb
+++ b/spec/lib/ruby_smb/smb1/packet/smb_header_spec.rb
@@ -1,3 +1,5 @@
+require 'spec_helper'
+
 RSpec.describe RubySMB::SMB1::Packet::SMBHeader do
 
   subject(:header) { described_class.new }
@@ -17,8 +19,7 @@ RSpec.describe RubySMB::SMB1::Packet::SMBHeader do
 
   describe 'protocol' do
     it 'should be a 32-bit field per the SMB spec' do
-      protocol_size_field = header.fields.detect { |f| f.name == :protocol }
-      expect(protocol_size_field.length).to eq 32
+      expect(header.protocol.num_bytes).to eq 4
     end
 
     it 'should be hardcoded to SMB_PROTOCOL_ID by default per the SMB spec' do
@@ -28,78 +29,67 @@ RSpec.describe RubySMB::SMB1::Packet::SMBHeader do
 
   describe 'command' do
     it 'should be a 8-bit field per the SMB spec' do
-      command_size_field = header.fields.detect { |f| f.name == :command }
-      expect(command_size_field.length).to eq 8
+      expect(header.command.num_bytes).to eq 1
     end
   end
 
   describe 'nt_status' do
     it 'should be a 32-bit field per the SMB spec' do
-      nt_status_size_field = header.fields.detect { |f| f.name == :nt_status }
-      expect(nt_status_size_field.length).to eq 32
+      expect(header.nt_status.num_bytes).to eq 4
     end
   end
 
   describe 'flags' do
     it 'should be a 8-bit field per the SMB spec' do
-      flags_size_field = header.fields.detect { |f| f.name == :flags }
-      expect(flags_size_field.length).to eq 8
+      expect(header.flags.num_bytes).to eq 1
     end
   end
 
   describe 'flags2' do
     it 'should be a 16-bit field per the SMB spec' do
-      flags2_size_field = header.fields.detect { |f| f.name == :flags2 }
-      expect(flags2_size_field.length).to eq 16
+      expect(header.flags2.num_bytes).to eq 2
     end
   end
 
   describe 'pid_high' do
     it 'should be a 16-bit field per the SMB spec' do
-      pid_high_size_field = header.fields.detect { |f| f.name == :pid_high }
-      expect(pid_high_size_field.length).to eq 16
+      expect(header.pid_high.num_bytes).to eq 2
     end
   end
 
   describe 'security_features' do
     it 'should be a 64-bit field per the SMB spec' do
-      security_features_size_field = header.fields.detect { |f| f.name == :security_features }
-      expect(security_features_size_field.length).to eq 64
+      expect(header.security_features.num_bytes).to eq 8
     end
   end
 
   describe 'reserved' do
     it 'should be a 16-bit field per the SMB spec' do
-      reserved_size_field = header.fields.detect { |f| f.name == :reserved }
-      expect(reserved_size_field.length).to eq 16
+      expect(header.reserved.num_bytes).to eq 2
     end
   end
 
   describe 'tid' do
     it 'should be a 16-bit field per the SMB spec' do
-      tid_size_field = header.fields.detect { |f| f.name == :tid }
-      expect(tid_size_field.length).to eq 16
+      expect(header.tid.num_bytes).to eq 2
     end
   end
 
   describe 'pid_low' do
     it 'should be a 16-bit field per the SMB spec' do
-      pid_low_size_field = header.fields.detect { |f| f.name == :pid_low }
-      expect(pid_low_size_field.length).to eq 16
+      expect(header.pid_low.num_bytes).to eq 2
     end
   end
 
   describe 'uid' do
     it 'should be a 16-bit field per the SMB spec' do
-      uid_size_field = header.fields.detect { |f| f.name == :uid }
-      expect(uid_size_field.length).to eq 16
+      expect(header.uid.num_bytes).to eq 2
     end
   end
 
   describe 'mid' do
     it 'should be a 16-bit field per the SMB spec' do
-      mid_size_field = header.fields.detect { |f| f.name == :mid }
-      expect(mid_size_field.length).to eq 16
+      expect(header.mid.num_bytes).to eq 2
     end
   end
 end

--- a/spec/lib/ruby_smb/smb1/packet/smb_parameter_block_spec.rb
+++ b/spec/lib/ruby_smb/smb1/packet/smb_parameter_block_spec.rb
@@ -1,3 +1,5 @@
+require 'spec_helper'
+
 RSpec.describe RubySMB::SMB1::Packet::SMBParameterBlock do
 
   subject(:param_block) { described_class.new }
@@ -7,8 +9,7 @@ RSpec.describe RubySMB::SMB1::Packet::SMBParameterBlock do
 
   describe 'word_count' do
     it 'should be a 8-bit field per the SMB spec' do
-      word_count_size_field = param_block.fields.detect { |f| f.name == :word_count}
-      expect(word_count_size_field.length).to eq 8
+      expect(param_block.word_count.num_bytes).to eq 1
     end
   end
 
@@ -17,7 +18,9 @@ RSpec.describe RubySMB::SMB1::Packet::SMBParameterBlock do
       let(:words_value) { "\xFF\xFF\xFF\xFF" }
 
       it 'sets the word_count appropriately' do
-        expect{ param_block.words = words_value }.to change{param_block.word_count}.to((words_value.size/2))
+        expect(param_block.word_count).to eq 0
+        param_block.words = words_value
+        expect(param_block.word_count).to eq 2
       end
     end
 
@@ -25,7 +28,7 @@ RSpec.describe RubySMB::SMB1::Packet::SMBParameterBlock do
       let(:words_value) { 0xFFFFFFFF }
 
       it 'raises an ArgumentError' do
-        expect{ param_block.words = words_value }.to raise_error ArgumentError, 'value must be a binary string'
+        expect{ param_block.words = words_value }.to raise_error BinData::ValidityError, "value '#{words_value}' not as expected for obj.words"
       end
     end
   end

--- a/spec/support/shared/examples/smb1_packet.rb
+++ b/spec/support/shared/examples/smb1_packet.rb
@@ -1,0 +1,7 @@
+RSpec.shared_examples 'smb1_packet' do
+
+  it { is_expected.to respond_to :smb_header }
+  it { is_expected.to respond_to :smb_parameter_block }
+  it { is_expected.to respond_to :smb_data_block }
+
+end


### PR DESCRIPTION
MSP-12911

1. Made the switch to bindata
2. Negotiate command request done
3. Negotiate command response done

GENERAL VERIFICATION STEPS 
- [ ] `rake spec`
- [ ] VERIFY all specs pass (version may fail because of this being a branch off of staging)

NEGOTIATE COMMAND REQUEST STEPS (in bundle console)
- [ ] `request = RubySMB::SMB1::Packet::NegotiateCommand::Request.new` 
    - creates an instance of a negotiate request with :protocol being "\xFFSMB"
- [ ] `request.initialize_command` 
    - sets :command to 0x72
- [ ] `dialect = RubySMB::SMB1::Packet::NegotiateCommand::Dialect.new(:dialect_string => "NT LM 0.12")` 
    - creates an instance of a dialect with :dialect_string being "NT LM 0.12"
    - :buffer_format should be 0x2
- [ ] `request.set_dialects([dialect])`
    - the request's data block should include the binary string of dialect
- [ ] `request.to_binary_s` 
    - should return the binary string of the created negotiate request


NEGOTIATE COMMAND RESPONSE STEPS (in bundle console)
- [ ] `core_response_bin_s = "\xFF\x53\x4d\x42\x72\x00\x00\x00\x00\x18\x01H\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xFF\xFF\x00\x00\x00\x00\x00\x00\x01\x00\x01\x00\x00"`
- [ ] `response = RubySMB::SMB1::Packet::NegotiateCommand::Response.parse(core_response_bin_s)`
    - should return an instance of a NegotiateCommand::Response with parameter block having a :word_count of 1 and :words being 1 
- [ ] `response.nt_lm_response_block` 
    - should return an instance of a NTLMParameterBlock with only :word_count and :words attributes
- [ ] `nt_lm_response_bin_s = "\xFF\x53\x4d\x42\x72\x00\x00\x00\x00\x18\x01H\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xFF\xFF\x00\x00\x00\x00\x00\x00\x11\x00\x02\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"`
- [ ] `response = RubySMB::SMB1::Packet::NegotiateCommand::Response.parse(nt_lm_response_bin_s)`
    - should return an instance of a NegotiateCommand::Response with parameter block having a :word_count of 17 (for nt lm dialects)
- [ ] `response.nt_lm_response_block`
    - should return an instance of a NTLMParameterBlock this time with additional attributes specifically for when dialect is NT LM

