### PR TITLE
Add SMB_COM_WRITE_ANDX Request and Response

### DIFF
--- a/lib/ruby_smb/smb1/commands.rb
+++ b/lib/ruby_smb/smb1/commands.rb
@@ -3,6 +3,7 @@ module RubySMB
     module Commands
       SMB_COM_ECHO                    = 0x2B
       SMB_COM_READ_ANDX               = 0x2E
+      SMB_COM_WRITE_ANDX              = 0x2F
       SMB_COM_TRANSACTION2            = 0x32
       SMB_COM_TRANSACTION2_SECONDARY  = 0x33
       SMB_COM_TREE_DISCONNECT         = 0x71

--- a/lib/ruby_smb/smb1/packet.rb
+++ b/lib/ruby_smb/smb1/packet.rb
@@ -25,6 +25,8 @@ module RubySMB
       require 'ruby_smb/smb1/packet/nt_create_andx_response'
       require 'ruby_smb/smb1/packet/read_andx_request'
       require 'ruby_smb/smb1/packet/read_andx_response'
+      require 'ruby_smb/smb1/packet/write_andx_request'
+      require 'ruby_smb/smb1/packet/write_andx_response'
     end
   end
 end

--- a/lib/ruby_smb/smb1/packet/write_andx_request.rb
+++ b/lib/ruby_smb/smb1/packet/write_andx_request.rb
@@ -1,0 +1,72 @@
+module RubySMB
+  module SMB1
+    module Packet
+
+      # A SMB1 SMB_COM_WRITE_ANDX Request Packet as defined in
+      # [2.2.4.43.1 Request](https://msdn.microsoft.com/en-us/library/ee441954.aspx)
+      # [2.2.4.3.1 Client Request Extensions](https://msdn.microsoft.com/en-us/library/ff469893.aspx)
+      class WriteAndxRequest < RubySMB::GenericPacket
+
+        # A SMB1 Parameter Block as defined by the {WriteAndxRequest}
+        class ParameterBlock < RubySMB::SMB1::ParameterBlock
+          endian      :little
+
+          and_x_block :andx_block
+          uint16      :fid,                  label: 'FID'
+          uint32      :offset,               label: 'Offset'
+          uint32      :timeout,              label: 'Timeout'
+
+          struct      :write_mode,           label: 'Write Mode' do
+            bit4      :reserved,             label: 'Reserved Space'
+            bit1      :msg_start,            label: 'Message Start'
+            bit1      :raw_mode,             label: 'Raw Mode'
+            bit1      :read_bytes_available, label: 'Read Bytes Available'
+            bit1      :writethrough_mode,    label: 'Writethrough Mode'
+            # byte boundary
+            bit8      :reserved2,            label: 'Reserved Space'
+          end
+
+          uint16      :remaining,            label: 'Remaining'
+          uint16      :data_length_high,     label: 'Data Length High'
+          uint16      :data_length,          label: 'Data Length(bytes)', value: lambda { self.parent.data_block.data.length }
+          uint16      :data_offset,          label: 'Data Offset',        value: lambda { self.parent.data_block.data.abs_offset }
+          uint32      :offset_high,          label: 'Offset High',        onlyif: -> { word_count == 0x0E }
+
+          # Bypass the word count calculation to use 32-bit offset by default.
+          # As a result, the optional offset_high field won't be defined until
+          # #set_64_bit_offset(true) is explicitly called.
+          def calculate_word_count
+            0x0C
+          end
+          private :calculate_word_count
+
+        end
+
+        # Represents the specific layout of the DataBlock for a {WriteAndxRequest} Packet.
+        class DataBlock < RubySMB::SMB1::DataBlock
+          uint8  :pad,  label: 'Pad'
+          string :data, label: 'Data'
+        end
+
+        smb_header        :smb_header
+        parameter_block   :parameter_block
+        data_block        :data_block
+
+        def initialize_instance
+          super
+          smb_header.command = RubySMB::SMB1::Commands::SMB_COM_WRITE_ANDX
+        end
+
+        # Specifies whether the offset is a 32-bit (default) or 64-bit value. When `is_64_bit`
+        # is true, a 64-bit offset will be used and the OffsetHigh field will be added to the structure.
+        #
+        # @param is_64_bit [TrueClass, FalseClass] use a 64-bit offset if set to true, 32-bit otherwise
+        def set_64_bit_offset(is_64_bit)
+          raise ArgumentError.new, "The value can only be true or false" unless [true, false].include?(is_64_bit)
+          parameter_block.word_count = is_64_bit ? 0x0E : 0x0C
+        end
+
+      end
+    end
+  end
+end

