### PR TITLE
Add SMB2 file rename functionality

### DIFF
--- a/examples/rename_file.rb
+++ b/examples/rename_file.rb
@@ -1,0 +1,41 @@
+#!/usr/bin/ruby
+
+# This example script is used for testing the deleting of a file.
+# It will attempt to connect to a specific share and then rename a specified file.
+# Example usage: ruby rename_file.rb 192.168.172.138 msfadmin msfadmin TEST_SHARE short.txt
+# This will try to connect to \\192.168.172.138\TEST_SHARE with the msfadmin:msfadmin credentials
+# and rename the file short.txt
+
+require 'bundler/setup'
+require 'ruby_smb'
+
+address  = ARGV[0]
+username = ARGV[1]
+password = ARGV[2]
+share    = ARGV[3]
+file     = ARGV[4]
+new_name = ARGV[5]
+path     = "\\\\#{address}\\#{share}"
+
+sock = TCPSocket.new address, 445
+dispatcher = RubySMB::Dispatcher::Socket.new(sock)
+
+client = RubySMB::Client.new(dispatcher, smb1: false, smb2: true, username: username, password: password)
+
+protocol = client.negotiate
+status = client.authenticate
+
+puts "#{protocol} : #{status}"
+
+begin
+  tree = client.tree_connect(path)
+  puts "Connected to #{path} successfully!"
+rescue StandardError => e
+  puts "Failed to connect to #{path}: #{e.message}"
+end
+
+file = tree.open_file(filename: file, write: true, delete: true)
+
+data = file.rename(new_name)
+puts data
+file.close

--- a/examples/rename_file.rb
+++ b/examples/rename_file.rb
@@ -2,7 +2,7 @@
 
 # This example script is used for testing the deleting of a file.
 # It will attempt to connect to a specific share and then rename a specified file.
-# Example usage: ruby rename_file.rb 192.168.172.138 msfadmin msfadmin TEST_SHARE short.txt
+# Example usage: ruby rename_file.rb 192.168.172.138 msfadmin msfadmin TEST_SHARE short.txt shortrenamed.txt
 # This will try to connect to \\192.168.172.138\TEST_SHARE with the msfadmin:msfadmin credentials
 # and rename the file short.txt
 

--- a/lib/ruby_smb/fscc/file_information.rb
+++ b/lib/ruby_smb/fscc/file_information.rb
@@ -10,6 +10,7 @@ module RubySMB
       require 'ruby_smb/fscc/file_information/file_both_directory_information'
       require 'ruby_smb/fscc/file_information/file_id_both_directory_information'
       require 'ruby_smb/fscc/file_information/file_names_information'
+      require 'ruby_smb/fscc/file_information/file_rename_information'
     end
   end
 end

--- a/lib/ruby_smb/fscc/file_information/file_disposition_information.rb
+++ b/lib/ruby_smb/fscc/file_information/file_disposition_information.rb
@@ -13,8 +13,6 @@ module RubySMB
 
         endian :little
 
-        uint8  :info_type,          label: 'Info Type',       initial_value: 0x01
-        uint8  :file_info_class,    label: 'File Info Class', initial_value: 0x0D
         uint32 :buffer_length,      label: 'Buffer Length',   initial_value: 1
         uint16 :buffer_offset,      label: 'Buffer Offset',   initial_value: 96
         string :buffer,             label: 'Buffer',          initial_value: 1

--- a/lib/ruby_smb/fscc/file_information/file_rename_information.rb
+++ b/lib/ruby_smb/fscc/file_information/file_rename_information.rb
@@ -12,11 +12,6 @@ module RubySMB
         SMB2_FLAG = 0x0A
 
         endian :little
-
-        # uint8  :info_type,          label: 'Info Type',         initial_value: 0x01
-#         uint8  :file_info_class,    label: 'File Info Class',   initial_value: 0x0A
-#         uint32 :buffer_length,      label: 'Buffer Length',     initial_value: 1
-#         uint16 :buffer_offset,      label: 'Buffer Offset',     initial_value: 96
         
         uint8  :replace_if_exists,  label: 'Replace If Exists', initial_value: 1
         uint8  :reserved_0,         label: 'Reserved 0',        initial_value: 0

