### PR TITLE
store negotiated max server buffer size

### DIFF
--- a/lib/ruby_smb/client.rb
+++ b/lib/ruby_smb/client.rb
@@ -146,11 +146,17 @@ module RubySMB
     #   @return [String]
     attr_accessor :user_id
 
-    # The maximum size of a SMB message that the Client accepts (in bytes)
-    # Its default value is equal to {MAX_BUFFER_SIZE}.
+    # The maximum size SMB message that the Client accepts (in bytes)
+    # The default value is equal to {MAX_BUFFER_SIZE}.
     # @!attribute [rw] max_buffer_size
     #   @return [Integer]
     attr_accessor :max_buffer_size
+
+    # The maximum size SMB message that the Server accepts (in bytes)
+    # The default value is small by default
+    # @!attribute [rw] max_buffer_size
+    #   @return [Integer]
+    attr_accessor :server_max_buffer_size
 
     # @param dispatcher [RubySMB::Dispacther::Socket] the packet dispatcher to use
     # @param smb1 [Boolean] whether or not to enable SMB1 support
@@ -172,6 +178,7 @@ module RubySMB
       @smb2              = smb2
       @username          = username.encode('utf-8') || ''.encode('utf-8')
       @max_buffer_size   = MAX_BUFFER_SIZE
+      @server_max_buffer_size = MAX_BUFFER_SIZE
 
       negotiate_version_flag = 0x02000000
       flags = Net::NTLM::Client::DEFAULT_FLAGS |
@@ -185,7 +192,7 @@ module RubySMB
         domain: @domain,
         flags: flags
       )
-      
+
       @tree_connects = []
       @open_files = {}
 
@@ -253,7 +260,7 @@ module RubySMB
       flags = Net::NTLM::Client::DEFAULT_FLAGS |
         Net::NTLM::FLAGS[:TARGET_INFO] |
         negotiate_version_flag
-      
+
       @ntlm_client = Net::NTLM::Client.new(
           @username,
           @password,
@@ -334,7 +341,7 @@ module RubySMB
         smb1_net_share_enum_all(host)
       end
     end
-    
+
     #
     # SMB2 Methods
     #

--- a/lib/ruby_smb/client/negotiation.rb
+++ b/lib/ruby_smb/client/negotiation.rb
@@ -80,24 +80,19 @@ module RubySMB
         when RubySMB::SMB1::Packet::NegotiateResponseExtended
           self.smb1 = true
           self.smb2 = false
-          if packet.parameter_block.security_mode.security_signatures_required == 1
-            self.signing_required = true
-          else
-            self.signing_required = false
-          end
+          self.signing_required = packet.parameter_block.security_mode.security_signatures_required == 1
           self.dialect = packet.negotiated_dialect.to_s
+          self.server_max_buffer_size = packet.parameter_block.max_buffer_size
           'SMB1'
         when RubySMB::SMB2::Packet::NegotiateResponse
           self.smb1 = false
           self.smb2 = true
-          self.signing_required = if packet.security_mode.signing_required == 1
-                                    true
-                                  else
-                                    false
-                                  end
+          self.signing_required = packet.security_mode.signing_required == 1
           self.dialect = "0x%04x" % packet.dialect_revision
+          self.server_max_buffer_size = 16644
           'SMB2'
         end
+
       end
 
       # Create a {RubySMB::SMB1::Packet::NegotiateRequest} packet with the


### PR DESCRIPTION
This is something that is used by the new named pipe functionality, so let's pull it in at the client level.