### PR TITLE
Add SET_INFO packets for file deletion

### DIFF
--- a/examples/delete_file.rb
+++ b/examples/delete_file.rb
@@ -1,0 +1,40 @@
+#!/usr/bin/ruby
+
+# This example script is used for testing the reading of a file.
+# It will attempt to connect to a specific share and then read a specified file.
+# Example usage: ruby read_file.rb 192.168.172.138 msfadmin msfadmin TEST_SHARE short.txt
+# This will try to connect to \\192.168.172.138\TEST_SHARE with the msfadmin:msfadmin credentials
+# and read the file short.txt
+
+require 'bundler/setup'
+require 'ruby_smb'
+
+address  = ARGV[0]
+username = ARGV[1]
+password = ARGV[2]
+share    = ARGV[3]
+file     = ARGV[4]
+path     = "\\\\#{address}\\#{share}"
+
+sock = TCPSocket.new address, 445
+dispatcher = RubySMB::Dispatcher::Socket.new(sock)
+
+client = RubySMB::Client.new(dispatcher, smb1: false, smb2: true, username: username, password: password)
+
+protocol = client.negotiate
+status = client.authenticate
+
+puts "#{protocol} : #{status}"
+
+begin
+  tree = client.tree_connect(path)
+  puts "Connected to #{path} successfully!"
+rescue StandardError => e
+  puts "Failed to connect to #{path}: #{e.message}"
+end
+
+file = tree.open_file(filename: file, delete: true)
+
+data = file.delete
+puts data
+file.close

--- a/examples/delete_file.rb
+++ b/examples/delete_file.rb
@@ -1,10 +1,10 @@
 #!/usr/bin/ruby
 
-# This example script is used for testing the reading of a file.
-# It will attempt to connect to a specific share and then read a specified file.
-# Example usage: ruby read_file.rb 192.168.172.138 msfadmin msfadmin TEST_SHARE short.txt
+# This example script is used for testing the deleting of a file.
+# It will attempt to connect to a specific share and then delete a specified file.
+# Example usage: ruby delete_file.rb 192.168.172.138 msfadmin msfadmin TEST_SHARE short.txt
 # This will try to connect to \\192.168.172.138\TEST_SHARE with the msfadmin:msfadmin credentials
-# and read the file short.txt
+# and delete the file short.txt
 
 require 'bundler/setup'
 require 'ruby_smb'

--- a/lib/ruby_smb/fscc/file_information.rb
+++ b/lib/ruby_smb/fscc/file_information.rb
@@ -5,6 +5,7 @@ module RubySMB
     module FileInformation
       require 'ruby_smb/fscc/file_information/file_directory_information'
       require 'ruby_smb/fscc/file_information/file_full_directory_information'
+      require 'ruby_smb/fscc/file_information/file_disposition_information'
       require 'ruby_smb/fscc/file_information/file_id_full_directory_information'
       require 'ruby_smb/fscc/file_information/file_both_directory_information'
       require 'ruby_smb/fscc/file_information/file_id_both_directory_information'

--- a/lib/ruby_smb/fscc/file_information/file_disposition_information.rb
+++ b/lib/ruby_smb/fscc/file_information/file_disposition_information.rb
@@ -12,13 +12,12 @@ module RubySMB
         SMB2_FLAG = 0x0D
 
         endian :little
-        
-        uint8  :info_type,          label: "Info Type",       initial_value: 0x01
+
+        uint8  :info_type,          label: 'Info Type',       initial_value: 0x01
         uint8  :file_info_class,    label: 'File Info Class', initial_value: 0x0D
         uint32 :buffer_length,      label: 'Buffer Length',   initial_value: 1
         uint16 :buffer_offset,      label: 'Buffer Offset',   initial_value: 96
         string :buffer,             label: 'Buffer',          initial_value: 1
-        
       end
     end
   end