--- a/lib/ruby_smb/fscc/file_information/file_rename_information.rb
+++ b/lib/ruby_smb/fscc/file_information/file_rename_information.rb
@@ -13,10 +13,10 @@ module RubySMB
 
         endian :little
 
-        uint8  :info_type,          label: 'Info Type',         initial_value: 0x01
-        uint8  :file_info_class,    label: 'File Info Class',   initial_value: 0x0A
-        uint32 :buffer_length,      label: 'Buffer Length',     initial_value: 1
-        uint16 :buffer_offset,      label: 'Buffer Offset',     initial_value: 96
+        # uint8  :info_type,          label: 'Info Type',         initial_value: 0x01
+#         uint8  :file_info_class,    label: 'File Info Class',   initial_value: 0x0A
+#         uint32 :buffer_length,      label: 'Buffer Length',     initial_value: 1
+#         uint16 :buffer_offset,      label: 'Buffer Offset',     initial_value: 96
         
         uint8  :replace_if_exists,  label: 'Replace If Exists', initial_value: 1
         uint8  :reserved_0,         label: 'Reserved 0',        initial_value: 0

--- a/lib/ruby_smb/fscc/file_information/file_rename_information.rb
+++ b/lib/ruby_smb/fscc/file_information/file_rename_information.rb
@@ -18,8 +18,8 @@ module RubySMB
         uint16 :reserved_1,         label: 'Reserved 1',        initial_value: 0
         uint32 :reserved_2,         label: 'Reserved 2',        initial_value: 0
         uint64 :root_firectory,     label: 'Root Directory',    initial_value: 0
-        uint32 :file_name_length,   label: 'File Name Length',  initial_value: 0
-        string :file_name,          label: 'File Name',         initial_value: 1
+        uint32 :file_name_length,   label: 'File Name Length',  initial_value: -> { file_name.do_num_bytes }
+        string :file_name,          label: 'File Name',           read_length: -> { file_name_length }
         
       end
     end

--- a/lib/ruby_smb/fscc/file_information/file_rename_information.rb
+++ b/lib/ruby_smb/fscc/file_information/file_rename_information.rb
@@ -1,0 +1,32 @@
+module RubySMB
+  module Fscc
+    module FileInformation
+      # The FileRenameInformation Class as defined in
+      # [2.4.34.2 FileRenameInformation](https://msdn.microsoft.com/en-us/library/cc704597.aspx)
+      class FileRenameInformation < BinData::Record
+        # Null bytes because SMB1 Requests can't use this
+        # Information Class.
+        SMB1_FLAG = 0x0000
+        # The value set in the InformationLevel field of an SMB2 request to indicate
+        # the response should use this Information Class Structure.
+        SMB2_FLAG = 0x0A
+
+        endian :little
+
+        uint8  :info_type,          label: 'Info Type',         initial_value: 0x01
+        uint8  :file_info_class,    label: 'File Info Class',   initial_value: 0x0A
+        uint32 :buffer_length,      label: 'Buffer Length',     initial_value: 1
+        uint16 :buffer_offset,      label: 'Buffer Offset',     initial_value: 96
+        
+        uint8  :replace_if_exists,  label: 'Replace If Exists', initial_value: 1
+        uint8  :reserved_0,         label: 'Reserved 0',        initial_value: 0
+        uint16 :reserved_1,         label: 'Reserved 1',        initial_value: 0
+        uint32 :reserved_2,         label: 'Reserved 2',        initial_value: 0
+        uint64 :root_firectory,     label: 'Root Directory',    initial_value: 0
+        uint32 :file_name_length,   label: 'File Name Length',  initial_value: 0
+        string :file_name,          label: 'File Name',         initial_value: 1
+        
+      end
+    end
+  end
+end

--- a/lib/ruby_smb/smb2/file.rb
+++ b/lib/ruby_smb/smb2/file.rb
@@ -221,20 +221,20 @@ module RubySMB
       def rename_packet(new_file_name)
         rename_request                      = set_header_fields(RubySMB::SMB2::Packet::SetInfoRequest.new)
         file_rename_information             = RubySMB::Fscc::FileInformation::FileRenameInformation.new
