### PR TITLE
SMB2 Rename and Delete Improvement

### DIFF
--- a/lib/ruby_smb/field/smb_gea_list.rb
+++ b/lib/ruby_smb/field/smb_gea_list.rb
@@ -4,7 +4,7 @@ module RubySMB
     # [2.2.1.2.1.1 SMB_GEA_LIST](https://msdn.microsoft.com/en-us/library/ff359447.aspx)
     class SmbGeaList < BinData::Record
       endian :little
-      uint32  :size_of_list, label: 'Size of List in Bytes', initial_value: -> { gea_list.do_num_bytes }
+      uint32  :size_of_list, label: 'Size of List in Bytes', initial_value: -> { self.do_num_bytes }
       array   :gea_list, initial_length: 0 do
         smb_gea
       end

--- a/lib/ruby_smb/fscc/file_information.rb
+++ b/lib/ruby_smb/fscc/file_information.rb
@@ -3,15 +3,6 @@ module RubySMB
     # Namespace and constant values for File Information Classes, as defined in
     # [2.4 File Information Classes](https://msdn.microsoft.com/en-us/library/cc232064.aspx)
     module FileInformation
-      require 'ruby_smb/fscc/file_information/file_directory_information'
-      require 'ruby_smb/fscc/file_information/file_full_directory_information'
-      require 'ruby_smb/fscc/file_information/file_disposition_information'
-      require 'ruby_smb/fscc/file_information/file_id_full_directory_information'
-      require 'ruby_smb/fscc/file_information/file_both_directory_information'
-      require 'ruby_smb/fscc/file_information/file_id_both_directory_information'
-      require 'ruby_smb/fscc/file_information/file_names_information'
-      require 'ruby_smb/fscc/file_information/file_rename_information'
-
       # Information class used in directory enumeration to return detailed
       # information about the contents of a directory.
       FILE_DIRECTORY_INFORMATION         = 0x01
@@ -46,6 +37,15 @@ module RubySMB
       # contents of a directory.
       FILE_ID_FULL_DIRECTORY_INFORMATION = 0x26
 
+
+      require 'ruby_smb/fscc/file_information/file_directory_information'
+      require 'ruby_smb/fscc/file_information/file_full_directory_information'
+      require 'ruby_smb/fscc/file_information/file_disposition_information'
+      require 'ruby_smb/fscc/file_information/file_id_full_directory_information'
+      require 'ruby_smb/fscc/file_information/file_both_directory_information'
+      require 'ruby_smb/fscc/file_information/file_id_both_directory_information'
+      require 'ruby_smb/fscc/file_information/file_names_information'
+      require 'ruby_smb/fscc/file_information/file_rename_information'
     end
   end
 end

--- a/lib/ruby_smb/fscc/file_information.rb
+++ b/lib/ruby_smb/fscc/file_information.rb
@@ -1,7 +1,7 @@
 module RubySMB
   module Fscc
-    # Contains the Constant values for File Information Classes, as defined in
-    # [2.2.33 SMB2 QUERY_DIRECTORY Request](https://msdn.microsoft.com/en-us/library/cc246551.aspx)
+    # Namespace and constant values for File Information Classes, as defined in
+    # [2.4 File Information Classes](https://msdn.microsoft.com/en-us/library/cc232064.aspx)
     module FileInformation
       require 'ruby_smb/fscc/file_information/file_directory_information'
       require 'ruby_smb/fscc/file_information/file_full_directory_information'
@@ -11,6 +11,41 @@ module RubySMB
       require 'ruby_smb/fscc/file_information/file_id_both_directory_information'
       require 'ruby_smb/fscc/file_information/file_names_information'
       require 'ruby_smb/fscc/file_information/file_rename_information'
+
+      # Information class used in directory enumeration to return detailed
+      # information about the contents of a directory.
+      FILE_DIRECTORY_INFORMATION         = 0x01
+
+      # Information class used in directory enumeration to return detailed
+      # information (with extended attributes size) about the contents of a
+      # directory.
+      FILE_FULL_DIRECTORY_INFORMATION    = 0x02
+
+      # Information class used in directory enumeration to return detailed
+      # information (with extended attributes size and short names) about the
+      # contents of a directory.
+      FILE_BOTH_DIRECTORY_INFORMATION    = 0x03
+
+      # Information class used to rename a file.
+      FILE_RENAME_INFORMATION            = 0x0A
+
+      # Information class used in directory enumeration to return detailed
+      # information (with only filenames) about the contents of a directory.
+      FILE_NAMES_INFORMATION             = 0x0C
+
+      # Information class used to mark a file for deletion.
+      FILE_DISPOSITION_INFORMATION       = 0x0D
+
+      # Information class used in directory enumeration to return detailed
+      # information (with extended attributes size, short names and file ID)
+      # about the contents of a directory.
+      FILE_ID_BOTH_DIRECTORY_INFORMATION = 0x25
+
+      # Information class used in directory enumeration to return detailed
+      # information (with extended attributes size and file ID) about the
+      # contents of a directory.
+      FILE_ID_FULL_DIRECTORY_INFORMATION = 0x26
+
     end
   end
 end

--- a/lib/ruby_smb/fscc/file_information/file_both_directory_information.rb
+++ b/lib/ruby_smb/fscc/file_information/file_both_directory_information.rb
@@ -4,6 +4,8 @@ module RubySMB
       # The FileBothDirectoryInformation Class as defined in
       # [2.4.8 FileBothDirectoryInformation](https://msdn.microsoft.com/en-us/library/cc232095.aspx)
       class FileBothDirectoryInformation < BinData::Record
+        CLASS_LEVEL = FileInformation::FILE_BOTH_DIRECTORY_INFORMATION
+
         endian :little
 
         uint32           :next_offset,        label: 'Next Entry Offset'

--- a/lib/ruby_smb/fscc/file_information/file_both_directory_information.rb
+++ b/lib/ruby_smb/fscc/file_information/file_both_directory_information.rb
@@ -4,12 +4,6 @@ module RubySMB
       # The FileBothDirectoryInformation Class as defined in
       # [2.4.8 FileBothDirectoryInformation](https://msdn.microsoft.com/en-us/library/cc232095.aspx)
       class FileBothDirectoryInformation < BinData::Record
-        # the response should use this Information Class Structure.
-        SMB1_FLAG = 0x0104
-        # The value set in the InformationLevel field of an SMB2 request to indicate
-        # the response should use this Information Class Structure.
-        SMB2_FLAG = 0x03
-
         endian :little
 
         uint32           :next_offset,        label: 'Next Entry Offset'

--- a/lib/ruby_smb/fscc/file_information/file_directory_information.rb
+++ b/lib/ruby_smb/fscc/file_information/file_directory_information.rb
@@ -4,6 +4,8 @@ module RubySMB
       # The FileDirectoryInformation Class as defined in
       # [2.4.10 FileDirectoryInformation](https://msdn.microsoft.com/en-us/library/cc232097.aspx)
       class FileDirectoryInformation < BinData::Record
+        CLASS_LEVEL = FileInformation::FILE_DIRECTORY_INFORMATION
+
         endian :little
 
         uint32           :next_offset,      label: 'Next Entry Offset'

--- a/lib/ruby_smb/fscc/file_information/file_directory_information.rb
+++ b/lib/ruby_smb/fscc/file_information/file_directory_information.rb
@@ -4,13 +4,6 @@ module RubySMB
       # The FileDirectoryInformation Class as defined in
       # [2.4.10 FileDirectoryInformation](https://msdn.microsoft.com/en-us/library/cc232097.aspx)
       class FileDirectoryInformation < BinData::Record
-        # The value set in the InformationLevel field of an SMB1 request to indicate
-        # the response should use this Information Class Structure.
-        SMB1_FLAG = 0x0101
-        # The value set in the InformationLevel field of an SMB2 request to indicate
-        # the response should use this Information Class Structure.
-        SMB2_FLAG = 0x01
-
         endian :little
 
         uint32           :next_offset,      label: 'Next Entry Offset'

--- a/lib/ruby_smb/fscc/file_information/file_disposition_information.rb
+++ b/lib/ruby_smb/fscc/file_information/file_disposition_information.rb
@@ -4,6 +4,8 @@ module RubySMB
       # The FileDispositionInformation Class as defined in
       # [2.4.11 FileDispositionInformation](https://msdn.microsoft.com/en-us/library/cc232098.aspx)
       class FileDispositionInformation < BinData::Record
+        CLASS_LEVEL = FileInformation::FILE_DISPOSITION_INFORMATION
+
         endian :little
 
         uint8 :delete_pending, label: 'Delete Pending', initial_value: 0

