### PR TITLE
Add `require 'date'` where we use Time#to_datetime

### DIFF
--- a/lib/ruby_smb/field/file_time.rb
+++ b/lib/ruby_smb/field/file_time.rb
@@ -1,3 +1,5 @@
+require 'date'
+
 module RubySMB
   module Field
     # Represents a Windows FILETIME structure as defined in

--- a/lib/ruby_smb/field/utime.rb
+++ b/lib/ruby_smb/field/utime.rb
@@ -1,3 +1,5 @@
+require 'date'
+
 module RubySMB
   module Field
     # Conveneince class for dealing with 32-bit unsigned UTIME

--- a/spec/lib/ruby_smb/field/file_time_spec.rb
+++ b/spec/lib/ruby_smb/field/file_time_spec.rb
@@ -1,3 +1,5 @@
+require 'date'
+
 RSpec.describe RubySMB::Field::FileTime do
   subject(:file_time) { described_class.read(binary_filetime) }
 

--- a/spec/lib/ruby_smb/field/utime_spec.rb
+++ b/spec/lib/ruby_smb/field/utime_spec.rb
@@ -1,3 +1,5 @@
+require 'date'
+
 RSpec.describe RubySMB::Field::Utime do
   subject(:time) { described_class.read(binary_filetime) }
 


### PR DESCRIPTION
Without this, load order in some situations can lead to messages like:
```
undefined method `to_datetime' for 2017-08-27 05:53:45 -0500:Time
```