+        
+        file_rename_information.file_name          = new_file_name
+        file_rename_information.file_name_length   = new_file_name.length
+        
+        # require 'pry'
+#         binding.pry
+        
+        rename_request.buffer                      = file_rename_information.to_binary_s
 
-        rename_request.info_type            = file_rename_information.info_type
-        rename_request.file_info_class      = file_rename_information.file_info_class
+        rename_request.info_type            = 0x01
+        rename_request.file_info_class      = 0x0A
         
-        rename_request.buffer_length        = file_rename_information.buffer_length
-        rename_request.buffer_offset        = file_rename_information.buffer_offset
-        
-        rename_request.buffer              += file_rename_information.replace_if_exists
-        rename_request.buffer              += file_rename_information.reserved_0
-        rename_request.buffer              += file_rename_information.reserved_1
-        rename_request.buffer              += file_rename_information.reserved_2
-        rename_request.buffer              += file_rename_information.root_firectory
-        rename_request.buffer              += file_rename_information.file_name_length
-        rename_request.buffer              += file_rename_information.file_name
+        rename_request.buffer_length        = file_rename_information.num_bytes
+        rename_request.buffer_offset        = 96
         
         rename_request
       end

--- a/lib/ruby_smb/smb2/file.rb
+++ b/lib/ruby_smb/smb2/file.rb
@@ -222,11 +222,8 @@ module RubySMB
         rename_request                      = set_header_fields(RubySMB::SMB2::Packet::SetInfoRequest.new)
         file_rename_information             = RubySMB::Fscc::FileInformation::FileRenameInformation.new
         
-        file_rename_information.file_name          = new_file_name
-        file_rename_information.file_name_length   = new_file_name.length
-        
-        # require 'pry'
-#         binding.pry
+        file_rename_information.file_name          = new_file_name.encode('utf-16le')
+        file_rename_information.file_name_length   = file_rename_information.file_name.do_num_bytes
         
         rename_request.buffer                      = file_rename_information.to_binary_s
 

--- a/lib/ruby_smb/smb2/file.rb
+++ b/lib/ruby_smb/smb2/file.rb
@@ -206,6 +206,38 @@ module RubySMB
         write_request.buffer        = data
         write_request
       end
+      
+      # Rename a file
+      #
+      # @return [String] the rename response to string
+      def rename(new_file_name)
+        raw_response = tree.client.send_recv(rename_packet(new_file_name))
+        RubySMB::SMB2::Packet::SetInfoResponse.read(raw_response)
+      end
+
+      # Crafts the SetInfoRequest packet to be sent for rename operations.
+      #
+      # @return [RubySMB::SMB2::Packet::SetInfoRequest] the set info packet
+      def rename_packet(new_file_name)
+        rename_request                      = set_header_fields(RubySMB::SMB2::Packet::SetInfoRequest.new)
+        file_rename_information             = RubySMB::Fscc::FileInformation::FileRenameInformation.new
+
+        rename_request.info_type            = file_rename_information.info_type
+        rename_request.file_info_class      = file_rename_information.file_info_class
+        
+        rename_request.buffer_length        = file_rename_information.buffer_length
+        rename_request.buffer_offset        = file_rename_information.buffer_offset
+        
+        rename_request.buffer              += file_rename_information.replace_if_exists
+        rename_request.buffer              += file_rename_information.reserved_0
+        rename_request.buffer              += file_rename_information.reserved_1
+        rename_request.buffer              += file_rename_information.reserved_2
+        rename_request.buffer              += file_rename_information.root_firectory
+        rename_request.buffer              += file_rename_information.file_name_length
+        rename_request.buffer              += file_rename_information.file_name
+        
+        rename_request
+      end
 
     end
   end