--- a/lib/ruby_smb/fscc/file_information/file_disposition_information.rb
+++ b/lib/ruby_smb/fscc/file_information/file_disposition_information.rb
@@ -4,18 +4,9 @@ module RubySMB
       # The FileDispositionInformation Class as defined in
       # [2.4.11 FileDispositionInformation](https://msdn.microsoft.com/en-us/library/cc232098.aspx)
       class FileDispositionInformation < BinData::Record
-        # Null bytes because SMB1 Requests can't use this
-        # Information Class.
-        SMB1_FLAG = 0x0000
-        # The value set in the InformationLevel field of an SMB2 request to indicate
-        # the response should use this Information Class Structure.
-        SMB2_FLAG = 0x0D
-
         endian :little
 
-        uint32 :buffer_length,      label: 'Buffer Length',   initial_value: 1
-        uint16 :buffer_offset,      label: 'Buffer Offset',   initial_value: 96
-        string :buffer,             label: 'Buffer',          initial_value: 1
+        uint8 :delete_pending, label: 'Delete Pending', initial_value: 0
       end
     end
   end

--- a/lib/ruby_smb/fscc/file_information/file_full_directory_information.rb
+++ b/lib/ruby_smb/fscc/file_information/file_full_directory_information.rb
@@ -4,13 +4,6 @@ module RubySMB
       # The FileFullDirectoryInformation Class as defined in
       # [2.4.14 FileFullDirectoryInformation](https://msdn.microsoft.com/en-us/library/cc232068.aspx)
       class FileFullDirectoryInformation < BinData::Record
-        # The value set in the InformationLevel field of an SMB1 request to indicate
-        # the response should use this Information Class Structure.
-        SMB1_FLAG = 0x0102
-        # The value set in the InformationLevel field of an SMB2 request to indicate
-        # the response should use this Information Class Structure.
-        SMB2_FLAG = 0x02
-
         endian :little
 
         uint32           :next_offset,      label: 'Next Entry Offset'

--- a/lib/ruby_smb/fscc/file_information/file_full_directory_information.rb
+++ b/lib/ruby_smb/fscc/file_information/file_full_directory_information.rb
@@ -4,6 +4,8 @@ module RubySMB
       # The FileFullDirectoryInformation Class as defined in
       # [2.4.14 FileFullDirectoryInformation](https://msdn.microsoft.com/en-us/library/cc232068.aspx)
       class FileFullDirectoryInformation < BinData::Record
+        CLASS_LEVEL = FileInformation::FILE_FULL_DIRECTORY_INFORMATION
+
         endian :little
 
         uint32           :next_offset,      label: 'Next Entry Offset'

--- a/lib/ruby_smb/fscc/file_information/file_id_both_directory_information.rb
+++ b/lib/ruby_smb/fscc/file_information/file_id_both_directory_information.rb
@@ -4,6 +4,8 @@ module RubySMB
       # The FileIdBothDirectoryInformation Class as defined in
       # [2.4.17 FileIdBothDirectoryInformation](https://msdn.microsoft.com/en-us/library/cc232070.aspx)
       class FileIdBothDirectoryInformation < BinData::Record
+        CLASS_LEVEL = FileInformation::FILE_ID_BOTH_DIRECTORY_INFORMATION
+
         endian :little
 
         uint32           :next_offset,        label: 'Next Entry Offset'

--- a/lib/ruby_smb/fscc/file_information/file_id_both_directory_information.rb
+++ b/lib/ruby_smb/fscc/file_information/file_id_both_directory_information.rb
@@ -4,13 +4,6 @@ module RubySMB
       # The FileIdBothDirectoryInformation Class as defined in
       # [2.4.17 FileIdBothDirectoryInformation](https://msdn.microsoft.com/en-us/library/cc232070.aspx)
       class FileIdBothDirectoryInformation < BinData::Record
-        # Null bytes because SMB1 Requests can't use this
-        # Information Class.
-        SMB1_FLAG = 0x0000
-        # The value set in the InformationLevel field of an SMB2 request to indicate
-        # the response should use this Information Class Structure.
-        SMB2_FLAG = 0x25
-
         endian :little
 
         uint32           :next_offset,        label: 'Next Entry Offset'

--- a/lib/ruby_smb/fscc/file_information/file_id_full_directory_information.rb
+++ b/lib/ruby_smb/fscc/file_information/file_id_full_directory_information.rb
@@ -1,16 +1,9 @@
 module RubySMB
   module Fscc
     module FileInformation
-      # The FileDirectoryInformation Class as defined in
+      # The FileIdDirectoryInformation Class as defined in
       # [2.4.18 FileIdFullDirectoryInformation](https://msdn.microsoft.com/en-us/library/cc232071.aspx)
       class FileIdFullDirectoryInformation < BinData::Record
-        # Null bytes because SMB1 Requests can't use this
-        # Information Class.
-        SMB1_FLAG = 0x0000
-        # The value set in the InformationLevel field of an SMB2 request to indicate
-        # the response should use this Information Class Structure.
-        SMB2_FLAG = 0x26
-
         endian :little
 
         uint32           :next_offset,      label: 'Next Entry Offset'

--- a/lib/ruby_smb/fscc/file_information/file_id_full_directory_information.rb
+++ b/lib/ruby_smb/fscc/file_information/file_id_full_directory_information.rb
@@ -4,6 +4,8 @@ module RubySMB
       # The FileIdDirectoryInformation Class as defined in
       # [2.4.18 FileIdFullDirectoryInformation](https://msdn.microsoft.com/en-us/library/cc232071.aspx)
       class FileIdFullDirectoryInformation < BinData::Record
+        CLASS_LEVEL = FileInformation::FILE_ID_FULL_DIRECTORY_INFORMATION
+
         endian :little
 
         uint32           :next_offset,      label: 'Next Entry Offset'

--- a/lib/ruby_smb/fscc/file_information/file_names_information.rb
+++ b/lib/ruby_smb/fscc/file_information/file_names_information.rb
@@ -4,13 +4,6 @@ module RubySMB
       # The FileNamesInformation Class as defined in
       # [2.4.26 FileNamesInformation](https://msdn.microsoft.com/en-us/library/cc232077.aspx)
       class FileNamesInformation < BinData::Record
-        # The value set in the InformationLevel field of an SMB1 request to indicate
-        # the response should use this Information Class Structure.
-        SMB1_FLAG = 0x0103
-        # The value set in the InformationLevel field of an SMB2 request to indicate
-        # the response should use this Information Class Structure.
-        SMB2_FLAG = 0x0C
-
         endian :little
 
         uint32           :next_offset,      label: 'Next Entry Offset'

--- a/lib/ruby_smb/fscc/file_information/file_names_information.rb
+++ b/lib/ruby_smb/fscc/file_information/file_names_information.rb
@@ -4,6 +4,8 @@ module RubySMB
       # The FileNamesInformation Class as defined in
       # [2.4.26 FileNamesInformation](https://msdn.microsoft.com/en-us/library/cc232077.aspx)
       class FileNamesInformation < BinData::Record
+        CLASS_LEVEL = FileInformation::FILE_NAMES_INFORMATION
+
         endian :little
 
         uint32           :next_offset,      label: 'Next Entry Offset'

--- a/lib/ruby_smb/fscc/file_information/file_rename_information.rb
+++ b/lib/ruby_smb/fscc/file_information/file_rename_information.rb
@@ -4,23 +4,16 @@ module RubySMB
       # The FileRenameInformation Class as defined in
       # [2.4.34.2 FileRenameInformation](https://msdn.microsoft.com/en-us/library/cc704597.aspx)
       class FileRenameInformation < BinData::Record
-        # Null bytes because SMB1 Requests can't use this
-        # Information Class.
-        SMB1_FLAG = 0x0000
-        # The value set in the InformationLevel field of an SMB2 request to indicate
-        # the response should use this Information Class Structure.
-        SMB2_FLAG = 0x0A
-
         endian :little
-        
-        uint8  :replace_if_exists,  label: 'Replace If Exists', initial_value: 1
+
+        uint8  :replace_if_exists,  label: 'Replace If Exists'
         uint8  :reserved_0,         label: 'Reserved 0',        initial_value: 0
         uint16 :reserved_1,         label: 'Reserved 1',        initial_value: 0
         uint32 :reserved_2,         label: 'Reserved 2',        initial_value: 0
         uint64 :root_firectory,     label: 'Root Directory',    initial_value: 0
         uint32 :file_name_length,   label: 'File Name Length',  initial_value: -> { file_name.do_num_bytes }
         string :file_name,          label: 'File Name',           read_length: -> { file_name_length }
-        
+
       end
     end
   end

