### PR TITLE
Add SMB1 file delete and rename functionalities

### DIFF
--- a/examples/delete_file.rb
+++ b/examples/delete_file.rb
@@ -19,7 +19,7 @@ path     = "\\\\#{address}\\#{share}"
 sock = TCPSocket.new address, 445
 dispatcher = RubySMB::Dispatcher::Socket.new(sock)
 
-client = RubySMB::Client.new(dispatcher, smb1: false, smb2: true, username: username, password: password)
+client = RubySMB::Client.new(dispatcher, smb1: true, smb2: true, username: username, password: password)
 
 protocol = client.negotiate
 status = client.authenticate

--- a/examples/rename_file.rb
+++ b/examples/rename_file.rb
@@ -20,7 +20,7 @@ path     = "\\\\#{address}\\#{share}"
 sock = TCPSocket.new address, 445
 dispatcher = RubySMB::Dispatcher::Socket.new(sock)
 
-client = RubySMB::Client.new(dispatcher, smb1: false, smb2: true, username: username, password: password)
+client = RubySMB::Client.new(dispatcher, smb1: true, smb2: true, username: username, password: password)
 
 protocol = client.negotiate
 status = client.authenticate

--- a/lib/ruby_smb/fscc/file_information.rb
+++ b/lib/ruby_smb/fscc/file_information.rb
@@ -38,6 +38,15 @@ module RubySMB
       FILE_ID_FULL_DIRECTORY_INFORMATION = 0x26
 
 
+      # These Information Classes can be used by SMB1 using the pass-through
+      # Information Levels when available on the server (CAP_INFOLEVEL_PASSTHRU
+      # capability flag in an SMB_COM_NEGOTIATE server response). The constant
+      # SMB_INFO_PASSTHROUGH needs to be added to access these Information
+      # Levels. This is documented in
+      # [2.2.2.3.5 Pass-through Information Level Codes](https://msdn.microsoft.com/en-us/library/ff470158.aspx)
+      SMB_INFO_PASSTHROUGH               = 0x03e8
+
+
       require 'ruby_smb/fscc/file_information/file_directory_information'
       require 'ruby_smb/fscc/file_information/file_full_directory_information'
       require 'ruby_smb/fscc/file_information/file_disposition_information'

--- a/lib/ruby_smb/fscc/file_information/file_rename_information.rb
+++ b/lib/ruby_smb/fscc/file_information/file_rename_information.rb
@@ -8,13 +8,35 @@ module RubySMB
 
         endian :little
 
-        uint8  :replace_if_exists,  label: 'Replace If Exists'
-        uint8  :reserved_0,         label: 'Reserved 0',        initial_value: 0
-        uint16 :reserved_1,         label: 'Reserved 1',        initial_value: 0
-        uint32 :reserved_2,         label: 'Reserved 2',        initial_value: 0
-        uint64 :root_firectory,     label: 'Root Directory',    initial_value: 0
-        uint32 :file_name_length,   label: 'File Name Length',  initial_value: -> { file_name.do_num_bytes }
-        string :file_name,          label: 'File Name',           read_length: -> { file_name_length }
+        uint8  :replace_if_exists, label: 'Replace If Exists'
+
+        choice :reserved, selection: -> { get_smb_version } do
+          uint24 1, label: 'Reserved Space'
+          uint56 2, label: 'Reserved Space'
+        end
+
+        choice :root_directory, selection: -> { get_smb_version } do
+          uint32 1, label: 'Root Directory', initial_value: 0
+          uint64 2, label: 'Root Directory', initial_value: 0
+        end
+
+        uint32 :file_name_length, label: 'File Name Length', initial_value: -> { file_name.do_num_bytes }
+        string :file_name,        label: 'File Name',        read_length: -> { file_name_length }
+
+        def get_smb_version(obj = self)
+          # Return version 1 by default in case the structure is not part of a
+          # SMB packet. This way, we can still instantiate this structure
+          # independently without breaking the "choice" logic.
+          return 1 if obj.nil?
+          smb_version = if obj.respond_to?(:smb_header)
+                          1
+                        elsif obj.respond_to?(:smb2_header)
+                          2
+                        else
+                          get_smb_version(obj.parent)
+                        end
+          return smb_version
+        end
 
       end
     end

