### PR TITLE
Small fix for CreateOptions bit field (#2)

### DIFF
--- a/lib/ruby_smb/smb1/bit_field/create_options.rb
+++ b/lib/ruby_smb/smb1/bit_field/create_options.rb
@@ -31,7 +31,7 @@ module RubySMB
         bit1    :reserve_opfilter,            label: 'Reserve OPFilter'
         bit4    :reserved,                    label: 'Reserved Space'
         # Byte Boundary
-        bit8
+        bit8    :reserved2,                   label: 'Reserved Space'
       end
     end
   end


### PR DESCRIPTION
Reserved bit field name and label was missing.

# Verification Steps
- [x] `bundle install`
## `rake spec`
- [x] `rake spec`
- [x] VERIFY no failures