--- a/lib/ruby_smb/fscc/file_information/file_rename_information.rb
+++ b/lib/ruby_smb/fscc/file_information/file_rename_information.rb
@@ -4,6 +4,8 @@ module RubySMB
       # The FileRenameInformation Class as defined in
       # [2.4.34.2 FileRenameInformation](https://msdn.microsoft.com/en-us/library/cc704597.aspx)
       class FileRenameInformation < BinData::Record
+        CLASS_LEVEL = FileInformation::FILE_ID_FULL_DIRECTORY_INFORMATION
+
         endian :little
 
         uint8  :replace_if_exists,  label: 'Replace If Exists'

--- a/lib/ruby_smb/smb1/packet/trans2.rb
+++ b/lib/ruby_smb/smb1/packet/trans2.rb
@@ -4,7 +4,7 @@ module RubySMB
       # Namespace for the Transaction2 sub-protocol documented in
       # [2.2.4.46 SMB_COM_TRANSACTION2 (0x32)](https://msdn.microsoft.com/en-us/library/ee441652.aspx)
       module Trans2
-        require 'ruby_smb/smb1/packet/trans2/information_level'
+        require 'ruby_smb/smb1/packet/trans2/find_information_level'
         require 'ruby_smb/smb1/packet/trans2/data_block'
         require 'ruby_smb/smb1/packet/trans2/subcommands'
         require 'ruby_smb/smb1/packet/trans2/request'

--- a/lib/ruby_smb/smb1/packet/trans2/find_first2_request.rb
+++ b/lib/ruby_smb/smb1/packet/trans2/find_first2_request.rb
@@ -28,7 +28,7 @@ module RubySMB
             uint16    :information_level, label: 'Information Level'
             uint32    :storage_type,      label: 'Search Storage type'
 
-            choice :filename, :copy_on_change => true, selection: -> { @obj.parent.parent.parent.smb_header.flags2.unicode } do
+            choice :filename, :copy_on_change => true, selection: -> { self.smb_header.flags2.unicode } do
               stringz16 1, label: 'FileName'
               stringz   0, label: 'FileName'
             end

--- a/lib/ruby_smb/smb1/packet/trans2/find_first2_request.rb
+++ b/lib/ruby_smb/smb1/packet/trans2/find_first2_request.rb
@@ -27,7 +27,11 @@ module RubySMB
 
             uint16    :information_level, label: 'Information Level'
             uint32    :storage_type,      label: 'Search Storage type'
-            stringz16 :filename,          label: 'Filename'
+
+            choice :filename, :copy_on_change => true, selection: -> { @obj.parent.parent.parent.smb_header.flags2.unicode } do
+              stringz16 1, label: 'FileName'
+              stringz   0, label: 'FileName'
+            end
 
             # Returns the length of the Trans2Parameters struct
             # in number of bytes
@@ -38,7 +42,8 @@ module RubySMB
 
           # The Trans2 Data Blcok for this particular Subcommand
           class Trans2Data < BinData::Record
-            smb_gea_list :extended_attribute_list, label: 'Get Extended Attribute List'
+            smb_gea_list :extended_attribute_list, label: 'Get Extended Attribute List',
+              onlyif: -> { parent.trans2_parameters.information_level == FindInformationLevel::SMB_INFO_QUERY_EAS_FROM_LIST}
 
             # Returns the length of the Trans2Data struct
             # in number of bytes

--- a/lib/ruby_smb/smb1/packet/trans2/find_first2_response.rb
+++ b/lib/ruby_smb/smb1/packet/trans2/find_first2_response.rb
@@ -62,7 +62,7 @@ module RubySMB
           #
           # @param klass [Class] the FileInformationClass class to read the data as
           # @return [array<BinData::Record>] An array of structs holding the requested information
-          def results(klass)
+          def results(klass, unicode:)
             information_classes = []
             blob = data_block.trans2_data.buffer.to_binary_s.dup
             until blob.empty?
@@ -74,7 +74,9 @@ module RubySMB
                        blob.slice!(0, length)
                      end
 
-              information_classes << klass.read(data)
+              file_info = klass.new
+              file_info.unicode = unicode
+              information_classes << file_info.read(data)
             end
             information_classes
           end

--- a/lib/ruby_smb/smb1/packet/trans2/find_information_level.rb
+++ b/lib/ruby_smb/smb1/packet/trans2/find_information_level.rb
@@ -6,7 +6,7 @@ module RubySMB
         # TRANS2_FIND_NEXT2 (section 2.2.6.3) subcommand requests to indicate the level
         # of information that a server MUST respond with for each file matching the
         # request's search criteria.
-        module SmbInfo
+        module FindInformationLevel
           # Return creation, access, and last write timestamps, size and file attributes along with the file name.
           SMB_INFO_STANDARD                 = 0x0001
           # Return the SMB_INFO_STANDARD data along with the size of a file's extended attributes (EAs).
@@ -21,6 +21,10 @@ module RubySMB
           SMB_FIND_FILE_NAMES_INFO          = 0x0103
           # Returns a combination of the data from SMB_FIND_FILE_FULL_DIRECTORY_INFO and SMB_FIND_FILE_NAMES_INFO.
           SMB_FIND_FILE_BOTH_DIRECTORY_INFO = 0x0104
+
+
+          require 'ruby_smb/smb1/packet/trans2/find_information_level/find_file_full_directory_info'
+
         end
       end
     end

--- a/lib/ruby_smb/smb1/packet/trans2/find_information_level/find_file_full_directory_info.rb
+++ b/lib/ruby_smb/smb1/packet/trans2/find_information_level/find_file_full_directory_info.rb
@@ -1,0 +1,45 @@
+module RubySMB
+  module SMB1
+    module Packet
+      module Trans2
+        module FindInformationLevel
+          # The SMB_FIND_FILE_FULL_DIRECTORY_INFO class as defined in
+          # [2.2.8.1.5 SMB_FIND_FILE_FULL_DIRECTORY_INFO](https://msdn.microsoft.com/en-us/library/ff470042.aspx)
+          class FindFileFullDirectoryInfo < BinData::Record
+            CLASS_LEVEL = FindInformationLevel::SMB_FIND_FILE_FULL_DIRECTORY_INFO
+
+            endian :little
+
+            uint32                  :next_offset,         label: 'Next Entry Offset'
+            uint32                  :file_index,          label: 'File Index'
+            file_time               :create_time,         label: 'Create Time'
+            file_time               :last_access,         label: 'Last Accessed Time'
+            file_time               :last_write,          label: 'Last Write Time'
+            file_time               :last_change,         label: 'Last Attribute Change Time'
+            uint64                  :end_of_file,         label: 'End of File'
+            uint64                  :allocation_size,     label: 'Allocated Size'
+            smb_ext_file_attributes :ext_file_attributes, label: 'Extended File Attributes'
+            uint32                  :file_name_length,    label: 'File Name Length', initial_value: -> { file_name.do_num_bytes }
+            uint32                  :ea_size,             label: 'Extended Attributes Size'
+
+            choice :file_name, :copy_on_change => true, selection: -> { unicode } do
+              string16 true,  label: 'File Name', read_length: -> { file_name_length }
+              stringz  false, label: 'File Name', read_length: -> { file_name_length }
+            end
+
+            # Set unicode encoding for filename
+            # @!attribute [rw] unicode
+            #   @return [Boolean]
+            attr_accessor :unicode
+
+            def initialize_instance
+              super
+              @unicode = false
+            end
+
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby_smb/smb1/packet/trans2/find_next2_request.rb
+++ b/lib/ruby_smb/smb1/packet/trans2/find_next2_request.rb
@@ -28,7 +28,10 @@ module RubySMB
               bit8  :reserved2,   label: 'Reserved Space'
             end
 
-            stringz16 :filename, label: 'Filename'
+            choice :filename, :copy_on_change => true, selection: -> { @obj.parent.parent.parent.smb_header.flags2.unicode } do
+              stringz16 1, label: 'FileName'
+              stringz   0, label: 'FileName'
+            end
 
             # Returns the length of the Trans2Parameters struct
             # in number of bytes
@@ -39,7 +42,8 @@ module RubySMB
 
           # The Trans2 Data Blcok for this particular Subcommand
           class Trans2Data < BinData::Record
-            smb_gea_list :extended_attribute_list, label: 'Get Extended Attribute List'
+            smb_gea_list :extended_attribute_list, label: 'Get Extended Attribute List',
+              onlyif: -> { parent.trans2_parameters.information_level == FindInformationLevel::SMB_INFO_QUERY_EAS_FROM_LIST}
 
             # Returns the length of the Trans2Data struct
             # in number of bytes

--- a/lib/ruby_smb/smb1/packet/trans2/find_next2_response.rb
+++ b/lib/ruby_smb/smb1/packet/trans2/find_next2_response.rb
@@ -61,7 +61,7 @@ module RubySMB
           #
           # @param klass [Class] the FileInformationClass class to read the data as
           # @return [array<BinData::Record>] An array of structs holding the requested information