--- a/lib/ruby_smb/smb1/packet/trans2.rb
+++ b/lib/ruby_smb/smb1/packet/trans2.rb
@@ -16,6 +16,8 @@ module RubySMB
         require 'ruby_smb/smb1/packet/trans2/find_first2_response'
         require 'ruby_smb/smb1/packet/trans2/find_next2_request'
         require 'ruby_smb/smb1/packet/trans2/find_next2_response'
+        require 'ruby_smb/smb1/packet/trans2/set_file_information_request'
+        require 'ruby_smb/smb1/packet/trans2/set_file_information_response'
       end
     end
   end

--- a/lib/ruby_smb/smb1/packet/trans2/set_file_information_request.rb
+++ b/lib/ruby_smb/smb1/packet/trans2/set_file_information_request.rb
@@ -1,0 +1,66 @@
+module RubySMB
+  module SMB1
+    module Packet
+      module Trans2
+        # A Trans2 SET_FILE_INFORMATION Request Packet as defined in
+        # [2.2.6.9.1 Request](https://msdn.microsoft.com/en-us/library/ee441527.aspx)
+        class SetFileInformationRequest < RubySMB::GenericPacket
+          class ParameterBlock < RubySMB::SMB1::Packet::Trans2::Request::ParameterBlock
+          end
+
+          # The Trans2 Parameter Block for this particular Subcommand
+          class Trans2Parameters < BinData::Record
+            endian :little
+
+            uint16  :fid,               label: 'FID'
+            uint16  :information_level, label: 'Information Level'
+            uint16  :reserved,          label: 'Reserved Space'
+
+            # Returns the length of the Trans2Parameters struct
+            # in number of bytes
+            def length
+              do_num_bytes
+            end
+          end
+
+          # The Trans2 Data Block for this particular Subcommand
+          class Trans2Data < BinData::Record
+            include RubySMB::Fscc::FileInformation
+
+            choice :info_level_struct, selection: -> { parent.trans2_parameters.information_level } do
+              # It supports new pass-through Information Level capabilities, as specified in
+              # [2.2.2.3.5 Pass-through Information Level Codes](https://msdn.microsoft.com/en-us/library/ff470158.aspx)
+              file_disposition_information (FILE_DISPOSITION_INFORMATION + SMB_INFO_PASSTHROUGH), label: 'File Disposition Information'
+              file_rename_information      (FILE_RENAME_INFORMATION + SMB_INFO_PASSTHROUGH),      label: 'File Rename Information'
+            end
+
+            # Returns the length of the Trans2Data struct
+            # in number of bytes
+            def length
+              do_num_bytes
+            end
+          end
+
+          # The {RubySMB::SMB1::DataBlock} specific to this packet type.
+          class DataBlock < RubySMB::SMB1::Packet::Trans2::DataBlock
+            uint8              :name,               label: 'Name', initial_value: 0x00
+            string             :pad1,               length: -> { pad1_length }
+            trans2_parameters  :trans2_parameters,  label: 'Trans2 Parameters'
+            string             :pad2,               length: -> { pad2_length }
+            trans2_data        :trans2_data,        label: 'Trans2 Data'
+          end
+
+          smb_header        :smb_header
+          parameter_block   :parameter_block
+          data_block        :data_block
+
+          def initialize_instance
+            super
+            smb_header.command = RubySMB::SMB1::Commands::SMB_COM_TRANSACTION2
+            parameter_block.setup << RubySMB::SMB1::Packet::Trans2::Subcommands::SET_FILE_INFORMATION
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby_smb/smb1/packet/trans2/set_file_information_response.rb
+++ b/lib/ruby_smb/smb1/packet/trans2/set_file_information_response.rb
@@ -1,0 +1,57 @@
+module RubySMB
+  module SMB1
+    module Packet
+      module Trans2
+        # A Trans2 SET_FILE_INFORMATION Response Packet as defined in
+        # [2.2.6.9.2 Response](https://msdn.microsoft.com/en-us/library/ff469853.aspx)
+        class SetFileInformationResponse < RubySMB::GenericPacket
+          class ParameterBlock < RubySMB::SMB1::Packet::Trans2::Response::ParameterBlock
+          end
+
+          # The Trans2 Parameter Block for this particular Subcommand
+          class Trans2Parameters < BinData::Record
+            endian :little
+
+            uint16 :ea_error_offset, label: 'Extended Attribute Error Offset'
+
+            # Returns the length of the Trans2Parameters struct
+            # in number of bytes
+            def length
+              do_num_bytes
+            end
+          end
+
+          # The Trans2 Data Block for this particular Subcommand
+          class Trans2Data < BinData::Record
+
+            # Returns the length of the Trans2Data struct
+            # in number of bytes
+            def length
+              do_num_bytes
+            end
+          end
+
+          # The {RubySMB::SMB1::DataBlock} specific to this packet type.
+          class DataBlock < RubySMB::SMB1::Packet::Trans2::DataBlock
+            uint8              :name,               label: 'Name', initial_value: 0x00
+            string             :pad1,               length: -> { pad1_length }
+            trans2_parameters  :trans2_parameters,  label: 'Trans2 Parameters'
+            string             :pad2,               length: -> { pad2_length }
+            trans2_data        :trans2_data,        label: 'Trans2 Data'
+          end
+
+          smb_header        :smb_header
+          parameter_block   :parameter_block
+          data_block        :data_block
+
+          def initialize_instance
+            super
+            smb_header.command = RubySMB::SMB1::Commands::SMB_COM_TRANSACTION2
+            parameter_block.setup << RubySMB::SMB1::Packet::Trans2::Subcommands::SET_FILE_INFORMATION
+            smb_header.flags.reply = 1
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby_smb/smb1/packet/trans2/subcommands.rb
+++ b/lib/ruby_smb/smb1/packet/trans2/subcommands.rb
@@ -3,10 +3,11 @@ module RubySMB
     module Packet
       module Trans2
         module Subcommands
