### PR TITLE
Raise an exception if the socket closes unexpectedly

### DIFF
--- a/lib/ruby_smb/dispatcher/socket.rb
+++ b/lib/ruby_smb/dispatcher/socket.rb
@@ -40,6 +40,13 @@ module RubySMB
           while bytes_written < data.size
             bytes_written += @tcp_socket.write(data[bytes_written..-1])
           end
+
+          if retval == nil
+            raise RubySMB::Error::CommunicationError
+          else
+            bytes_written += retval
+          end
+
         rescue IOError, Errno::ECONNABORTED, Errno::ECONNRESET => e
           raise RubySMB::Error::CommunicationError, "An error occured writing to the Socket: #{e.message}"
         end

--- a/lib/ruby_smb/dispatcher/socket.rb
+++ b/lib/ruby_smb/dispatcher/socket.rb
@@ -38,13 +38,13 @@ module RubySMB
         bytes_written = 0
         begin
           while bytes_written < data.size
-            bytes_written += @tcp_socket.write(data[bytes_written..-1])
-          end
+            retval = @tcp_socket.write(data[bytes_written..-1])
 
-          if retval == nil
-            raise RubySMB::Error::CommunicationError
-          else
-            bytes_written += retval
+            if retval == nil
+              raise RubySMB::Error::CommunicationError
+            else
+              bytes_written += retval
+            end
           end
 
         rescue IOError, Errno::ECONNABORTED, Errno::ECONNRESET => e


### PR DESCRIPTION
The `ms17_010_eternalblue` module was occasionally causing a `nil` to be returned from the `tcp_socket.write()`.  This PR adds exception handling and reports a `RubySMB::Error::CommunicationError` so it can be handled by the module.

In a related PR, the Metasploit project will need to modify `ms17_010_eternalblue` module handles this exception cleanly.  See comments for that matching PR.