### PR TITLE
Add support to NetBIOS Session Service

### DIFF
--- a/examples/negotiate_with_netbios_service.rb
+++ b/examples/negotiate_with_netbios_service.rb
@@ -1,0 +1,36 @@
+#!/usr/bin/ruby
+
+# This script is for testing the NetBIOS Session Service Request on port 139/tcp.
+# Example usage: ruby negotiate.rb 192.168.172.138 NBNAME
+# This will connect to 192.168.172.138 (139/TCP) and request a NetBIOS session with NBNAME as the called name. 
+# If successful, a SMB negotiation is performed using this NetBIOS session.
+# The default *SMBSERVER name is used if the NetBIOS name is not provided.
+
+require 'bundler/setup'
+require 'ruby_smb'
+
+def run_negotiation(address, smb1, smb2, netbios_name)
+  sock = TCPSocket.new address, 139
+  dispatcher = RubySMB::Dispatcher::Socket.new(sock)
+
+  client = RubySMB::Client.new(dispatcher, smb1: smb1, smb2: smb2, username: 'msfadmin', password: 'msfadmin')
+  begin
+    client.session_request(netbios_name)
+  rescue RubySMB::Error::NetBiosSessionService => e
+    puts "NetBIOS Session refused with #{netbios_name}: #{e.message}"
+    return
+  end
+  puts "NetBIOS Session granted with #{netbios_name}, negotiating..."
+  smb_version = client.negotiate
+  puts "#{smb_version} successfully negotiated."
+end
+
+address      = ARGV[0]
+netbios_name = ARGV[1] || '*SMBSERVER'
+
+# Negotiate with both SMB1 and SMB2 enabled on the client
+run_negotiation(ARGV[0], true, true, netbios_name)
+# Negotiate with only SMB1 enabled
+run_negotiation(ARGV[0], true, false, netbios_name)
+# Negotiate with only SMB2 enabled
+run_negotiation(ARGV[0], false, true, netbios_name)

--- a/lib/ruby_smb.rb
+++ b/lib/ruby_smb.rb
@@ -12,6 +12,7 @@ module RubySMB
   require 'ruby_smb/impersonation_levels'
   require 'ruby_smb/gss'
   require 'ruby_smb/field'
+  require 'ruby_smb/nbss'
   require 'ruby_smb/fscc'
   require 'ruby_smb/generic_packet'
   require 'ruby_smb/dispatcher'

--- a/lib/ruby_smb/dispatcher/base.rb
+++ b/lib/ruby_smb/dispatcher/base.rb
@@ -2,10 +2,15 @@ module RubySMB
   module Dispatcher
     # Provides the base class for the packet dispatcher.
     class Base
-      # @param packet [#length]
-      # @return [Fixnum] NBSS header to go in front of `packet`
+      # Creates a NetBIOS Session Service (NBSS) header
+      #
+      # @param packet [#do_num_bytes] the packet to be sent
+      # @return [String] NBSS header to go in front of `packet`
       def nbss(packet)
-        [packet.do_num_bytes].pack('N')
+        nbss = RubySMB::Nbss::SessionHeader.new
+        nbss.session_packet_type = RubySMB::Nbss::SESSION_MESSAGE
+        nbss.packet_length       = packet.do_num_bytes
+        nbss.to_binary_s
       end
 
       # @abstract

--- a/lib/ruby_smb/dispatcher/socket.rb
+++ b/lib/ruby_smb/dispatcher/socket.rb
@@ -30,9 +30,11 @@ module RubySMB
       end
 
       # @param packet [SMB2::Packet,#to_s]
+      # @param nbss [Boolean] wether to include the NetBIOS Session header
       # @return [void]
-      def send_packet(packet)
-        data = nbss(packet) + packet.to_binary_s
+      def send_packet(packet, nbss_header: true)
+        data = nbss_header ? nbss(packet) : ''
+        data << packet.to_binary_s
         bytes_written = 0
         begin
           while bytes_written < data.size
@@ -45,21 +47,32 @@ module RubySMB
       end
 
       # Read a packet off the wire and parse it into a string
