### PR TITLE
Small Fix for READ_ANDX Response

### DIFF
--- a/lib/ruby_smb/smb1/packet/read_andx_response.rb
+++ b/lib/ruby_smb/smb1/packet/read_andx_response.rb
@@ -39,6 +39,7 @@ module RubySMB
         def initialize_instance
           super
           smb_header.command = RubySMB::SMB1::Commands::SMB_COM_READ_ANDX
+          smb_header.flags.reply = 1
         end
       end
     end

--- a/spec/lib/ruby_smb/smb1/packet/read_andx_response_spec.rb
+++ b/spec/lib/ruby_smb/smb1/packet/read_andx_response_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe RubySMB::SMB1::Packet::ReadAndxResponse do
       expect(header.command).to eq RubySMB::SMB1::Commands::SMB_COM_READ_ANDX
     end
 
-    it 'should not have the response flag set' do
-      expect(header.flags.reply).to eq 0
+    it 'should have the response flag set' do
+      expect(header.flags.reply).to eq 1
     end
   end
 


### PR DESCRIPTION
I forgot to set the `smb_header.flags.reply` to 1 for READ_ANDX response packet, bad copy/paste. It is fixed now.

# Verification Steps
- [x] `bundle install`
## `rake spec`
- [x] `rake spec`
- [x] VERIFY no failures