--- a/lib/ruby_smb/smb2/file.rb
+++ b/lib/ruby_smb/smb2/file.rb
@@ -150,8 +150,7 @@ module RubySMB
         delete_request                      = set_header_fields(RubySMB::SMB2::Packet::SetInfoRequest.new)
         file_disposition_information        = RubySMB::Fscc::FileInformation::FileDispositionInformation.new
 
-        delete_request.info_type            = file_disposition_information.info_type
-        delete_request.file_info_class      = file_disposition_information.file_info_class
+        delete_request.file_info_class      = RubySMB::Fscc::FileInformation::FileDispositionInformation::SMB2_FLAG
         delete_request.buffer_length        = file_disposition_information.buffer_length
         delete_request.buffer_offset        = file_disposition_information.buffer_offset
         delete_request.buffer               = file_disposition_information.buffer
@@ -223,11 +222,9 @@ module RubySMB
       def rename_packet(new_file_name)
         file_rename_information                  = RubySMB::Fscc::FileInformation::FileRenameInformation.new
         file_rename_information.file_name        = new_file_name.encode('utf-16le')
-        file_rename_information.file_name_length = file_rename_information.file_name.do_num_bytes
         
         rename_request                           = set_header_fields(RubySMB::SMB2::Packet::SetInfoRequest.new)
-        rename_request.info_type                 = 0x01
-        rename_request.file_info_class           = 0x0A
+        rename_request.file_info_class           = RubySMB::Fscc::FileInformation::FileRenameInformation::SMB2_FLAG
         rename_request.buffer                    = file_rename_information.to_binary_s
         rename_request.buffer_length             = file_rename_information.num_bytes
         

--- a/lib/ruby_smb/smb2/file.rb
+++ b/lib/ruby_smb/smb2/file.rb
@@ -209,10 +209,11 @@ module RubySMB
       # Rename a file
       #
       # @param new_file_name [String] the new name
-      # @return [String] the rename response to string
+      # @return [WindowsError::ErrorCode] the NTStatus Response code
       def rename(new_file_name)
         raw_response = tree.client.send_recv(rename_packet(new_file_name))
-        RubySMB::SMB2::Packet::SetInfoResponse.read(raw_response)
+        response = RubySMB::SMB2::Packet::SetInfoResponse.read(raw_response)
+        response.smb2_header.nt_status.to_nt_status
       end
 
       # Crafts the SetInfoRequest packet to be sent for rename operations.

--- a/lib/ruby_smb/smb2/file.rb
+++ b/lib/ruby_smb/smb2/file.rb
@@ -209,6 +209,7 @@ module RubySMB
       
       # Rename a file
       #
+      # @param new_file_name [String] the new name
       # @return [String] the rename response to string
       def rename(new_file_name)
         raw_response = tree.client.send_recv(rename_packet(new_file_name))
@@ -217,21 +218,18 @@ module RubySMB
 
       # Crafts the SetInfoRequest packet to be sent for rename operations.
       #
+      # @param new_file_name [String] the new name
       # @return [RubySMB::SMB2::Packet::SetInfoRequest] the set info packet
       def rename_packet(new_file_name)
-        rename_request                      = set_header_fields(RubySMB::SMB2::Packet::SetInfoRequest.new)
-        file_rename_information             = RubySMB::Fscc::FileInformation::FileRenameInformation.new
+        file_rename_information                  = RubySMB::Fscc::FileInformation::FileRenameInformation.new
+        file_rename_information.file_name        = new_file_name.encode('utf-16le')
+        file_rename_information.file_name_length = file_rename_information.file_name.do_num_bytes
         
-        file_rename_information.file_name          = new_file_name.encode('utf-16le')
-        file_rename_information.file_name_length   = file_rename_information.file_name.do_num_bytes
-        
-        rename_request.buffer                      = file_rename_information.to_binary_s
-
-        rename_request.info_type            = 0x01
-        rename_request.file_info_class      = 0x0A
-        
-        rename_request.buffer_length        = file_rename_information.num_bytes
-        rename_request.buffer_offset        = 96
+        rename_request                           = set_header_fields(RubySMB::SMB2::Packet::SetInfoRequest.new)
+        rename_request.info_type                 = 0x01
+        rename_request.file_info_class           = 0x0A
+        rename_request.buffer                    = file_rename_information.to_binary_s
+        rename_request.buffer_length             = file_rename_information.num_bytes
         
         rename_request
       end