-      # Throw Error::NetBiosSessionService if there's an error reading the first 4 bytes,
-      # which are assumed to be the NetBiosSessionService header.
-      # @return [String]
-      def recv_packet
+      #
+      # @param full_response [Boolean] whether to include the NetBios Session Service header in the repsonse
+      # @return [String] the raw response (including the NetBios Session Service header if full_response is true)
+      # @raise [RubySMB::Error::NetBiosSessionService] if there's an error reading the first 4 bytes,
+      #   which are assumed to be the NetBiosSessionService header.
+      # @raise [RubySMB::Error::CommunicationError] if the read timeout expires or an error occurs when reading the socket
+      def recv_packet(full_response: false)
         if IO.select([@tcp_socket], nil, nil, @read_timeout).nil?
           raise RubySMB::Error::CommunicationError, "Read timeout expired when reading from the Socket (timeout=#{@read_timeout})"
         end
-        nbss_header = @tcp_socket.read(4) # Length of NBSS header. TODO: remove to a constant
-        raise ::RubySMB::Error::NetBiosSessionService, 'NBSS Header is missing' if nbss_header.nil? || nbss_header.empty?
-        length = nbss_header.unpack('N').first
-        if IO.select([@tcp_socket], nil, nil, @read_timeout).nil?
-          raise RubySMB::Error::CommunicationError, "Read timeout expired when reading from the Socket (timeout=#{@read_timeout})"
+
+        begin
+          nbss_header = RubySMB::Nbss::SessionHeader.read(@tcp_socket)
+        rescue IOError
+          raise ::RubySMB::Error::NetBiosSessionService, 'NBSS Header is missing'
         end
-        data = @tcp_socket.read(length)
-        data << @tcp_socket.read(length - data.length) while data.length < length
+
+        length = nbss_header.packet_length
+        data = full_response ? nbss_header.to_binary_s : ''
+        if length > 0
+          if IO.select([@tcp_socket], nil, nil, @read_timeout).nil?
+            raise RubySMB::Error::CommunicationError, "Read timeout expired when reading from the Socket (timeout=#{@read_timeout})"
+          end
+          data << tcp_socket.read(length)
+          data << @tcp_socket.read(length - data.length) while data.length < length
+        end
         data
       rescue Errno::EINVAL, Errno::ECONNABORTED, Errno::ECONNRESET, TypeError, NoMethodError => e
         raise RubySMB::Error::CommunicationError, "An error occured reading from the Socket #{e.message}"

--- a/lib/ruby_smb/dispatcher/socket.rb
+++ b/lib/ruby_smb/dispatcher/socket.rb
@@ -70,7 +70,7 @@ module RubySMB
           if IO.select([@tcp_socket], nil, nil, @read_timeout).nil?
             raise RubySMB::Error::CommunicationError, "Read timeout expired when reading from the Socket (timeout=#{@read_timeout})"
           end
-          data << tcp_socket.read(length)
+          data << @tcp_socket.read(length)
           data << @tcp_socket.read(length - data.length) while data.length < length
         end
         data

--- a/lib/ruby_smb/nbss.rb
+++ b/lib/ruby_smb/nbss.rb
@@ -1,0 +1,16 @@
+module RubySMB
+  # Namespace for all of the NetBIOS packets used by RubySMB
+  module Nbss
+    # Session Packet Types
+    SESSION_MESSAGE           = 0x00
+    SESSION_REQUEST           = 0x81
+    POSITIVE_SESSION_RESPONSE = 0x82
+    NEGATIVE_SESSION_RESPONSE = 0x83
+    RETARGET_SESSION_RESPONSE = 0x84
+    SESSION_KEEP_ALIVE        = 0x85
+
+    require 'ruby_smb/nbss/session_header'
+    require 'ruby_smb/nbss/session_request'
+    require 'ruby_smb/nbss/negative_session_response'
+  end
+end

--- a/lib/ruby_smb/nbss/negative_session_response.rb
+++ b/lib/ruby_smb/nbss/negative_session_response.rb
@@ -1,0 +1,30 @@
+module RubySMB
+  module Nbss
+
+
+    # Representation of the NetBIOS Negative Session Service Response packet as defined in
+    # [4.3.4 SESSION REQUEST PACKET](https://tools.ietf.org/html/rfc1002)
+    class NegativeSessionResponse < BinData::Record
+      endian :big
+
+      session_header :session_header
+      uint8          :error_code, label: 'Error Code'
+
+      def error_msg
+        case error_code
+        when 0x80
+          'Not listening on called name'
+        when 0x81
+          'Not listening for calling name'
+        when 0x82
+          'Called name not present'
+        when 0x83
+          'Called name present, but insufficient resources'
+        when 0x8F
+          'Unspecified error'
+        end
+      end
+    end
+
+  end
+end