-          OPEN2         = 0x0000
-          FIND_FIRST2   = 0x0001
-          FIND_NEXT2    = 0x0002
-          SESSION_SETUP = 0x000E
+          OPEN2                = 0x0000
+          FIND_FIRST2          = 0x0001
+          FIND_NEXT2           = 0x0002
+          SET_FILE_INFORMATION = 0x0008
+          SESSION_SETUP        = 0x000E
         end
       end
     end

--- a/spec/lib/ruby_smb/fscc/file_information/file_rename_information_spec.rb
+++ b/spec/lib/ruby_smb/fscc/file_information/file_rename_information_spec.rb
@@ -9,10 +9,8 @@ RSpec.describe RubySMB::Fscc::FileInformation::FileRenameInformation do
   subject(:struct) { described_class.new }
 
   it { should respond_to :replace_if_exists }
-  it { should respond_to :reserved_0 }
-  it { should respond_to :reserved_1 }
-  it { should respond_to :reserved_2 }
-  it { should respond_to :root_firectory }
+  it { should respond_to :reserved }
+  it { should respond_to :root_directory }
   it { should respond_to :file_name_length }
   it { should respond_to :file_name }
 
@@ -37,14 +35,51 @@ RSpec.describe RubySMB::Fscc::FileInformation::FileRenameInformation do
     end
   end
 
-  describe '#root_firectory' do
-    it 'is a 64-bit field' do
-      expect(struct.root_firectory).to be_a BinData::Uint64le
+  describe '#reserved' do
+    context 'with SMB1' do
+      it 'is a 3-bytes field' do
+        allow(struct).to receive(:get_smb_version).and_return 1
+        expect(struct.reserved.do_num_bytes).to eq 3
+      end
     end
 
-    it 'should have a default value of 0' do
-      expect(struct.root_firectory).to eq 0
+    context 'with SMB2' do
+      it 'is a 7-bytes field' do
+        allow(struct).to receive(:get_smb_version).and_return 2
+        expect(struct.reserved.do_num_bytes).to eq 7
+      end
     end
+  end
+
+  describe '#root_directory' do
+    context 'with SMB1' do
+      before :example do
+        allow(struct).to receive(:get_smb_version).and_return 1
+      end
+
+      it 'is a 4-bytes field' do
+        expect(struct.root_directory.do_num_bytes).to eq 4
+      end
+
+      it 'should have a default value of 0' do
+        expect(struct.root_directory).to eq 0
+      end
+    end
+
+    context 'with SMB2' do
+      before :example do
+        allow(struct).to receive(:get_smb_version).and_return 2
+      end
+
+      it 'is a 8-bytes field' do
+        expect(struct.root_directory.do_num_bytes).to eq 8
+      end
+
+      it 'should have a default value of 0' do
+        expect(struct.root_directory).to eq 0
+      end
+    end
+
   end
 
   describe '#file_name_length' do