--- a/lib/ruby_smb/smb2/packet/set_info_request.rb
+++ b/lib/ruby_smb/smb2/packet/set_info_request.rb
@@ -8,7 +8,7 @@ module RubySMB
 
         smb2_header           :smb2_header
         uint16                :structure_size,         label: 'Structure Size',         initial_value: 33
-        uint8                 :info_type,              label: 'Info Type'
+        uint8                 :info_type,              label: 'Info Type',              initial_value: 0x01
         uint8                 :file_info_class,        label: 'File Info Class'
         uint32                :buffer_length,          label: 'Buffer Length'
         uint16                :buffer_offset,          label: 'Buffer Offset',          initial_value: 96

--- a/spec/lib/ruby_smb/fscc/file_information/file_disposition_information_spec.rb
+++ b/spec/lib/ruby_smb/fscc/file_information/file_disposition_information_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+RSpec.describe RubySMB::Fscc::FileInformation::FileDispositionInformation do
+  subject(:struct) { described_class.new }
+
+  it { should respond_to :buffer_length }
+  it { should respond_to :buffer_offset }
+  it { should respond_to :buffer }
+
+  it 'is little endian' do
+    expect(described_class.fields.instance_variable_get(:@hints)[:endian]).to eq :little
+  end
+end

--- a/spec/lib/ruby_smb/fscc/file_information/file_rename_information_spec.rb
+++ b/spec/lib/ruby_smb/fscc/file_information/file_rename_information_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+RSpec.describe RubySMB::Fscc::FileInformation::FileRenameInformation do
+  subject(:struct) { described_class.new }
+
+  it { should respond_to :replace_if_exists }
+  it { should respond_to :reserved_0 }
+  it { should respond_to :reserved_1 }
+  it { should respond_to :reserved_2 }
+  it { should respond_to :root_firectory }
+  it { should respond_to :file_name_length }
+  it { should respond_to :file_name }
+
+  it 'is little endian' do
+    expect(described_class.fields.instance_variable_get(:@hints)[:endian]).to eq :little
+  end
+
+  it 'tracks the length of the file_name field' do
+    struct.file_name = 'Hello.txt'
+    expect(struct.file_name_length).to eq struct.file_name.do_num_bytes
+  end
+
+  it 'encodes the file name in UTF-16LE' do
+    name = 'Hello_world.txt'
+    struct.file_name = name
+    expect(struct.file_name.encode('utf-16le')).to eq name.encode('utf-16le')
+  end
+
+  describe 'reading in from a blob' do
+    it 'uses the file_name_length to know when to stop reading' do
+      name = 'Hello_world.txt'
+      struct.file_name = name
+      blob = struct.to_binary_s
+      blob << 'AAAA'
+      new_from_blob = described_class.read(blob)
+      expect(new_from_blob.file_name.encode('utf-16le')).to eq name.encode('utf-16le')
+    end
+  end
+end

--- a/spec/lib/ruby_smb/smb2/file_spec.rb
+++ b/spec/lib/ruby_smb/smb2/file_spec.rb
@@ -217,7 +217,7 @@ RSpec.describe RubySMB::SMB2::File do
         expect(file).to receive(:rename_packet).and_return(small_rename)
         expect(client).to receive(:send_recv).with(small_rename).and_return 'raw_response'
         expect(RubySMB::SMB2::Packet::SetInfoResponse).to receive(:read).with('raw_response').and_return(small_response)
-        expect(file.rename('new_file.txt')[:smb2_header][:command]).to eq 17
+        expect(file.rename('new_file.txt')).to eq WindowsError::NTStatus::STATUS_SUCCESS
       end
     end
   end


### PR DESCRIPTION
MS-2839

This PR adds rename functionality (SMB2) to the file class.

fixes #86

## Validation
- [ ] Verify you can rename a file with `ruby examples/rename_file.rb <ip-address> <username> <password> <share> <file-to-rename> <new-file-name>`