--- a/lib/ruby_smb/smb1/packet/write_andx_response.rb
+++ b/lib/ruby_smb/smb1/packet/write_andx_response.rb
@@ -1,0 +1,38 @@
+module RubySMB
+  module SMB1
+    module Packet
+
+      # A SMB1 SMB_COM_WRITE_ANDX Response Packet as defined in
+      # [2.2.4.43.2 Response](https://msdn.microsoft.com/en-us/library/ee441673.aspx)
+      # [2.2.4.3.2 Server Response Extensions](https://msdn.microsoft.com/en-us/library/ff469858.aspx)
+      class WriteAndxResponse < RubySMB::GenericPacket
+
+        # A SMB1 Parameter Block as defined by the {WriteAndxResponse}
+        class ParameterBlock < RubySMB::SMB1::ParameterBlock
+          endian      :little
+
+          and_x_block :andx_block
+          uint16      :count_low,  label: 'Count Low'
+          uint16      :available,  label: 'Available'
+          uint16      :count_high, label: 'Count High'
+          uint16      :reserved,   label: 'Reserved'
+        end
+
+        # Represents the specific layout of the DataBlock for a {WriteAndxResponse} Packet.
+        class DataBlock < RubySMB::SMB1::DataBlock
+        end
+
+        smb_header        :smb_header
+        parameter_block   :parameter_block
+        data_block        :data_block
+
+        def initialize_instance
+          super
+          smb_header.command = RubySMB::SMB1::Commands::SMB_COM_WRITE_ANDX
+          smb_header.flags.reply = 1
+        end
+
+      end
+    end
+  end
+end

--- a/spec/lib/ruby_smb/smb1/packet/write_andx_request_spec.rb
+++ b/spec/lib/ruby_smb/smb1/packet/write_andx_request_spec.rb
@@ -1,0 +1,153 @@
+RSpec.describe RubySMB::SMB1::Packet::WriteAndxRequest  do
+  subject(:packet) { described_class.new }
+
+  describe '#smb_header' do
+    subject(:header) { packet.smb_header }
+
+    it 'is a standard SMB Header' do
+      expect(header).to be_a RubySMB::SMB1::SMBHeader
+    end
+
+    it 'should have the command set to SMB_COM_WRITE_ANDX' do
+      expect(header.command).to eq RubySMB::SMB1::Commands::SMB_COM_WRITE_ANDX
+    end
+
+    it 'should not have the response flag set' do
+      expect(header.flags.reply).to eq 0
+    end
+  end
+
+  describe '#parameter_block' do
+    subject(:parameter_block) { packet.parameter_block }
+
+    it 'is a standard ParameterBlock' do
+      expect(parameter_block).to be_a RubySMB::SMB1::ParameterBlock
+    end
+
+    it 'is little endian' do
+      expect(parameter_block.get_parameter(:endian).endian).to eq :little
+    end
+
+    describe '#word_count' do
+      it 'is set to the correct default value' do
+        expect(parameter_block.word_count).to eq(0x0C)
+      end
+    end
+
+    it { is_expected.to respond_to :andx_block }
+    it { is_expected.to respond_to :fid }
+    it { is_expected.to respond_to :offset }
+    it { is_expected.to respond_to :timeout }
+    it { is_expected.to respond_to :write_mode }
+    it { is_expected.to respond_to :remaining }
+    it { is_expected.to respond_to :data_length_high }
+    it { is_expected.to respond_to :data_length }
+    it { is_expected.to respond_to :data_offset }
+    it { is_expected.to respond_to :offset_high }
+
+    describe '#andx_block' do
+      it 'is a AndXBlock struct' do
+        expect(parameter_block.andx_block).to be_a RubySMB::SMB1::AndXBlock
+      end
+    end
+
+    describe '#write_mode' do
+      subject(:write_mode) { parameter_block.write_mode }
+
+      it { is_expected.to respond_to :msg_start }
+      it { is_expected.to respond_to :raw_mode }
+      it { is_expected.to respond_to :read_bytes_available }
+      it { is_expected.to respond_to :writethrough_mode }
+
+      it 'is little endian' do
+        expect(write_mode.get_parameter(:endian).endian).to eq :little
+      end
+
+      describe '#msg_start' do
+        it 'is a 1-bit flag' do
+          expect(write_mode.msg_start).to be_a BinData::Bit1
+        end
+
+        it_behaves_like 'bit field with one flag set', :msg_start, 'v', 0x0008
+      end
+
+      describe '#raw_mode' do
+        it 'is a 1-bit flag' do
+          expect(write_mode.raw_mode).to be_a BinData::Bit1
+        end
+
+        it_behaves_like 'bit field with one flag set', :raw_mode, 'v', 0x0004
+      end
+
+      describe '#read_bytes_available' do
+        it 'is a 1-bit flag' do
+          expect(write_mode.read_bytes_available).to be_a BinData::Bit1
+        end
+
+        it_behaves_like 'bit field with one flag set', :read_bytes_available, 'v', 0x0002
+      end
+
+      describe '#writethrough_mode' do
+        it 'is a 1-bit flag' do
+          expect(write_mode.writethrough_mode).to be_a BinData::Bit1
+        end
+
+        it_behaves_like 'bit field with one flag set', :writethrough_mode, 'v', 0x0001
+      end
+
+    end
+
+    describe '#offset_high' do
+      it 'exists when word_count is 0x0E' do
+        parameter_block.word_count = 0x0E
+        expect(parameter_block.offset_high?).to be true
+      end
+
+      it 'does not exist when word_count is 0x0C' do
+        parameter_block.word_count = 0x0C
+        expect(parameter_block.offset_high?).to be false
+      end
+    end
+
+  end
+
+  describe '#data_block' do
+    subject(:data_block) { packet.data_block }
+
+    it 'is a standard DataBlock' do
+      expect(data_block).to be_a RubySMB::SMB1::DataBlock
+    end
+
+    it { is_expected.to respond_to :pad }
+    it { is_expected.to respond_to :data }
+
+  end
+
+  describe '#set_64_bit_offset' do
+    it 'sets the #word_count field to 0x0E when passing true' do
+      packet.parameter_block.word_count = 0
+      packet.set_64_bit_offset(true)
+      expect(packet.parameter_block.word_count).to eq(0x0E)
+    end
+
+    it 'sets the #word_count field to 0x0C when passing false' do
+      packet.parameter_block.word_count = 0
+      packet.set_64_bit_offset(false)
+      expect(packet.parameter_block.word_count).to eq(0x0C)
+    end
+
+    it 'raises an exception when the value is a String' do
+      expect { packet.set_64_bit_offset("true") }.to raise_error(ArgumentError)
+    end
+
+    it 'raises an exception when the value is a Numeric' do
+      expect { packet.set_64_bit_offset(1) }.to raise_error(ArgumentError)
+    end
+
+    it 'raises an exception when the value is a Symbol' do
+      expect { packet.set_64_bit_offset(:true) }.to raise_error(ArgumentError)
+    end
+  end
+
+end
+