--- a/lib/ruby_smb/nbss/session_header.rb
+++ b/lib/ruby_smb/nbss/session_header.rb
@@ -1,0 +1,13 @@
+module RubySMB
+  module Nbss
+    # Representation of the NetBIOS Session Service Header as defined in
+    # [4.3.1 GENERAL FORMAT OF SESSION PACKETS](https://tools.ietf.org/html/rfc1002)
+    class SessionHeader < BinData::Record
+      endian :big
+
+      uint8  :session_packet_type, label: 'Session Packet Type'
+      uint8  :flags,               label: 'Flags',              initial_value: 0
+      uint16 :packet_length,       label: 'Packet Length'
+    end
+  end
+end

--- a/lib/ruby_smb/nbss/session_request.rb
+++ b/lib/ruby_smb/nbss/session_request.rb
@@ -1,0 +1,13 @@
+module RubySMB
+  module Nbss
+    # Representation of the NetBIOS Session Service Request packet as defined in
+    # [4.3.2 SESSION REQUEST PACKET](https://tools.ietf.org/html/rfc1002)
+    class SessionRequest < BinData::Record
+      endian :big
+
+      session_header :session_header
+      string         :called_name,  label: 'Called Name'
+      string         :calling_name, label: 'Calling Name'
+    end
+  end
+end

--- a/spec/lib/ruby_smb/dispatcher/base_spec.rb
+++ b/spec/lib/ruby_smb/dispatcher/base_spec.rb
@@ -2,10 +2,16 @@ require 'spec_helper'
 
 RSpec.describe RubySMB::Dispatcher::Base do
   subject(:dispatcher) { described_class.new }
+  let(:session_header) { RubySMB::Nbss::SessionHeader.new }
+  let(:packet) { RubySMB::SMB1::Packet::NegotiateRequest.new }
 
   describe '#nbss' do
+    it 'creates a SessionHeader packet' do
+      expect(RubySMB::Nbss::SessionHeader).to receive(:new).and_return(session_header)
+      dispatcher.nbss(packet)
+    end
+
     it 'returns the size of the packet to the packet in 4 bytes' do
-      packet = RubySMB::SMB1::Packet::NegotiateRequest.new
       expect(dispatcher.nbss(packet)).to eq "\x00\x00\x00\x23"
     end
   end

--- a/spec/lib/ruby_smb/dispatcher/socket_spec.rb
+++ b/spec/lib/ruby_smb/dispatcher/socket_spec.rb
@@ -46,50 +46,30 @@ RSpec.describe RubySMB::Dispatcher::Socket do
   end
 
   describe '#recv_packet' do
-    let(:blank_socket) { StringIO.new('') }
+    let(:blank_socket)    { StringIO.new('') }
     let(:response_socket) { StringIO.new(response_packet) }
+    let(:session_header)  { RubySMB::Nbss::SessionHeader.new }
 
-    describe 'when reading from the socket results in a nil value' do
+    context 'when reading from the socket results in a nil value' do
       it 'should raise Error::NetBiosSessionService' do
         smb_socket.tcp_socket = blank_socket
         expect { smb_socket.recv_packet }.to raise_error(::RubySMB::Error::NetBiosSessionService)
       end
     end
 
-    describe 'when reading from the socket results in an empty value' do
+    context 'when reading from the socket results in an empty value' do
       it 'should raise Error::NetBiosSessionService' do
         smb_socket.tcp_socket = blank_socket
-        allow(blank_socket).to receive(:read).with(4).and_return('')
+        allow(blank_socket).to receive(:read).and_return('')
         expect { smb_socket.recv_packet }.to raise_error(::RubySMB::Error::NetBiosSessionService)
       end
     end
 
-    describe 'when reading an SMB Response packet' do
-      it 'reads a number of bytes defined in the nbss header' do
-        smb_socket.tcp_socket = response_socket
-        expect(response_socket).to receive(:read).with(4).and_call_original
-        expect(response_socket).to receive(:read).with(negotiate_response.do_num_bytes).and_call_original
-        smb_socket.recv_packet
+    context 'when a socket error occurs' do
+      it 'raises a CommunicationError exception' do
+        expect(fake_tcp_socket).to receive(:read).and_raise(Errno::ECONNRESET)
+        expect { smb_socket.recv_packet }.to raise_error(RubySMB::Error::CommunicationError)
       end