-          def results(klass)
+          def results(klass, unicode:)
             information_classes = []
             blob = data_block.trans2_data.buffer.to_binary_s.dup
             until blob.empty?
@@ -73,7 +73,9 @@ module RubySMB
                        blob.slice!(0, length)
                      end
 
-              information_classes << klass.read(data)
+              file_info = klass.new
+              file_info.unicode = unicode
+              information_classes << file_info.read(data)
             end
             information_classes
           end

--- a/lib/ruby_smb/smb1/packet/trans2/request.rb
+++ b/lib/ruby_smb/smb1/packet/trans2/request.rb
@@ -7,21 +7,21 @@ module RubySMB
         class Request < RubySMB::GenericPacket
           # The {RubySMB::SMB1::ParameterBlock} specific to this packet type.
           class ParameterBlock < RubySMB::SMB1::ParameterBlock
-            uint16 :total_parameter_count, label: 'Total Parameter Count(bytes)'
+            uint16        :total_parameter_count, label: 'Total Parameter Count(bytes)'
             uint16        :total_data_count,      label: 'Total Data Count(bytes)'
             uint16        :max_parameter_count,   label: 'Max Parameter Count(bytes)'
             uint16        :max_data_count,        label: 'Max Data Count(bytes)'
             uint8         :max_setup_count,       label: 'Max Setup Count'
-            uint8         :reserved,              label: 'Reserved Space', initial_value: 0x00
+            uint8         :reserved,              label: 'Reserved Space',         initial_value: 0x00
             trans2_flags  :flags
-            uint32        :timeout,               label: 'Timeout',                        initial_value: 0x00000000
-            uint16        :reserved2,             label: 'Reserved Space',                 initial_value: 0x00
-            uint16        :parameter_count,       label: 'Parameter Count(bytes)',         initial_value: -> { parent.data_block.trans2_parameters.length }
-            uint16        :parameter_offset,      label: 'Parameter Offset',               initial_value: -> { parent.data_block.trans2_parameters.abs_offset }
-            uint16        :data_count,            label: 'Data Count(bytes)',              initial_value: -> { parent.data_block.trans2_data.length }
-            uint16        :data_offset,           label: 'Data Offset',                    initial_value: -> { parent.data_block.trans2_data.abs_offset }
-            uint8         :setup_count,           label: 'Setup Count',                    initial_value: -> { setup.length }
-            uint8         :reserved3,             label: 'Reserved Space',                 initial_value: 0x00
+            uint32        :timeout,               label: 'Timeout',                initial_value: 0x00000000
+            uint16        :reserved2,             label: 'Reserved Space',         initial_value: 0x00
+            uint16        :parameter_count,       label: 'Parameter Count(bytes)', initial_value: -> { parent.data_block.trans2_parameters.length }
+            uint16        :parameter_offset,      label: 'Parameter Offset',       initial_value: -> { parent.data_block.trans2_parameters.abs_offset }
+            uint16        :data_count,            label: 'Data Count(bytes)',      initial_value: -> { parent.data_block.trans2_data.length }
+            uint16        :data_offset,           label: 'Data Offset',            initial_value: -> { parent.data_block.trans2_data.abs_offset }
+            uint8         :setup_count,           label: 'Setup Count',            initial_value: -> { setup.length }
+            uint8         :reserved3,             label: 'Reserved Space',         initial_value: 0x00
 
             array :setup, type: :uint16, initial_length: 0
           end

--- a/lib/ruby_smb/smb1/tree.rb
+++ b/lib/ruby_smb/smb1/tree.rb
@@ -168,8 +168,7 @@ module RubySMB
 
         while eos.zero?
           find_next_request = RubySMB::SMB1::Packet::Trans2::FindNext2Request.new
-          find_next_request.smb_header.tid              = id
-          find_next_request.smb_header.flags2.eas       = 1
+          find_next_request = set_header_fields(find_next_request)
           find_next_request.smb_header.flags2.unicode   = 1 if unicode
 
           t2_params                             = find_next_request.data_block.trans2_parameters

--- a/lib/ruby_smb/smb2.rb
+++ b/lib/ruby_smb/smb2.rb
@@ -6,6 +6,7 @@ module RubySMB
     # Protocol ID value. Translates to \xFESMB
     SMB2_PROTOCOL_ID = 0xFE534D42
 
+    require 'ruby_smb/smb2/info_type'
     require 'ruby_smb/smb2/commands'
     require 'ruby_smb/smb2/create_context'
     require 'ruby_smb/smb2/bit_field'

--- a/lib/ruby_smb/smb2/file.rb
+++ b/lib/ruby_smb/smb2/file.rb
@@ -147,13 +147,9 @@ module RubySMB
       #
       # @return [RubySMB::SMB2::Packet::SetInfoRequest] the set info packet
       def delete_packet
-        delete_request                      = set_header_fields(RubySMB::SMB2::Packet::SetInfoRequest.new)
-        file_disposition_information        = RubySMB::Fscc::FileInformation::FileDispositionInformation.new
-
-        delete_request.file_info_class      = RubySMB::Fscc::FileInformation::FileDispositionInformation::SMB2_FLAG
-        delete_request.buffer_length        = file_disposition_information.buffer_length
-        delete_request.buffer_offset        = file_disposition_information.buffer_offset
-        delete_request.buffer               = file_disposition_information.buffer
+        delete_request                       = set_header_fields(RubySMB::SMB2::Packet::SetInfoRequest.new)
+        delete_request.file_info_class       = RubySMB::Fscc::FileInformation::FILE_DISPOSITION_INFORMATION
+        delete_request.buffer.delete_pending = 1
         delete_request
       end
 
@@ -221,14 +217,9 @@ module RubySMB
       # @param new_file_name [String] the new name
       # @return [RubySMB::SMB2::Packet::SetInfoRequest] the set info packet
       def rename_packet(new_file_name)
-        file_rename_information                  = RubySMB::Fscc::FileInformation::FileRenameInformation.new
-        file_rename_information.file_name        = new_file_name.encode('utf-16le')
-        
-        rename_request                           = set_header_fields(RubySMB::SMB2::Packet::SetInfoRequest.new)
-        rename_request.file_info_class           = RubySMB::Fscc::FileInformation::FileRenameInformation::SMB2_FLAG
-        rename_request.buffer                    = file_rename_information.to_binary_s
-        rename_request.buffer_length             = file_rename_information.num_bytes
-        
+        rename_request                  = set_header_fields(RubySMB::SMB2::Packet::SetInfoRequest.new)
+        rename_request.file_info_class  = RubySMB::Fscc::FileInformation::FILE_RENAME_INFORMATION
+        rename_request.buffer.file_name = new_file_name.encode('utf-16le')
         rename_request
       end
 

--- a/lib/ruby_smb/smb2/info_type.rb
+++ b/lib/ruby_smb/smb2/info_type.rb
@@ -11,10 +11,10 @@ module RubySMB
       SMB2_0_INFO_FILESYSTEM = 0x02
 
       # The security information
-      SMB2_0_INFO_SECURITY   = 0x01
+      SMB2_0_INFO_SECURITY   = 0x03
 
       # The underlying object store quota information
-      SMB2_0_INFO_QUOTA      = 0x01
+      SMB2_0_INFO_QUOTA      = 0x04
     end
   end
 end

--- a/lib/ruby_smb/smb2/info_type.rb
+++ b/lib/ruby_smb/smb2/info_type.rb
@@ -1,0 +1,21 @@
+module RubySMB
+  module SMB2
+    # Contains constants for the InfoType values as defined in
+    # [2.2.39 SMB2 SET_INFO Request](https://msdn.microsoft.com/en-us/library/cc246560.aspx) and
+    # [2.2.37 SMB2 QUERY_INFO Request](https://msdn.microsoft.com/en-us/library/cc246557.aspx)
+    module InfoType
+      # The file information
+      SMB2_0_INFO_FILE       = 0x01
+
+      # The underlying object store information
+      SMB2_0_INFO_FILESYSTEM = 0x02
+
+      # The security information
+      SMB2_0_INFO_SECURITY   = 0x01
+
+      # The underlying object store quota information
+      SMB2_0_INFO_QUOTA      = 0x01
+    end
+  end
+end
+

--- a/lib/ruby_smb/smb2/packet/set_info_request.rb
+++ b/lib/ruby_smb/smb2/packet/set_info_request.rb
@@ -4,18 +4,49 @@ module RubySMB
       # An SMB2 Set Info Request Packet as defined in
       # [2.2.39 SMB2 SET_INFO Request](https://msdn.microsoft.com/en-us/library/cc246560.aspx)
       class SetInfoRequest < RubySMB::GenericPacket