--- a/spec/lib/ruby_smb/smb1/packet/write_andx_response_spec.rb
+++ b/spec/lib/ruby_smb/smb1/packet/write_andx_response_spec.rb
@@ -1,0 +1,57 @@
+RSpec.describe RubySMB::SMB1::Packet::WriteAndxResponse  do
+  subject(:packet) { described_class.new }
+
+  describe '#smb_header' do
+    subject(:header) { packet.smb_header }
+
+    it 'is a standard SMB Header' do
+      expect(header).to be_a RubySMB::SMB1::SMBHeader
+    end
+
+    it 'should have the command set to SMB_COM_WRITE_ANDX' do
+      expect(header.command).to eq RubySMB::SMB1::Commands::SMB_COM_WRITE_ANDX
+    end
+
+    it 'should have the response flag set' do
+      expect(header.flags.reply).to eq 1
+    end
+  end
+
+  describe '#parameter_block' do
+    subject(:parameter_block) { packet.parameter_block }
+
+    it 'is a standard ParameterBlock' do
+      expect(parameter_block).to be_a RubySMB::SMB1::ParameterBlock
+    end
+
+    it 'is little endian' do
+      expect(parameter_block.get_parameter(:endian).endian).to eq :little
+    end
+
+    it { is_expected.to respond_to :andx_block }
+    it { is_expected.to respond_to :count_low }
+    it { is_expected.to respond_to :available }
+    it { is_expected.to respond_to :count_high }
+
+    describe '#andx_block' do
+      it 'is a AndXBlock struct' do
+        expect(parameter_block.andx_block).to be_a RubySMB::SMB1::AndXBlock
+      end
+    end
+
+  end
+
+  describe '#data_block' do
+    subject(:data_block) { packet.data_block }
+
+    it 'is a standard DataBlock' do
+      expect(data_block).to be_a RubySMB::SMB1::DataBlock
+    end
+
+    it 'should be empty' do
+      expect(data_block.byte_count).to eq(0)
+    end
+
+  end
+
+end


### PR DESCRIPTION
Adding the WRITE_ANDX request and response messages and specs

Documentation:
- [2.2.4.43.1 Request](https://msdn.microsoft.com/en-us/library/ee441954.aspx)
- [2.2.4.3.1 Client Request Extensions](https://msdn.microsoft.com/en-us/library/ff469893.aspx)
- [2.2.4.43.2 Response](https://msdn.microsoft.com/en-us/library/ee441673.aspx)
- [2.2.4.3.2 Server Response Extensions](https://msdn.microsoft.com/en-us/library/ff469858.aspx)
 
# Verification Steps
- [x] `bundle install`
## `rake spec`
- [x] `rake spec`
- [x] VERIFY no failures