--- a/lib/ruby_smb/fscc/file_information/file_disposition_information.rb
+++ b/lib/ruby_smb/fscc/file_information/file_disposition_information.rb
@@ -1,0 +1,25 @@
+module RubySMB
+  module Fscc
+    module FileInformation
+      # The FileDispositionInformation Class as defined in
+      # [2.4.11 FileDispositionInformation](https://msdn.microsoft.com/en-us/library/cc232098.aspx)
+      class FileDispositionInformation < BinData::Record
+        # Null bytes because SMB1 Requests can't use this
+        # Information Class.
+        SMB1_FLAG = 0x0000
+        # The value set in the InformationLevel field of an SMB2 request to indicate
+        # the response should use this Information Class Structure.
+        SMB2_FLAG = 0x0D
+
+        endian :little
+        
+        uint8  :info_type,          label: "Info Type",       initial_value: 0x01
+        uint8  :file_info_class,    label: 'File Info Class', initial_value: 0x0D
+        uint32 :buffer_length,      label: 'Buffer Length',   initial_value: 1
+        uint16 :buffer_offset,      label: 'Buffer Offset',   initial_value: 96
+        string :buffer,             label: 'Buffer',          initial_value: 1
+        
+      end
+    end
+  end
+end

--- a/lib/ruby_smb/smb2/file.rb
+++ b/lib/ruby_smb/smb2/file.rb
@@ -3,6 +3,7 @@ module RubySMB
     # Represents a file on the Remote server that we can perform
     # various I/O operations on.
     class File
+
       # The maximum number of byte we want to read or write
       # in a single packet.
       MAX_PACKET_SIZE = 32_768
@@ -143,8 +144,14 @@ module RubySMB
       
       # Crafts the SetInfoRequest packet to be sent for read operations.
       def delete_packet
-        delete_request                 = set_header_fields(RubySMB::SMB2::Packet::SetInfoRequest.new)
-        delete_request.file_info_class = 13
+        delete_request                      = set_header_fields(RubySMB::SMB2::Packet::SetInfoRequest.new)
+        file_disposition_information        = RubySMB::Fscc::FileInformation::FileDispositionInformation.new
+        
+        delete_request.info_type            = file_disposition_information.info_type
+        delete_request.file_info_class      = file_disposition_information.file_info_class
+        delete_request.buffer_length        = file_disposition_information.buffer_length
+        delete_request.buffer_offset        = file_disposition_information.buffer_offset
+        delete_request.buffer               = file_disposition_information.buffer
         delete_request
       end
 

--- a/lib/ruby_smb/smb2/file.rb
+++ b/lib/ruby_smb/smb2/file.rb
@@ -3,7 +3,6 @@ module RubySMB
     # Represents a file on the Remote server that we can perform
     # various I/O operations on.
     class File
-
       # The maximum number of byte we want to read or write
       # in a single packet.
       MAX_PACKET_SIZE = 32_768
@@ -134,23 +133,22 @@ module RubySMB
         read_request.offset       = offset
         read_request
       end
-      
+
       # Delete a file on close
       #
       # @return [String] the delete response to string
       def delete
-        delete_request = delete_packet
-        raw_response   = tree.client.send_recv(delete_request)
-        response       = RubySMB::SMB2::Packet::SetInfoResponse.read(raw_response)
+        raw_response = tree.client.send_recv(delete_packet)
+        RubySMB::SMB2::Packet::SetInfoResponse.read(raw_response)
       end
-      
+
       # Crafts the SetInfoRequest packet to be sent for delete operations.
       #
       # @return [RubySMB::SMB2::Packet::SetInfoRequest] the set info packet
       def delete_packet
         delete_request                      = set_header_fields(RubySMB::SMB2::Packet::SetInfoRequest.new)
         file_disposition_information        = RubySMB::Fscc::FileInformation::FileDispositionInformation.new
-        
+
         delete_request.info_type            = file_disposition_information.info_type
         delete_request.file_info_class      = file_disposition_information.file_info_class
         delete_request.buffer_length        = file_disposition_information.buffer_length

--- a/lib/ruby_smb/smb2/file.rb
+++ b/lib/ruby_smb/smb2/file.rb
@@ -135,14 +135,18 @@ module RubySMB
         read_request
       end
       
-      # Delete a file
+      # Delete a file on close
+      #
+      # @return [String] the delete response to string
       def delete
         delete_request = delete_packet
         raw_response   = tree.client.send_recv(delete_request)
         response       = RubySMB::SMB2::Packet::SetInfoResponse.read(raw_response)
       end
       
-      # Crafts the SetInfoRequest packet to be sent for read operations.
+      # Crafts the SetInfoRequest packet to be sent for delete operations.
+      #
+      # @return [RubySMB::SMB2::Packet::SetInfoRequest] the set info packet
       def delete_packet
         delete_request                      = set_header_fields(RubySMB::SMB2::Packet::SetInfoRequest.new)
         file_disposition_information        = RubySMB::Fscc::FileInformation::FileDispositionInformation.new