@@ -65,6 +100,34 @@ RSpec.describe RubySMB::Fscc::FileInformation::FileRenameInformation do
   describe '#file_name' do
     it 'is a string field' do
       expect(struct.file_name).to be_a BinData::String
+    end
+  end
+
+  describe '#get_smb_version' do
+    it 'is a recurssive method' do
+      parent = double('parent object')
+      allow(struct).to receive(:parent).and_return(parent)
+      expect(struct).to receive(:respond_to?).and_return(false).twice.ordered
+      expect(parent).to receive(:respond_to?).and_return(true).once.ordered
+      struct.get_smb_version
+    end
+
+    it 'returns version 1 if smb_header structure is found in parents' do
+      allow(struct).to receive(:respond_to?).with(:smb_header).and_return(true)
+      expect(struct.get_smb_version).to eq 1
+    end
+
+    it 'returns version 2 if smb2_header structure is found in parents' do
+      allow(struct).to receive(:respond_to?).with(:smb_header).and_return(false)
+      allow(struct).to receive(:respond_to?).with(:smb2_header).and_return(true)
+      expect(struct.get_smb_version).to eq 2
+    end
+
+    it 'returns version 1 if no header structure is found in parents' do
+      allow(struct).to receive(:parent)
+      allow(struct).to receive(:respond_to?).with(:smb_header).and_return(false)
+      allow(struct).to receive(:respond_to?).with(:smb2_header).and_return(false)
+      expect(struct.get_smb_version).to eq 1
     end
   end
 end

--- a/spec/lib/ruby_smb/smb1/packet/trans2/set_file_information_request_spec.rb
+++ b/spec/lib/ruby_smb/smb1/packet/trans2/set_file_information_request_spec.rb
@@ -1,0 +1,98 @@
+include RubySMB::Fscc::FileInformation
+
+RSpec.describe RubySMB::SMB1::Packet::Trans2::SetFileInformationRequest do
+  subject(:packet) { described_class.new }
+
+  describe '#smb_header' do
+    subject(:header) { packet.smb_header }
+
+    it 'is a standard SMB Header' do
+      expect(header).to be_a RubySMB::SMB1::SMBHeader
+    end
+
+    it 'should have the command set to SMB_COM_TRANSACTION2' do
+      expect(header.command).to eq RubySMB::SMB1::Commands::SMB_COM_TRANSACTION2
+    end
+
+    it 'should not have the response flag set' do
+      expect(header.flags.reply).to eq 0
+    end
+  end
+
+  describe '#parameter_block' do
+    subject(:parameter_block) { packet.parameter_block }
+
+    it 'is a standard ParameterBlock' do
+      expect(parameter_block).to be_a RubySMB::SMB1::Packet::Trans2::Request::ParameterBlock
+    end
+
+    it 'should have the setup set to the OPEN2 subcommand' do
+      expect(parameter_block.setup).to include RubySMB::SMB1::Packet::Trans2::Subcommands::SET_FILE_INFORMATION
+    end
+  end
+
+  describe '#data_block' do
+    subject(:data_block) { packet.data_block }
+
+    it 'is a standard DataBlock' do
+      expect(data_block).to be_a RubySMB::SMB1::DataBlock
+    end
+
+    it { is_expected.to respond_to :name }
+    it { is_expected.to respond_to :trans2_parameters }
+    it { is_expected.to respond_to :trans2_data }
+
+    it 'should keep #trans2_parameters 4-byte aligned' do
+      expect(data_block.trans2_parameters.abs_offset % 4).to eq 0
+    end
+
+    it 'should keep #trans2_data 4-byte aligned' do
+      expect(data_block.trans2_data.abs_offset % 4).to eq 0
+    end
+
+    describe '#trans2_parameters' do
+      subject(:parameters) { data_block.trans2_parameters }
+
+      it { is_expected.to respond_to :fid }
+      it { is_expected.to respond_to :information_level }
+
+      describe '#fid' do
+        it 'is a 16-bit field' do
+          expect(parameters.fid).to be_a BinData::Uint16le
+        end
+      end
+
+      describe '#information_level' do
+        it 'is a 16-bit field' do
+          expect(parameters.information_level).to be_a BinData::Uint16le
+        end
+      end
+    end
+
+    describe '#trans2_data' do
+      subject(:data) { data_block.trans2_data }
+
+      it { is_expected.to respond_to :info_level_struct }
+
+      describe '#info_level_struct' do
+        context 'when #information_level field is FILE_DISPOSITION_INFORMATION with the pass-through capability'
+        it 'is a FileDispositionInformation structure' do
+          info_level = FILE_DISPOSITION_INFORMATION + SMB_INFO_PASSTHROUGH
+          data_block.trans2_parameters.information_level = info_level
+          file_info = FileDispositionInformation.new
+          expect(data.info_level_struct).to eq file_info
+        end
+
+        context 'when #information_level field is FILE_RENAME_INFORMATION with the pass-through capability'
+        it 'is a FileRenameInformation structure' do
+          info_level = FILE_RENAME_INFORMATION + SMB_INFO_PASSTHROUGH
+          data_block.trans2_parameters.information_level = info_level
+          file_info = FileRenameInformation.new
+          expect(data.info_level_struct).to eq file_info
+        end
+      end
+    end
+
+  end
+end
+

