### PR TITLE
Add client methods

### DIFF
--- a/lib/ruby_smb/client.rb
+++ b/lib/ruby_smb/client.rb
@@ -7,12 +7,14 @@ module RubySMB
     require 'ruby_smb/client/signing'
     require 'ruby_smb/client/tree_connect'
     require 'ruby_smb/client/echo'
+    require 'ruby_smb/client/utils'
 
     include RubySMB::Client::Negotiation
     include RubySMB::Client::Authentication
     include RubySMB::Client::Signing
     include RubySMB::Client::TreeConnect
     include RubySMB::Client::Echo
+    include RubySMB::Client::Utils
 
     # The Default SMB1 Dialect string used in an SMB1 Negotiate Request
     SMB1_DIALECT_SMB1_DEFAULT = 'NT LM 0.12'.freeze
@@ -183,6 +185,9 @@ module RubySMB
         domain: @domain,
         flags: flags
       )
+      
+      @tree_connects = {}
+      @open_files = {}
 
       @smb2_message_id = 0
     end
@@ -232,19 +237,31 @@ module RubySMB
     # Performs protocol negotiation and session setup. It defaults to using
     # the credentials supplied during initialization, but can take a new set of credentials if needed.
     def login(username: self.username, password: self.password, domain: self.domain, local_workstation: self.local_workstation)
+      negotiate
+      session_setup(username, password, domain, true,
+                    local_workstation: local_workstation)
+    end
+
+    def session_setup(user, pass, domain, do_recv=true,
+                      local_workstation: self.local_workstation)
       @domain            = domain
       @local_workstation = local_workstation
-      @password          = password.encode('utf-8') || ''.encode('utf-8')
-      @username          = username.encode('utf-8') || ''.encode('utf-8')
+      @password          = pass.encode('utf-8') || ''.encode('utf-8')
+      @username          = user.encode('utf-8') || ''.encode('utf-8')
 
+      negotiate_version_flag = 0x02000000
+      flags = Net::NTLM::Client::DEFAULT_FLAGS |
+        Net::NTLM::FLAGS[:TARGET_INFO] |
+        negotiate_version_flag
+      
       @ntlm_client = Net::NTLM::Client.new(
-        @username,
-        @password,
-        workstation: @local_workstation,
-        domain: @domain
+          @username,
+          @password,
+          workstation: @local_workstation,
+          domain: @domain,
+          flags: flags
       )
 
-      negotiate
       authenticate
     end
 
@@ -297,7 +314,7 @@ module RubySMB
     # @return [RubySMB::SMB1::Tree] if talking over SMB1
     # @return [RubySMB::SMB2::Tree] if talking over SMB2
     def tree_connect(share)
-      if smb2
+      @tree_connects[share] = if smb2
         smb2_tree_connect(share)
       else
         smb1_tree_connect(share)

--- a/lib/ruby_smb/client.rb
+++ b/lib/ruby_smb/client.rb
@@ -186,7 +186,7 @@ module RubySMB
         flags: flags
       )
       
-      @tree_connects = {}
+      @tree_connects = []
       @open_files = {}
 
       @smb2_message_id = 0
@@ -314,11 +314,13 @@ module RubySMB
     # @return [RubySMB::SMB1::Tree] if talking over SMB1
     # @return [RubySMB::SMB2::Tree] if talking over SMB2
     def tree_connect(share)
-      @tree_connects[share] = if smb2
+      connected_tree = if smb2
         smb2_tree_connect(share)
       else
         smb1_tree_connect(share)
       end
+      @tree_connects << connected_tree
+      connected_tree
     end
 
     # Returns array of shares

--- a/lib/ruby_smb/client/utils.rb
+++ b/lib/ruby_smb/client/utils.rb
@@ -13,7 +13,7 @@ module RubySMB
       attr_accessor :last_file_id
 
       def last_tree
-        @tree_connects.values.last
+        @tree_connects.last
       end
 
       def last_file