--- a/lib/ruby_smb/smb2/file.rb
+++ b/lib/ruby_smb/smb2/file.rb
@@ -133,6 +133,20 @@ module RubySMB
         read_request.offset       = offset
         read_request
       end
+      
+      # Delete a file
+      def delete
+        delete_request = delete_packet
+        raw_response   = tree.client.send_recv(delete_request)
+        response       = RubySMB::SMB2::Packet::SetInfoResponse.read(raw_response)
+      end
+      
+      # Crafts the SetInfoRequest packet to be sent for read operations.
+      def delete_packet
+        delete_request                 = set_header_fields(RubySMB::SMB2::Packet::SetInfoRequest.new)
+        delete_request.file_info_class = 13
+        delete_request
+      end
 
       # Sets the header fields that we have to set on every packet
       # we send for File operations.

--- a/lib/ruby_smb/smb2/packet.rb
+++ b/lib/ruby_smb/smb2/packet.rb
@@ -22,6 +22,8 @@ module RubySMB
       require 'ruby_smb/smb2/packet/query_directory_response'
       require 'ruby_smb/smb2/packet/read_request'
       require 'ruby_smb/smb2/packet/read_response'
+      require 'ruby_smb/smb2/packet/set_info_request'
+      require 'ruby_smb/smb2/packet/set_info_response'
       require 'ruby_smb/smb2/packet/close_request'
       require 'ruby_smb/smb2/packet/close_response'
       require 'ruby_smb/smb2/packet/write_request'

--- a/lib/ruby_smb/smb2/packet/set_info_request.rb
+++ b/lib/ruby_smb/smb2/packet/set_info_request.rb
@@ -1,0 +1,27 @@
+module RubySMB
+  module SMB2
+    module Packet
+      # An SMB2 Set Info Request Packet as defined in
+      # [2.2.39 SMB2 SET_INFO Request](https://msdn.microsoft.com/en-us/library/cc246560.aspx)
+      class SetInfoRequest < RubySMB::GenericPacket
+        endian :little
+
+        smb2_header           :smb2_header
+        uint16                :structure_size,         label: 'Structure Size',        initial_value: 33
+        uint8                 :info_type,              label: 'Info Type',             initial_value: 0x01
+        uint8                 :file_info_class,        label: 'File Info Class'
+        uint32                :buffer_length,          label: 'Buffer Length'
+        uint16                :buffer_offset,          label: 'Buffer Offset'
+        uint16                :reserved,               label: 'Reserved',              initial_value: 1
+        uint32                :additional_information, label: 'Additional Information' initial_value: 0
+        smb2_fileid           :file_id,                label: 'File ID'
+        string                :buffer,                 label: 'Buffer',                initial_value: 0x00
+
+        def initialize_instance
+          super
+          smb2_header.command = RubySMB::SMB2::Commands::SET_INFO
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby_smb/smb2/packet/set_info_request.rb
+++ b/lib/ruby_smb/smb2/packet/set_info_request.rb
@@ -7,15 +7,15 @@ module RubySMB
         endian :little
 
         smb2_header           :smb2_header
-        uint16                :structure_size,         label: 'Structure Size',        initial_value: 33
-        uint8                 :info_type,              label: 'Info Type',             initial_value: 0x01
+        uint16                :structure_size,         label: 'Structure Size',         initial_value: 33
+        uint8                 :info_type,              label: 'Info Type'
         uint8                 :file_info_class,        label: 'File Info Class'
-        uint32                :buffer_length,          label: 'Buffer Length',          initial_value: 1
+        uint32                :buffer_length,          label: 'Buffer Length'
         uint16                :buffer_offset,          label: 'Buffer Offset',          initial_value: 96
         uint16                :reserved,               label: 'Reserved',               initial_value: 0
         uint32                :additional_information, label: 'Additional Information', initial_value: 0
         smb2_fileid           :file_id,                label: 'File ID'
-        string                :buffer,                 label: 'Buffer', length: -> { 1 }, initial_value: 1
+        string                :buffer,                 label: 'Buffer'
 
         def initialize_instance
           super

--- a/lib/ruby_smb/smb2/packet/set_info_request.rb
+++ b/lib/ruby_smb/smb2/packet/set_info_request.rb
@@ -10,10 +10,10 @@ module RubySMB
         uint16                :structure_size,         label: 'Structure Size',        initial_value: 33
         uint8                 :info_type,              label: 'Info Type',             initial_value: 0x01
         uint8                 :file_info_class,        label: 'File Info Class'