+        include RubySMB::Fscc::FileInformation
+
         endian :little
 
-        smb2_header           :smb2_header
-        uint16                :structure_size,         label: 'Structure Size',         initial_value: 33
-        uint8                 :info_type,              label: 'Info Type',              initial_value: 0x01
-        uint8                 :file_info_class,        label: 'File Info Class'
-        uint32                :buffer_length,          label: 'Buffer Length'
-        uint16                :buffer_offset,          label: 'Buffer Offset',          initial_value: 96
-        uint16                :reserved,               label: 'Reserved',               initial_value: 0
-        uint32                :additional_information, label: 'Additional Information', initial_value: 0
-        smb2_fileid           :file_id,                label: 'File ID'
-        string                :buffer,                 label: 'Buffer'
+        smb2_header :smb2_header
+        uint16      :structure_size,  label: 'Structure Size', initial_value: 33
+        # Constants defined in RubySMB::SMB2::InfoType
+        uint8       :info_type,       label: 'Info Type',      initial_value: RubySMB::SMB2::InfoType::SMB2_0_INFO_FILE
+        uint8       :file_info_class, label: 'File Info Class'
+        uint32      :buffer_length,   label: 'Buffer Length',  initial_value: -> { buffer.do_num_bytes }
+        uint16      :buffer_offset,   label: 'Buffer Offset',  initial_value: -> { buffer.abs_offset }
+        uint16      :reserved,        label: 'Reserved',       initial_value: 0
+
+        struct :additional_information do
+          bit1  :reserved,                       label: 'Reserved Space'
+          bit1  :scope_security_information,     label: 'Scope Security Information'
+          bit1  :attribute_security_information, label: 'Attribute Security Information'
+          bit1  :label_security_information,     label: 'Label Security Information'
+          bit1  :sacl_security_information,      label: 'SACL Security Information'
+          bit1  :dacl_security_information,      label: 'DACL Security Information'
+          bit1  :group_security_information,     label: 'Group Security Information'
+          bit1  :owner_security_information,     label: 'Owner Security Information'
+          # byte boundary
+          bit8  :reserved2,                      label: 'Reserved Space'
+          # byte boundary
+          bit7  :reserved3,                      label: 'Reserved Space'
+          bit1  :backup_security_information,    label: 'Backup Security Information'
+          # byte boundary
+          bit8  :reserved4,                      label: 'Reserved Space'
+        end
+
+        smb2_fileid :file_id, label: 'File ID'
+
+        choice :buffer, label: 'Buffer', selection: -> { file_info_class } do
+          file_directory_information         FILE_DIRECTORY_INFORMATION,         label: 'File Directory Information'
+          file_full_directory_information    FILE_FULL_DIRECTORY_INFORMATION,    label: 'File Full Directory Information'
+          file_both_directory_information    FILE_BOTH_DIRECTORY_INFORMATION,    label: 'File Both Directory Information'
+          file_rename_information            FILE_RENAME_INFORMATION,            label: 'File Rename Information'
+          file_names_information             FILE_NAMES_INFORMATION,             label: 'File Names Information'
+          file_disposition_information       FILE_DISPOSITION_INFORMATION,       label: 'File Disposition Information'
+          file_id_both_directory_information FILE_ID_BOTH_DIRECTORY_INFORMATION, label: 'File Id Both Directory Information'
+          file_id_full_directory_information FILE_ID_FULL_DIRECTORY_INFORMATION, label: 'File Id Full Directory Information'
+        end
 
         def initialize_instance
           super

--- a/lib/ruby_smb/smb2/tree.rb
+++ b/lib/ruby_smb/smb2/tree.rb
@@ -107,7 +107,7 @@ module RubySMB
         file_id         = create_response.file_id
 
         directory_request                         = RubySMB::SMB2::Packet::QueryDirectoryRequest.new
-        directory_request.file_information_class  = type::SMB2_FLAG
+        directory_request.file_information_class  = type::CLASS_LEVEL
         directory_request.file_id                 = file_id
         directory_request.name                    = pattern
         directory_request.output_length           = 65_535

--- a/spec/lib/ruby_smb/field/smb_gea_list_spec.rb
+++ b/spec/lib/ruby_smb/field/smb_gea_list_spec.rb
@@ -21,14 +21,17 @@ RSpec.describe RubySMB::Field::SmbGeaList do
   describe '#size_of_list' do
     it 'shows the size, in bytes, of the fea_list' do
       list.gea_list << gea1
-      expect(list.size_of_list).to eq gea1.do_num_bytes
+      total_size = list.size_of_list.do_num_bytes + gea1.do_num_bytes
+      expect(list.size_of_list).to eq total_size
     end
 
     it 'changes dynamically as new GEAs are added' do
       list.gea_list << gea1
-      expect(list.size_of_list).to eq gea1.do_num_bytes
+      total_size = list.size_of_list.do_num_bytes + gea1.do_num_bytes
+      expect(list.size_of_list).to eq total_size
       list.gea_list << gea2
-      expect(list.size_of_list).to eq(gea1.do_num_bytes + gea2.do_num_bytes)
+      total_size += gea2.do_num_bytes
+      expect(list.size_of_list).to eq total_size
     end
   end
 end

--- a/spec/lib/ruby_smb/fscc/file_information/file_both_directory_information_spec.rb
+++ b/spec/lib/ruby_smb/fscc/file_information/file_both_directory_information_spec.rb
@@ -1,6 +1,11 @@
 require 'spec_helper'
 
 RSpec.describe RubySMB::Fscc::FileInformation::FileBothDirectoryInformation do
+  it 'references the correct class level' do
+    expect(described_class).to be_const_defined(:CLASS_LEVEL)
+    expect(described_class::CLASS_LEVEL).to be RubySMB::Fscc::FileInformation::FILE_BOTH_DIRECTORY_INFORMATION
+  end
+
   subject(:struct) { described_class.new }
 
   it { should respond_to :next_offset }

--- a/spec/lib/ruby_smb/fscc/file_information/file_directory_information_spec.rb
+++ b/spec/lib/ruby_smb/fscc/file_information/file_directory_information_spec.rb
@@ -1,6 +1,11 @@
 require 'spec_helper'
 
 RSpec.describe RubySMB::Fscc::FileInformation::FileDirectoryInformation do
+  it 'references the correct class level' do
+    expect(described_class).to be_const_defined(:CLASS_LEVEL)
+    expect(described_class::CLASS_LEVEL).to be RubySMB::Fscc::FileInformation::FILE_DIRECTORY_INFORMATION
+  end
+
   subject(:struct) { described_class.new }
 
   it { should respond_to :next_offset }

--- a/spec/lib/ruby_smb/fscc/file_information/file_disposition_information_spec.rb
+++ b/spec/lib/ruby_smb/fscc/file_information/file_disposition_information_spec.rb
@@ -3,11 +3,19 @@ require 'spec_helper'
 RSpec.describe RubySMB::Fscc::FileInformation::FileDispositionInformation do
   subject(:struct) { described_class.new }
 
-  it { should respond_to :buffer_length }
-  it { should respond_to :buffer_offset }
-  it { should respond_to :buffer }
+  it { should respond_to :delete_pending }
 
   it 'is little endian' do
     expect(described_class.fields.instance_variable_get(:@hints)[:endian]).to eq :little
+  end
+
+  describe '#delete_pending' do
+    it 'is a 8-bit field' do
+      expect(struct.delete_pending).to be_a BinData::Uint8
+    end
+
+    it 'should have a default value of 0' do
+      expect(struct.delete_pending).to eq 0
+    end
   end
 end

--- a/spec/lib/ruby_smb/fscc/file_information/file_disposition_information_spec.rb
+++ b/spec/lib/ruby_smb/fscc/file_information/file_disposition_information_spec.rb
@@ -1,6 +1,11 @@
 require 'spec_helper'
 
 RSpec.describe RubySMB::Fscc::FileInformation::FileDispositionInformation do
+  it 'references the correct class level' do
+    expect(described_class).to be_const_defined(:CLASS_LEVEL)
+    expect(described_class::CLASS_LEVEL).to be RubySMB::Fscc::FileInformation::FILE_DISPOSITION_INFORMATION
+  end
+
   subject(:struct) { described_class.new }
 
   it { should respond_to :delete_pending }

--- a/spec/lib/ruby_smb/fscc/file_information/file_full_directory_information_spec.rb
+++ b/spec/lib/ruby_smb/fscc/file_information/file_full_directory_information_spec.rb
@@ -1,6 +1,11 @@
 require 'spec_helper'
 
 RSpec.describe RubySMB::Fscc::FileInformation::FileFullDirectoryInformation do