-    end
-
-    it 'raises a CommunicationError if it encounters a socket error' do
-      expect(fake_tcp_socket).to receive(:read).and_raise(Errno::ECONNRESET)
-      expect { smb_socket.recv_packet }.to raise_error(RubySMB::Error::CommunicationError)
-    end
-
-    it 'uses the default read_timeout with IO#select when it has not been specifically defined' do
-      smb_socket.tcp_socket = response_socket
-      expect(IO).to receive(:select).with([response_socket], nil, nil, described_class::READ_TIMEOUT).and_return([]).twice
-      smb_socket.recv_packet
-    end
-
-    it 'uses the defined read_timeout with IO#select' do
-      smb_socket.tcp_socket = response_socket
-      timeout = 10
-      smb_socket.read_timeout = timeout
-      expect(IO).to receive(:select).with([response_socket], nil, nil, timeout).and_return([]).twice
-      smb_socket.recv_packet
     end
 
     context 'when the read_timeout expires' do
@@ -98,12 +78,96 @@ RSpec.describe RubySMB::Dispatcher::Socket do
         expect { smb_socket.recv_packet }.to raise_error(RubySMB::Error::CommunicationError)
       end
     end
+
+    context 'when reading an SMB Response packet' do
+      before :example do
+        smb_socket.tcp_socket = response_socket
+      end
+
+      it 'reads the nbss header using Nbss::SessionHeader structure' do
+        expect(RubySMB::Nbss::SessionHeader).to receive(:read).with(response_socket).and_return(session_header)
+        smb_socket.recv_packet
+      end
+
+      it 'uses the default read_timeout with IO#select when it has not been specifically defined' do
+        expect(IO).to receive(:select).with([response_socket], nil, nil, described_class::READ_TIMEOUT).and_return([]).twice
+        smb_socket.recv_packet
+      end
+
+      it 'uses the defined read_timeout with IO#select' do
+        timeout = 10
+        smb_socket.read_timeout = timeout
+        expect(IO).to receive(:select).with([response_socket], nil, nil, timeout).and_return([]).twice
+        smb_socket.recv_packet
+      end
+
+      it 'reads the number of bytes specified in the nbss header' do
+        packet_length = 10
+        session_header.packet_length = packet_length
+        allow(RubySMB::Nbss::SessionHeader).to receive(:read).and_return(session_header)
+        expect(response_socket).to receive(:read).with(packet_length).and_return('A' * packet_length)
+        smb_socket.recv_packet
+      end
+
+      context 'when the socket does not return everything the first time' do
+        it 'calls #read several times until everything is returned' do
+          packet_length = 67
+          returned_length = 10
+          session_header.packet_length = packet_length
+          allow(RubySMB::Nbss::SessionHeader).to receive(:read).and_return(session_header)
+
+          loop do
+            expect(response_socket).to receive(:read).with(packet_length).and_return('A' * returned_length).once
+            packet_length -= returned_length
+            break if packet_length <= 0
+          end
+          smb_socket.recv_packet
+        end
+      end
+
+      context 'when the full_response argument is true' do
+        it 'returns the full packet including the nbss header' do
+          expect(smb_socket.recv_packet(full_response: true)).to eq(response_packet)
+        end
+
+        context 'when the SMB packet is empty' do
+          it 'returns the nbss header only' do
+            session_header.packet_length = 0
+            allow(RubySMB::Nbss::SessionHeader).to receive(:read).and_return(session_header)
+            expect(smb_socket.recv_packet(full_response: true)).to eq(session_header.to_binary_s)
+          end
+        end
+      end
+
+      context 'when the full_response argument is false' do
+        it 'returns the SMB packet without the nbss header' do
+          expect(smb_socket.recv_packet(full_response: false)).to eq(negotiate_response.to_binary_s)
+        end
+
+        context 'when the SMB packet is empty' do
+          it 'returns an empty string' do
+            session_header.packet_length = 0
+            allow(RubySMB::Nbss::SessionHeader).to receive(:read).and_return(session_header)
+            expect(smb_socket.recv_packet(full_response: false)).to eq('')
+          end
+        end
+      end
+    end
   end
 
   describe '#send_packet' do