-        uint32                :buffer_length,          label: 'Buffer Length'
-        uint16                :buffer_offset,          label: 'Buffer Offset'
-        uint16                :reserved,               label: 'Reserved',              initial_value: 1
-        uint32                :additional_information, label: 'Additional Information' initial_value: 0
+        uint32                :buffer_length,          label: 'Buffer Length',          initial_value: 0
+        uint16                :buffer_offset,          label: 'Buffer Offset',          initial_value: 0
+        uint16                :reserved,               label: 'Reserved',               initial_value: 0
+        uint32                :additional_information, label: 'Additional Information', initial_value: 0
         smb2_fileid           :file_id,                label: 'File ID'
         string                :buffer,                 label: 'Buffer',                initial_value: 0x00
 

--- a/lib/ruby_smb/smb2/packet/set_info_request.rb
+++ b/lib/ruby_smb/smb2/packet/set_info_request.rb
@@ -10,12 +10,12 @@ module RubySMB
         uint16                :structure_size,         label: 'Structure Size',        initial_value: 33
         uint8                 :info_type,              label: 'Info Type',             initial_value: 0x01
         uint8                 :file_info_class,        label: 'File Info Class'
-        uint32                :buffer_length,          label: 'Buffer Length',          initial_value: 0
-        uint16                :buffer_offset,          label: 'Buffer Offset',          initial_value: 0
+        uint32                :buffer_length,          label: 'Buffer Length',          initial_value: 1
+        uint16                :buffer_offset,          label: 'Buffer Offset',          initial_value: 96
         uint16                :reserved,               label: 'Reserved',               initial_value: 0
         uint32                :additional_information, label: 'Additional Information', initial_value: 0
         smb2_fileid           :file_id,                label: 'File ID'
-        string                :buffer,                 label: 'Buffer',                initial_value: 0x00
+        string                :buffer,                 label: 'Buffer', length: -> { 1 }, initial_value: 1
 
         def initialize_instance
           super

--- a/lib/ruby_smb/smb2/packet/set_info_response.rb
+++ b/lib/ruby_smb/smb2/packet/set_info_response.rb
@@ -7,7 +7,7 @@ module RubySMB
         endian :little
 
         smb2_header   :smb2_header
-        uint16        :structure_size,  label: 'Structure Size',      initial_value: 2
+        uint16        :structure_size, label: 'Structure Size', initial_value: 2
 
         def initialize_instance
           super

--- a/lib/ruby_smb/smb2/packet/set_info_response.rb
+++ b/lib/ruby_smb/smb2/packet/set_info_response.rb
@@ -1,0 +1,20 @@
+module RubySMB
+  module SMB2
+    module Packet
+      # An SMB2 Read Response Packet as defined in
+      # [2.2.40 SMB2 SET_INFO Response](https://msdn.microsoft.com/en-us/library/cc246562.aspx)
+      class SetInfoResponse < RubySMB::GenericPacket
+        endian :little
+
+        smb2_header   :smb2_header
+        uint16        :structure_size,  label: 'Structure Size',      initial_value: 2
+
+        def initialize_instance
+          super
+          smb2_header.command     = RubySMB::SMB2::Commands::SET_INFO
+          smb2_header.flags.reply = 1
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/ruby_smb/smb2/file_spec.rb
+++ b/spec/lib/ruby_smb/smb2/file_spec.rb
@@ -161,7 +161,7 @@ RSpec.describe RubySMB::SMB2::File do
       end
     end
   end
-  
+
   describe '#delete_packet' do
     it 'creates a new SetInfoRequest packet' do
       expect(RubySMB::SMB2::Packet::SetInfoRequest).to receive(:new).and_call_original
@@ -177,7 +177,7 @@ RSpec.describe RubySMB::SMB2::File do
       expect(file.delete_packet.file_info_class).to eq 13
     end
   end
-  
+
   describe '#delete' do
     context 'for a small file' do
       let(:small_delete) { file.delete_packet }

--- a/spec/lib/ruby_smb/smb2/file_spec.rb
+++ b/spec/lib/ruby_smb/smb2/file_spec.rb
@@ -161,4 +161,34 @@ RSpec.describe RubySMB::SMB2::File do
       end
     end
   end