+  it 'references the correct class level' do
+    expect(described_class).to be_const_defined(:CLASS_LEVEL)
+    expect(described_class::CLASS_LEVEL).to be RubySMB::Fscc::FileInformation::FILE_FULL_DIRECTORY_INFORMATION
+  end
+
   subject(:struct) { described_class.new }
 
   it { should respond_to :next_offset }

--- a/spec/lib/ruby_smb/fscc/file_information/file_id_both_directory_information_spec.rb
+++ b/spec/lib/ruby_smb/fscc/file_information/file_id_both_directory_information_spec.rb
@@ -1,6 +1,11 @@
 require 'spec_helper'
 
 RSpec.describe RubySMB::Fscc::FileInformation::FileIdBothDirectoryInformation do
+  it 'references the correct class level' do
+    expect(described_class).to be_const_defined(:CLASS_LEVEL)
+    expect(described_class::CLASS_LEVEL).to be RubySMB::Fscc::FileInformation::FILE_ID_BOTH_DIRECTORY_INFORMATION
+  end
+
   subject(:struct) { described_class.new }
 
   it { should respond_to :next_offset }

--- a/spec/lib/ruby_smb/fscc/file_information/file_id_full_directory_information_spec.rb
+++ b/spec/lib/ruby_smb/fscc/file_information/file_id_full_directory_information_spec.rb
@@ -1,6 +1,11 @@
 require 'spec_helper'
 
 RSpec.describe RubySMB::Fscc::FileInformation::FileIdFullDirectoryInformation do
+  it 'references the correct class level' do
+    expect(described_class).to be_const_defined(:CLASS_LEVEL)
+    expect(described_class::CLASS_LEVEL).to be RubySMB::Fscc::FileInformation::FILE_ID_FULL_DIRECTORY_INFORMATION
+  end
+
   subject(:struct) { described_class.new }
 
   it { should respond_to :next_offset }

--- a/spec/lib/ruby_smb/fscc/file_information/file_names_information_spec.rb
+++ b/spec/lib/ruby_smb/fscc/file_information/file_names_information_spec.rb
@@ -1,6 +1,11 @@
 require 'spec_helper'
 
 RSpec.describe RubySMB::Fscc::FileInformation::FileNamesInformation do
+  it 'references the correct class level' do
+    expect(described_class).to be_const_defined(:CLASS_LEVEL)
+    expect(described_class::CLASS_LEVEL).to be RubySMB::Fscc::FileInformation::FILE_NAMES_INFORMATION
+  end
+
   subject(:struct) { described_class.new }
 
   it { should respond_to :next_offset }

--- a/spec/lib/ruby_smb/fscc/file_information/file_rename_information_spec.rb
+++ b/spec/lib/ruby_smb/fscc/file_information/file_rename_information_spec.rb
@@ -1,6 +1,11 @@
 require 'spec_helper'
 
 RSpec.describe RubySMB::Fscc::FileInformation::FileRenameInformation do
+  it 'references the correct class level' do
+    expect(described_class).to be_const_defined(:CLASS_LEVEL)
+    expect(described_class::CLASS_LEVEL).to be RubySMB::Fscc::FileInformation::FILE_ID_FULL_DIRECTORY_INFORMATION
+  end
+
   subject(:struct) { described_class.new }
 
   it { should respond_to :replace_if_exists }

--- a/spec/lib/ruby_smb/fscc/file_information/file_rename_information_spec.rb
+++ b/spec/lib/ruby_smb/fscc/file_information/file_rename_information_spec.rb
@@ -15,17 +15,6 @@ RSpec.describe RubySMB::Fscc::FileInformation::FileRenameInformation do
     expect(described_class.fields.instance_variable_get(:@hints)[:endian]).to eq :little
   end
 
-  it 'tracks the length of the file_name field' do
-    struct.file_name = 'Hello.txt'
-    expect(struct.file_name_length).to eq struct.file_name.do_num_bytes
-  end
-
-  it 'encodes the file name in UTF-16LE' do
-    name = 'Hello_world.txt'
-    struct.file_name = name
-    expect(struct.file_name.encode('utf-16le')).to eq name.encode('utf-16le')
-  end
-
   describe 'reading in from a blob' do
     it 'uses the file_name_length to know when to stop reading' do
       name = 'Hello_world.txt'
@@ -33,7 +22,44 @@ RSpec.describe RubySMB::Fscc::FileInformation::FileRenameInformation do
       blob = struct.to_binary_s
       blob << 'AAAA'
       new_from_blob = described_class.read(blob)
-      expect(new_from_blob.file_name.encode('utf-16le')).to eq name.encode('utf-16le')
+      expect(new_from_blob.file_name).to eq name
+    end
+  end
+
+  describe '#replace_if_exists' do
+    it 'is a 8-bit field' do
+      expect(struct.replace_if_exists).to be_a BinData::Uint8
+    end
+  end
+
+  describe '#root_firectory' do
+    it 'is a 64-bit field' do
+      expect(struct.root_firectory).to be_a BinData::Uint64le
+    end
+
+    it 'should have a default value of 0' do
+      expect(struct.root_firectory).to eq 0
+    end
+  end
+
+  describe '#file_name_length' do
+    it 'is a 32-bit field' do
+      expect(struct.file_name_length).to be_a BinData::Uint32le
+    end
+
+    it 'should have a default value of 0' do
+      expect(struct.file_name_length).to eq 0
+    end
+
+    it 'tracks the length of the file_name field' do
+      struct.file_name = 'Hello.txt'
+      expect(struct.file_name_length).to eq struct.file_name.do_num_bytes
+    end
+  end
+
+  describe '#file_name' do
+    it 'is a string field' do
+      expect(struct.file_name).to be_a BinData::String
     end
   end
 end

--- a/spec/lib/ruby_smb/smb1/packet/trans2/find_information_level/find_file_full_directory_info_spec.rb
+++ b/spec/lib/ruby_smb/smb1/packet/trans2/find_information_level/find_file_full_directory_info_spec.rb
@@ -1,0 +1,128 @@
+RSpec.describe RubySMB::SMB1::Packet::Trans2::FindInformationLevel::FindFileFullDirectoryInfo do
+  it 'references the correct class level' do
+    expect(described_class).to be_const_defined(:CLASS_LEVEL)
+    expect(described_class::CLASS_LEVEL).to be RubySMB::SMB1::Packet::Trans2::FindInformationLevel::SMB_FIND_FILE_FULL_DIRECTORY_INFO
+  end
+
+  subject(:struct) { described_class.new }
+
+  it { should respond_to :next_offset }
+  it { should respond_to :file_index }
+  it { should respond_to :create_time }
+  it { should respond_to :last_access }
+  it { should respond_to :last_write }
+  it { should respond_to :last_change }
+  it { should respond_to :end_of_file }
+  it { should respond_to :allocation_size }
+  it { should respond_to :ext_file_attributes }
+  it { should respond_to :file_name_length }
+  it { should respond_to :ea_size }
+  it { should respond_to :file_name }
+  it { should respond_to :unicode }
+
+  it 'is little endian' do
+    expect(described_class.fields.instance_variable_get(:@hints)[:endian]).to eq :little
+  end
+
+  describe '#next_offset' do
+    it 'is a 32-bit field' do
+      expect(struct.next_offset).to be_a BinData::Uint32le
+    end
+  end
+
+  describe '#file_index' do
+    it 'is a 32-bit field' do
+      expect(struct.file_index).to be_a BinData::Uint32le
+    end
+  end
+
+  describe '#create_time' do
+    it 'is a Filetime field' do
+      expect(struct.create_time).to be_a RubySMB::Field::FileTime
+    end
+  end
+
+  describe '#last_access' do
+    it 'is a Filetime field' do
+      expect(struct.last_access).to be_a RubySMB::Field::FileTime
+    end
+  end
+
+  describe '#last_write' do
+    it 'is a Filetime field' do
+      expect(struct.last_write).to be_a RubySMB::Field::FileTime
+    end
+  end
+
+  describe '#last_change' do
+    it 'is a Filetime field' do
+      expect(struct.last_change).to be_a RubySMB::Field::FileTime
+    end
+  end
+
+  describe '#end_of_file' do
+    it 'is a 64-bit field' do
+      expect(struct.end_of_file).to be_a BinData::Uint64le
+    end
+  end
+
+  describe '#ext_file_attributes' do
+    it 'contains the extended file attributes of the file' do
+      expect(struct.ext_file_attributes).to be_a RubySMB::SMB1::BitField::SmbExtFileAttributes
+    end
+  end
+
+  describe '#file_name_length' do
+    it 'is a 32-bit field' do
+      expect(struct.file_name_length).to be_a BinData::Uint32le
+    end
+
+    it 'tracks the length of the file_name field including the null-terminating character when unicode is not set' do
+      filename = "Hello.txt"
+      struct.file_name = filename
+      expect(struct.file_name_length).to eq (filename.bytes.size + 1)
+    end
+
+    it 'tracks the length of the file_name field without null-terminating characters when unicode is set' do
+      filename = "Hello.txt"
+      struct.unicode = true
+      struct.file_name = filename
+      expect(struct.file_name_length).to eq (filename.encode('UTF-16LE').bytes.size)
+    end
+  end
+
+  describe '#ea_size' do
+    it 'is a 32-bit field' do
+      expect(struct.ea_size).to be_a BinData::Uint32le
+    end
+  end
+
+  describe '#file_name' do
+    let(:filename) { "Hello.txt" }
+
+    before :example do
+      struct.file_name = filename
+    end
+
+    it 'is an unicode string field when unicode attribute is set to true' do
+      struct.unicode = true
+      expect(struct.file_name.encoding.name).to eq 'UTF-16LE'
+    end
+
+    it 'is an ASCII-8BIT field when unicode attribute is set to false' do
+      expect(struct.file_name.encoding.name).to eq 'ASCII-8BIT'
+    end
+
+    it 'is null-terminated when unicode attribute is set to false' do
+      expect(struct.file_name.to_binary_s).to eq "#{filename}\x00"
+    end
+  end
+
+  describe '#unicode' do
+    it 'is set to false by default' do
+      expect(struct.unicode).to be false
+    end
+  end
+
+end
+