@@ -49,11 +49,11 @@ module RubySMB
       end
 
       def close(file_id, tree_id)
-       @open_files[file_id].close
+       @open_files[file_id.to_binary_s].close
       end
 
       def tree_disconnect(share)
-       @tree_connects[share].disconnect!
+       @tree_connects.detect{|tree| tree.id == share }.disconnect!
       end
       
       def native_os

--- a/lib/ruby_smb/client/utils.rb
+++ b/lib/ruby_smb/client/utils.rb
@@ -17,7 +17,7 @@ module RubySMB
       end
 
       def last_file
-        @open_files.last
+        @open_files[@last_file_id]
       end
 
       def last_tree_id
@@ -43,7 +43,9 @@ module RubySMB
         @open_files[file_id].send_recv_write(data: data, offset: offset)
       end
 
-      def read(file_id, offset = 0, length = @last_file.size)
+      def read(file_id, offset = 0, length = last_file.size_on_disk)
+        offset = 0
+        length = last_file.size_on_disk
         data = @open_files[file_id].send_recv_read(read_length: length, offset: offset)
         data.bytes
       end

--- a/lib/ruby_smb/client/utils.rb
+++ b/lib/ruby_smb/client/utils.rb
@@ -1,0 +1,77 @@
+module RubySMB
+  class Client    # This module holds all of the methods backing the {RubySMB::Client#open_file} method
+    module Utils
+
+      attr_accessor :tree_connects
+      attr_accessor :open_files
+      
+      attr_accessor :use_ntlmv2, :usentlm2_session, :send_lm, :use_lanman_key, :send_ntlm, :spnopt
+      attr_accessor :evasion_opts
+      
+      attr_accessor :native_os, :native_lm, :verify_signature, :auth_user
+      
+      attr_accessor :last_file_id
+
+      def last_tree
+        @tree_connects.values.last
+      end
+
+      def last_file
+        @open_files.last
+      end
+
+      def last_tree_id
+        last_tree.id
+      end
+
+      def open(path, disposition=RubySMB::Dispositions::FILE_OPEN, access, write: false, read: true)
+         file = last_tree.open_file(filename: path, write: write, read: read, disposition: disposition)
+         @last_file_id = if file.respond_to?(:guid)
+           file.guid.to_binary_s
+         elsif file.respond_to?(:fid)
+           file.fid.to_binary_s
+         end
+         @open_files[@last_file_id] = file
+      end
+
+      def create_pipe(path, disposition=RubySMB::Dispositions::FILE_OPEN_IF, impersonation)
+        open(path.gsub(/\\/, ''), disposition, nil, write: true, read: true)
+      end
+      
+      #Writes data to an open file handle
+      def write(file_id, offset = 0, data = '', do_recv = true)
+        @open_files[file_id].send_recv_write(data: data, offset: offset)
+      end
+
+      def read(file_id, offset = 0, length = @last_file.size)
+        data = @open_files[file_id].send_recv_read(read_length: length, offset: offset)
+        data.bytes
+      end
+
+      def close(file_id, tree_id)
+       @open_files[file_id].close
+      end
+
+      def tree_disconnect(share)
+       @tree_connects[share].disconnect!
+      end
+      
+      def native_os
+        @peer_native
+      end
+    
+      def native_lm
+        @native_lm
+      end
+    
+      def verify_signature
+        @signing_required
+      end
+    
+      def auth_user
+        @username
+      end
+      
+    end
+  end
+end

--- a/lib/ruby_smb/smb1/file.rb
+++ b/lib/ruby_smb/smb1/file.rb
@@ -149,6 +149,13 @@ module RubySMB
         read_request.parameter_block.offset = offset
         read_request
       end
+      
+      def send_recv_read(read_length: 0, offset: 0)
+        read_request = read_packet(read_length: read_length, offset: offset)
+        raw_response = tree.client.send_recv(read_request)
+        response = RubySMB::SMB1::Packet::ReadAndxResponse.read(raw_response)
+        response.data_block.data.to_binary_s
+      end
 
       # Delete a file on close
       #