-    it 'calls nbss to create the nbss header for the packet' do
-      expect(smb_socket).to receive(:nbss).with(negotiate_response).and_return(nbss)
-      smb_socket.send_packet(negotiate_response)
+    context 'when nbss_header argument is true' do
+      it 'calls #nbss to create the nbss header for the packet' do
+        expect(smb_socket).to receive(:nbss).with(negotiate_response).and_return(nbss)
+        smb_socket.send_packet(negotiate_response, nbss_header: true)
+      end
+    end
+
+    context 'when nbss_header argument is false' do
+      it 'does not call #nbss' do
+        expect(smb_socket).to_not receive(:nbss)
+        smb_socket.send_packet(negotiate_response, nbss_header: false)
+      end
     end
 
     it 'writes the packet to the socket' do

--- a/spec/lib/ruby_smb/nbss/negative_session_response_spec.rb
+++ b/spec/lib/ruby_smb/nbss/negative_session_response_spec.rb
@@ -1,0 +1,29 @@
+RSpec.describe RubySMB::Nbss::NegativeSessionResponse do
+  subject(:negative_session_response) { described_class.new }
+
+  it { is_expected.to respond_to :session_header }
+  it { is_expected.to respond_to :error_code }
+
+  it 'is big endian' do
+    expect(described_class.fields.instance_variable_get(:@hints)[:endian]).to eq :big
+  end
+
+  describe '#session_header' do
+    it 'is a SessionHeader field' do
+      expect(negative_session_response.session_header).to be_a RubySMB::Nbss::SessionHeader
+    end
+  end
+
+  describe '#error_code' do
+    it 'is a 8-bit Unsigned Integer' do
+      expect(negative_session_response.error_code).to be_a BinData::Uint8
+    end
+  end
+
+  describe '#error_msg' do
+    it 'returns a string describing the error' do
+      negative_session_response.error_code = 0x80
+      expect(negative_session_response.error_msg).to eq 'Not listening on called name'
+    end
+  end
+end

--- a/spec/lib/ruby_smb/nbss/session_header_spec.rb
+++ b/spec/lib/ruby_smb/nbss/session_header_spec.rb
@@ -1,0 +1,30 @@
+RSpec.describe RubySMB::Nbss::SessionHeader do
+  subject(:session_header) { described_class.new }
+
+  it { is_expected.to respond_to :session_packet_type }
+  it { is_expected.to respond_to :flags }
+  it { is_expected.to respond_to :packet_length }
+
+  it 'is big endian' do
+    expect(described_class.fields.instance_variable_get(:@hints)[:endian]).to eq :big
+  end
+
+  describe '#session_packet_type' do
+    it 'is a 8-bit Unsigned Integer' do
+      expect(session_header.session_packet_type).to be_a BinData::Uint8
+    end
+  end
+
+  describe '#flags' do
+    it 'is a 8-bit Unsigned Integer' do
+      expect(session_header.flags).to be_a BinData::Uint8
+    end
+  end
+
+  describe '#packet_length' do
+    it 'is a 16-bit Unsigned Integer' do
+      expect(session_header.packet_length).to be_a BinData::Uint16be
+    end
+  end
+end
+

--- a/spec/lib/ruby_smb/nbss/session_request_spec.rb
+++ b/spec/lib/ruby_smb/nbss/session_request_spec.rb
@@ -1,0 +1,30 @@
+RSpec.describe RubySMB::Nbss::SessionRequest do
+  subject(:session_request) { described_class.new }
+
+  it { is_expected.to respond_to :session_header }
+  it { is_expected.to respond_to :called_name }
+  it { is_expected.to respond_to :calling_name }
+
+  it 'is big endian' do
+    expect(described_class.fields.instance_variable_get(:@hints)[:endian]).to eq :big
+  end
+
+  describe '#session_header' do
+    it 'is a SessionHeader field' do
+      expect(session_request.session_header).to be_a RubySMB::Nbss::SessionHeader
+    end
+  end
+
+  describe '#called_name' do
+    it 'is a string' do
+      expect(session_request.called_name).to be_a BinData::String
+    end
+  end
+
+  describe '#calling_name' do
+    it 'is a string' do
+      expect(session_request.calling_name).to be_a BinData::String
+    end
+  end
+end
+


### PR DESCRIPTION
This PR adds support to NetBIOS Session Service.

This fixes #119.

# Verification Steps
- [x] `bundle install`
- [x] Verify you can request a NetBIOS session with NBNAME and perform a SMB negotiate to a remote server with `ruby examples/negotiate_with_netbios_service.rb <ip-address> <NBNAME>`
## `rake spec`
- [x] `rake spec`
- [x] VERIFY no failures