+  
+  describe '#delete_packet' do
+    it 'creates a new SetInfoRequest packet' do
+      expect(RubySMB::SMB2::Packet::SetInfoRequest).to receive(:new).and_call_original
+      file.delete_packet
+    end
+
+    it 'calls #set_header_fields' do
+      expect(file).to receive(:set_header_fields).and_call_original
+      file.delete_packet
+    end
+
+    it 'sets the file_info_class of the packet' do
+      expect(file.delete_packet.file_info_class).to eq 13
+    end
+  end
+  
+  describe '#delete' do
+    context 'for a small file' do
+      let(:small_delete) { file.delete_packet }
+      let(:small_response) { RubySMB::SMB2::Packet::SetInfoResponse.new }
+
+      it 'uses a single packet to delete the entire file' do
+        expect(file).to receive(:delete_packet).and_return(small_delete)
+        expect(client).to receive(:send_recv).with(small_delete).and_return 'raw_response'
+        expect(RubySMB::SMB2::Packet::SetInfoResponse).to receive(:read).with('raw_response').and_return(small_response)
+        expect(file.delete[:smb2_header][:command]).to eq 17
+      end
+    end
+  end
 end

--- a/spec/lib/ruby_smb/smb2/packet/set_info_request_spec.rb
+++ b/spec/lib/ruby_smb/smb2/packet/set_info_request_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+RSpec.describe RubySMB::SMB2::Packet::SetInfoRequest do
+  subject(:packet) { described_class.new }
+
+  it { is_expected.to respond_to :smb2_header }
+  it { is_expected.to respond_to :structure_size }
+  it { is_expected.to respond_to :info_type }
+  it { is_expected.to respond_to :file_info_class }
+  it { is_expected.to respond_to :buffer_length }
+  it { is_expected.to respond_to :buffer_offset }
+  it { is_expected.to respond_to :reserved }
+  it { is_expected.to respond_to :additional_information }
+  it { is_expected.to respond_to :file_id }
+  it { is_expected.to respond_to :buffer }
+
+  it 'is little endian' do
+    expect(described_class.fields.instance_variable_get(:@hints)[:endian]).to eq :little
+  end
+
+  describe '#smb2_header' do
+    subject(:header) { packet.smb2_header }
+
+    it 'is a standard SMB Header' do
+      expect(header).to be_a RubySMB::SMB2::SMB2Header
+    end
+
+    it 'should have the command set to SMB_COM_NEGOTIATE' do
+      expect(header.command).to eq RubySMB::SMB2::Commands::SET_INFO
+    end
+
+    it 'should not have the response flag set' do
+      expect(header.flags.reply).to eq 0
+    end
+  end
+
+  it 'should have a structure size of 49' do
+    expect(packet.structure_size).to eq 33
+  end
+end

--- a/spec/lib/ruby_smb/smb2/packet/set_info_response_spec.rb
+++ b/spec/lib/ruby_smb/smb2/packet/set_info_response_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+RSpec.describe RubySMB::SMB2::Packet::SetInfoResponse do
+  subject(:packet) { described_class.new }
+
+  it { is_expected.to respond_to :smb2_header }
+  it { is_expected.to respond_to :structure_size }
+
+  it 'is little endian' do
+    expect(described_class.fields.instance_variable_get(:@hints)[:endian]).to eq :little
+  end
+
+  describe '#smb2_header' do
+    subject(:header) { packet.smb2_header }
+
+    it 'is a standard SMB Header' do
+      expect(header).to be_a RubySMB::SMB2::SMB2Header
+    end
+
+    it 'should have the command set to SMB_COM_NEGOTIATE' do
+      expect(header.command).to eq RubySMB::SMB2::Commands::SET_INFO
+    end
+
+    it 'should have the response flag set' do
+      expect(header.flags.reply).to eq 1
+    end
+  end
+
+  it 'should have a structure size of 17' do
+    expect(packet.structure_size).to eq 2
+  end
+end


### PR DESCRIPTION
MS-2826

This PR adds the SMB2 SET_INFO_REQUEST and SET_INFO_RESPONSE for the purpose of file deletion. To delete a file, the FileDispositionInformation is set such that the file deletes on close.

## Validation
- [ ] verify `rspec spec` passes
- [ ] create a file on your remote windows machine
- [ ] verify the file can be deleted with the example delete script `ruby examples/delete_file.rb <ip-address> <username> <password> <share> <filename>`