@@ -222,6 +229,13 @@ module RubySMB
         write_request.data_block.data = data
         write_request.parameter_block.remaining = write_request.parameter_block.data_length
         write_request
+      end
+      
+      def send_recv_write(data:'', offset: 0)
+        pkt = write_packet(data: data, offset: offset)
+        raw_response = @tree.client.send_recv(pkt)
+        response = RubySMB::SMB1::Packet::WriteAndxResponse.read(raw_response)
+        response.parameter_block.count_low
       end
 
       # Rename a file

--- a/lib/ruby_smb/smb2/file.rb
+++ b/lib/ruby_smb/smb2/file.rb
@@ -133,6 +133,13 @@ module RubySMB
         read_request.offset       = offset
         read_request
       end
+      
+      def send_recv_read(read_length: 0, offset: 0)
+        read_request = read_packet(read_length: read_length, offset: offset)
+        raw_response = tree.client.send_recv(read_request)
+        response = RubySMB::SMB2::Packet::ReadResponse.read(raw_response)
+        response.buffer.to_binary_s
+      end
 
       # Delete a file on close
       #
@@ -200,6 +207,13 @@ module RubySMB
         write_request.write_offset  = offset
         write_request.buffer        = data
         write_request
+      end
+      
+      def send_recv_write(data:'', offset: 0)
+        pkt = write_packet(data: data, offset: offset)
+        raw_response = tree.client.send_recv(pkt)
+        response = RubySMB::SMB2::Packet::WriteResponse.read(raw_response)
+        response.write_count
       end
       
       # Rename a file

--- a/lib/ruby_smb/smb2/file.rb
+++ b/lib/ruby_smb/smb2/file.rb
@@ -138,8 +138,9 @@ module RubySMB
         read_request = read_packet(read_length: read_length, offset: offset)
         raw_response = tree.client.send_recv(read_request)
         response = RubySMB::SMB2::Packet::ReadResponse.read(raw_response)
-        if response.status_code == WindowsError::NTStatus::STATUS_BUFFER_OVERFLOW
-          
+        if response.status_code == WindowsError::NTStatus::STATUS_PENDING
+          sleep 1
+          return send_recv_read(read_length: read_length, offset: offset)
         elsif response.status_code != WindowsError::NTStatus::STATUS_SUCCESS
           raise RubySMB::Error::UnexpectedStatusCode, response.status_code.name
         end

--- a/lib/ruby_smb/smb2/file.rb
+++ b/lib/ruby_smb/smb2/file.rb
@@ -138,6 +138,11 @@ module RubySMB
         read_request = read_packet(read_length: read_length, offset: offset)
         raw_response = tree.client.send_recv(read_request)
         response = RubySMB::SMB2::Packet::ReadResponse.read(raw_response)
+        if response.status_code == WindowsError::NTStatus::STATUS_BUFFER_OVERFLOW
+          
+        elsif response.status_code != WindowsError::NTStatus::STATUS_SUCCESS
+          raise RubySMB::Error::UnexpectedStatusCode, response.status_code.name
+        end
         response.buffer.to_binary_s
       end
 
@@ -213,6 +218,9 @@ module RubySMB
         pkt = write_packet(data: data, offset: offset)
         raw_response = tree.client.send_recv(pkt)
         response = RubySMB::SMB2::Packet::WriteResponse.read(raw_response)
+        if response.status_code != WindowsError::NTStatus::STATUS_SUCCESS
+          raise RubySMB::Error::UnexpectedStatusCode, response.status_code.name
+        end
         response.write_count
       end
       


### PR DESCRIPTION
This is a WIP which adds various general methods and attributes to the smb client that metasploit-framework uses.

It adds convenience methods for opening/reading/writing to files from the client. It also adds attributes to the client. (there are also commits from the DCERPC work #118)