--- a/spec/lib/ruby_smb/smb1/packet/trans2/find_next2_request_spec.rb
+++ b/spec/lib/ruby_smb/smb1/packet/trans2/find_next2_request_spec.rb
@@ -112,14 +112,37 @@ RSpec.describe RubySMB::SMB1::Packet::Trans2::FindNext2Request do
 
       describe '#filename' do
         let(:name) { 'hello.txt' }
-        it 'should be null terminated' do
+
+        before :example do
           parameters.filename = name
-          expect(parameters.filename.to_binary_s).to end_with("\x00\x00")
         end
 
-        it 'should be UTF-16le' do
-          parameters.filename = name
-          expect(parameters.filename).to eq name.encode('UTF-16le')
+        context 'when unicode flag is set' do
+          before :example do
+            packet.smb_header.flags2.unicode = 1
+          end
+
+          it 'is terminated with unicode null-termination character' do
+            expect(parameters.filename.to_binary_s).to end_with("\x00\x00")
+          end
+
+          it 'is UTF-16LE encoded' do
+            expect(parameters.filename.encoding.name).to eq 'UTF-16LE'
+          end
+        end
+
+        context 'when unicode flag is not set' do
+          before :example do
+            packet.smb_header.flags2.unicode = 0
+          end
+
+          it 'is terminated with ASCII null-termination character' do
+            expect(parameters.filename.to_binary_s).to end_with("\x00")
+          end
+
+          it 'is ASCII-8BIT encoded' do
+            expect(parameters.filename.encoding.name).to eq 'ASCII-8BIT'
+          end
         end
       end
     end
@@ -132,6 +155,18 @@ RSpec.describe RubySMB::SMB1::Packet::Trans2::FindNext2Request do
       describe '#extended_attribute_list' do
         it 'is an smb_gea_list' do
           expect(data.extended_attribute_list).to be_a RubySMB::Field::SmbGeaList
+        end
+
+        it 'only exists if the information level is SMB_INFO_QUERY_EAS_FROM_LIST' do
+          data_block.trans2_parameters.information_level =
+            RubySMB::SMB1::Packet::Trans2::FindInformationLevel::SMB_INFO_QUERY_EAS_FROM_LIST
+          expect(data.do_num_bytes).to eq RubySMB::Field::SmbGeaList.new.do_num_bytes
+        end
+
+        it 'does not exist if the information level is SMB_INFO_STANDARD' do
+          data_block.trans2_parameters.information_level =
+            RubySMB::SMB1::Packet::Trans2::FindInformationLevel::SMB_INFO_STANDARD
+          expect(data.do_num_bytes).to eq 0
         end
       end
     end

--- a/spec/lib/ruby_smb/smb1/packet/trans2/find_next2_response_spec.rb
+++ b/spec/lib/ruby_smb/smb1/packet/trans2/find_next2_response_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+include RubySMB::SMB1::Packet::Trans2::FindInformationLevel
+
 RSpec.describe RubySMB::SMB1::Packet::Trans2::FindNext2Response do
   subject(:packet) { described_class.new }
 
@@ -60,14 +62,14 @@ RSpec.describe RubySMB::SMB1::Packet::Trans2::FindNext2Response do
 
   describe '#results' do
     let(:names1) {
-      names = RubySMB::Fscc::FileInformation::FileNamesInformation.new
+      names = FindFileFullDirectoryInfo.new
       names.file_name = 'test.txt'
       names.next_offset = names.do_num_bytes
       names
     }
 
     let(:names2) {
-      names = RubySMB::Fscc::FileInformation::FileNamesInformation.new
+      names = FindFileFullDirectoryInfo.new
       names.file_name = '..'
       names
     }
@@ -76,9 +78,25 @@ RSpec.describe RubySMB::SMB1::Packet::Trans2::FindNext2Response do
 
     let(:names_blob) { names_array.collect(&:to_binary_s).join('') }
 
-    it 'returns an array of parsed Fileinformation structs' do
+    it 'returns an array of parsed FindFileFullDirectoryInfo structs' do
       packet.data_block.trans2_data.buffer = names_blob
-      expect(packet.results(RubySMB::Fscc::FileInformation::FileNamesInformation)).to eq names_array
+      expect(packet.results(FindFileFullDirectoryInfo, unicode: false)).to eq names_array
+    end
+
+    it 'sets the FindFileFullDirectoryInfo unicode attribute when unicode argument is true' do
+      packet.data_block.trans2_data.buffer = names1.to_binary_s
+      find_info = FindFileFullDirectoryInfo.new
+      allow(FindFileFullDirectoryInfo).to receive(:new).and_return find_info
+      expect(find_info).to receive(:unicode=).with(true).once
+      packet.results(FindFileFullDirectoryInfo, unicode: true)
+    end
+
+    it 'does not set the FindFileFullDirectoryInfo unicode attribute when unicode argument is false' do
+      packet.data_block.trans2_data.buffer = names1.to_binary_s
+      find_info = FindFileFullDirectoryInfo.new
+      allow(FindFileFullDirectoryInfo).to receive(:new).and_return find_info
+      expect(find_info).to receive(:unicode=).with(false).once
+      packet.results(FindFileFullDirectoryInfo, unicode: false)
     end
   end
 end

--- a/spec/lib/ruby_smb/smb2/file_spec.rb
+++ b/spec/lib/ruby_smb/smb2/file_spec.rb
@@ -174,7 +174,11 @@ RSpec.describe RubySMB::SMB2::File do
     end
 
     it 'sets the file_info_class of the packet' do
-      expect(file.delete_packet.file_info_class).to eq 13
+      expect(file.delete_packet.file_info_class).to eq RubySMB::Fscc::FileInformation::FILE_DISPOSITION_INFORMATION
+    end
+
+    it 'sets the delete_pending field to 1' do
+      expect(file.delete_packet.buffer.delete_pending).to eq 1
     end
   end
 
@@ -204,7 +208,12 @@ RSpec.describe RubySMB::SMB2::File do
     end
 
     it 'sets the file_info_class of the packet' do
-      expect(file.rename_packet('new_file.txt').file_info_class).to eq 0x0A
+      expect(file.rename_packet('new_file.txt').file_info_class).to eq RubySMB::Fscc::FileInformation::FILE_RENAME_INFORMATION
+    end
+
+    it 'sets the file_name field to the unicode-encoded new file name' do
+      filename = "new_file.txt"
+      expect(file.rename_packet(filename).buffer.file_name).to eq filename.encode('UTF-16LE').force_encoding('ASCII-8BIT')
     end
   end
 

--- a/spec/lib/ruby_smb/smb2/packet/set_info_request_spec.rb
+++ b/spec/lib/ruby_smb/smb2/packet/set_info_request_spec.rb
@@ -21,11 +21,11 @@ RSpec.describe RubySMB::SMB2::Packet::SetInfoRequest do
   describe '#smb2_header' do
     subject(:header) { packet.smb2_header }
 
-    it 'is a standard SMB Header' do
+    it 'is a standard SMB2 Header' do
       expect(header).to be_a RubySMB::SMB2::SMB2Header
     end
 
-    it 'should have the command set to SMB_COM_NEGOTIATE' do
+    it 'should have the command set to SMB_INFO' do
       expect(header.command).to eq RubySMB::SMB2::Commands::SET_INFO
     end
 