--- a/spec/lib/ruby_smb/smb1/packet/trans2/set_file_information_response_spec.rb
+++ b/spec/lib/ruby_smb/smb1/packet/trans2/set_file_information_response_spec.rb
@@ -1,0 +1,56 @@
+RSpec.describe RubySMB::SMB1::Packet::Trans2::SetFileInformationResponse do
+  subject(:packet) { described_class.new }
+
+  describe '#smb_header' do
+    subject(:header) { packet.smb_header }
+
+    it 'is a standard SMB Header' do
+      expect(header).to be_a RubySMB::SMB1::SMBHeader
+    end
+
+    it 'should have the command set to SMB_COM_NEGOTIATE' do
+      expect(header.command).to eq RubySMB::SMB1::Commands::SMB_COM_TRANSACTION2
+    end
+
+    it 'should have the response flag set' do
+      expect(header.flags.reply).to eq 1
+    end
+  end
+
+  describe '#parameter_block' do
+    subject(:parameter_block) { packet.parameter_block }
+
+    it 'should have the setup set to the OPEN2 subcommand' do
+      expect(parameter_block.setup).to include RubySMB::SMB1::Packet::Trans2::Subcommands::SET_FILE_INFORMATION
+    end
+  end
+
+  describe '#data_block' do
+    subject(:data_block) { packet.data_block }
+
+    it { is_expected.to respond_to :name }
+    it { is_expected.to respond_to :trans2_parameters }
+    it { is_expected.to respond_to :trans2_data }
+
+    it 'should keep #trans2_parameters 4-byte aligned' do
+      expect(data_block.trans2_parameters.abs_offset % 4).to eq 0
+    end
+
+    it 'should keep #trans2_data 4-byte aligned' do
+      expect(data_block.trans2_data.abs_offset % 4).to eq 0
+    end
+
+    describe '#trans2_parameters' do
+      subject(:parameters) { data_block.trans2_parameters }
+
+      it { is_expected.to respond_to :ea_error_offset }
+
+      describe '#ea_error_offset' do
+        it 'is a 16-bit field' do
+          expect(parameters.ea_error_offset).to be_a BinData::Uint16le
+        end
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
This PR adds SMB1 delete and rename functionalities.

# Verification Steps
- [x] `bundle install`
- [x] Verify you can delete a file with `ruby examples/delete_file.rb <ip-address> <username> <password> <share> <file-to-delete>` (change `smb2: true` argument to `smb2: false` to force SMB1 when instantiating the Client)
- [x] Verify you can rename a file with `ruby examples/rename_file.rb <ip-address> <username> <password> <share> <old_name> <new_name>` (change `smb2: true` argument to `smb2: false` to force SMB1 when instantiating the Client)
## `rake spec`
- [x] `rake spec`
- [x] VERIFY no failures