@@ -34,7 +34,172 @@ RSpec.describe RubySMB::SMB2::Packet::SetInfoRequest do
     end
   end
 
-  it 'should have a structure size of 49' do
-    expect(packet.structure_size).to eq 33
+  describe '#structure_size' do
+    it 'is a 16-bit field' do
+      expect(packet.structure_size).to be_a BinData::Uint16le
+    end
+
+    it 'has a default value of 33' do
+      expect(packet.structure_size).to eq 33
+    end
   end
+
+  describe '#info_type' do
+    it 'is a 8-bit field' do
+      expect(packet.info_type).to be_a BinData::Uint8
+    end
+
+   it 'has a default value of SMB2_0_INFO_FILE' do
+      expect(packet.info_type).to eq RubySMB::SMB2::InfoType::SMB2_0_INFO_FILE
+    end
+  end
+
+  describe '#file_info_class' do
+    it 'is a 8-bit field' do
+      expect(packet.file_info_class).to be_a BinData::Uint8
+    end
+  end
+
+  describe '#buffer_length' do
+    it 'is a 32-bit field' do
+      expect(packet.buffer_length).to be_a BinData::Uint32le
+    end
+
+    it 'is set to the buffer size' do
+      packet.file_info_class = RubySMB::Fscc::FileInformation::FILE_FULL_DIRECTORY_INFORMATION
+      expect(packet.buffer_length).to eq packet.buffer.do_num_bytes
+    end
+  end
+
+  describe '#buffer_offset' do
+    it 'is a 16-bit field' do
+      expect(packet.buffer_offset).to be_a BinData::Uint16le
+    end
+
+    it 'is set to the buffer size' do
+      packet.file_info_class = RubySMB::Fscc::FileInformation::FILE_FULL_DIRECTORY_INFORMATION
+      expect(packet.buffer_offset).to eq packet.buffer.abs_offset
+    end
+  end
+
+  describe '#additional_information' do
+    subject(:additional_information) { packet.additional_information }
+
+    it { is_expected.to respond_to :scope_security_information }
+    it { is_expected.to respond_to :attribute_security_information }
+    it { is_expected.to respond_to :label_security_information }
+    it { is_expected.to respond_to :sacl_security_information }
+    it { is_expected.to respond_to :dacl_security_information }
+    it { is_expected.to respond_to :group_security_information }
+    it { is_expected.to respond_to :owner_security_information }
+    it { is_expected.to respond_to :backup_security_information }
+
+    describe '#scope_security_information' do
+      it 'should be a 1-bit field per the SMB spec' do
+        expect(additional_information.scope_security_information).to be_a BinData::Bit1
+      end
+
+      it_behaves_like 'bit field with one flag set', :scope_security_information, 'V', 0x00000040
+    end
+
+    describe '#attribute_security_information' do
+      it 'should be a 1-bit field per the SMB spec' do
+        expect(additional_information.attribute_security_information).to be_a BinData::Bit1
+      end
+
+      it_behaves_like 'bit field with one flag set', :attribute_security_information, 'V', 0x00000020
+    end
+
+    describe '#label_security_information' do
+      it 'should be a 1-bit field per the SMB spec' do
+        expect(additional_information.label_security_information).to be_a BinData::Bit1
+      end
+
+      it_behaves_like 'bit field with one flag set', :label_security_information, 'V', 0x00000010
+    end
+
+    describe '#sacl_security_information' do
+      it 'should be a 1-bit field per the SMB spec' do
+        expect(additional_information.sacl_security_information).to be_a BinData::Bit1
+      end
+
+      it_behaves_like 'bit field with one flag set', :sacl_security_information, 'V', 0x00000008
+    end
+
+    describe '#dacl_security_information' do
+      it 'should be a 1-bit field per the SMB spec' do
+        expect(additional_information.dacl_security_information).to be_a BinData::Bit1
+      end
+
+      it_behaves_like 'bit field with one flag set', :dacl_security_information, 'V', 0x00000004
+    end
+
+    describe '#group_security_information' do
+      it 'should be a 1-bit field per the SMB spec' do
+        expect(additional_information.group_security_information).to be_a BinData::Bit1
+      end
+
+      it_behaves_like 'bit field with one flag set', :group_security_information, 'V', 0x00000002
+    end
+
+    describe '#owner_security_information' do
+      it 'should be a 1-bit field per the SMB spec' do
+        expect(additional_information.owner_security_information).to be_a BinData::Bit1
+      end
+
+      it_behaves_like 'bit field with one flag set', :owner_security_information, 'V', 0x00000001
+    end
+
+    describe '#backup_security_information' do
+      it 'should be a 1-bit field per the SMB spec' do
+        expect(additional_information.backup_security_information).to be_a BinData::Bit1
+      end
+
+      it_behaves_like 'bit field with one flag set', :backup_security_information, 'V', 0x00010000
+    end
+  end
+
+  describe '#file_id' do
+    it 'is a Smb2Fileid field' do
+      expect(packet.file_id).to be_a RubySMB::Field::Smb2Fileid
+    end
+  end
+
+  describe '#buffer' do
+    context 'when file_info_class is set' do
+      it 'is set to a FileDirectoryInformation class with the FILE_DIRECTORY_INFORMATION code' do
+        packet.file_info_class = RubySMB::Fscc::FileInformation::FILE_DIRECTORY_INFORMATION
+        expect(packet.buffer).to eq RubySMB::Fscc::FileInformation::FileDirectoryInformation.new
+      end
+      it 'is set to a FileFullDirectoryInformation class with the FILE_FULL_DIRECTORY_INFORMATION code' do
+        packet.file_info_class = RubySMB::Fscc::FileInformation::FILE_FULL_DIRECTORY_INFORMATION
+        expect(packet.buffer).to eq RubySMB::Fscc::FileInformation::FileFullDirectoryInformation.new
+      end
+      it 'is set to a FileDispositionInformation class with the FILE_DISPOSITION_INFORMATION code' do
+        packet.file_info_class = RubySMB::Fscc::FileInformation::FILE_DISPOSITION_INFORMATION
+        expect(packet.buffer).to eq RubySMB::Fscc::FileInformation::FileDispositionInformation.new
+      end
+      it 'is set to a FileIdFullDirectoryInformation class with the FILE_ID_FULL_DIRECTORY_INFORMATION code' do
+        packet.file_info_class = RubySMB::Fscc::FileInformation::FILE_ID_FULL_DIRECTORY_INFORMATION
+        expect(packet.buffer).to eq RubySMB::Fscc::FileInformation::FileIdFullDirectoryInformation.new
+      end
+      it 'is set to a FileBothDirectoryInformation class with the FILE_BOTH_DIRECTORY_INFORMATION code' do
+        packet.file_info_class = RubySMB::Fscc::FileInformation::FILE_BOTH_DIRECTORY_INFORMATION
+        expect(packet.buffer).to eq RubySMB::Fscc::FileInformation::FileBothDirectoryInformation.new
+      end
+      it 'is set to a FileIdBothDirectoryInformation class with the FILE_ID_BOTH_DIRECTORY_INFORMATION code' do
+        packet.file_info_class = RubySMB::Fscc::FileInformation::FILE_ID_BOTH_DIRECTORY_INFORMATION
+        expect(packet.buffer).to eq RubySMB::Fscc::FileInformation::FileIdBothDirectoryInformation.new
+      end
+      it 'is set to a FileNamesInformation class with the FILE_NAMES_INFORMATION code' do
+        packet.file_info_class = RubySMB::Fscc::FileInformation::FILE_NAMES_INFORMATION
+        expect(packet.buffer).to eq RubySMB::Fscc::FileInformation::FileNamesInformation.new
+      end
+      it 'is set to a FileRenameInformation class with the FILE_RENAME_INFORMATION code' do
+        packet.file_info_class = RubySMB::Fscc::FileInformation::FILE_RENAME_INFORMATION
+        expect(packet.buffer).to eq RubySMB::Fscc::FileInformation::FileRenameInformation.new
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
This PR updates SMB2 rename and delete functionalities.
I also needed to update SMB1 and SMB2 Tree list methods.

This fixes #113.

# Verification Steps
- [x] `bundle install`
- [x] Verify you can rename a file with `ruby examples/rename_file.rb <ip-address> <username> <password> <share> <filename> <new filename>`
- [x] Verify you can delete a file with `ruby examples/delete_file.rb <ip-address> <username> <password> <share> <filename>`
- [x] Verify you can list files from a directory with `ruby examples/list_directory.rb <ip-address> <username> <password> <share> <directory>`
## `rake spec`
- [x] `rake spec`
- [x] VERIFY no failures
