### PR TITLE
simpleclient, namedpipe progress

### DIFF
--- a/examples/pipes.rb
+++ b/examples/pipes.rb
@@ -1,0 +1,43 @@
+#!/usr/bin/ruby
+
+#
+# Example script for connecting to a named pipe and performing a peek operation.
+# This is used to demonstrate pipe operations.
+#
+# Usage: ruby pipes.rb ADDRESS PIPENAME USER PASS 1|2
+#
+
+require 'bundler/setup'
+require 'ruby_smb'
+
+address  = ARGV[0]
+pipename = ARGV[1]
+username = ARGV[2]
+password = ARGV[3]
+smbver   = ARGV[4].to_i
+
+sock = TCPSocket.new(address, 445)
+dispatcher = RubySMB::Dispatcher::Socket.new(sock)
+
+if smbver == 2
+  client = RubySMB::Client.new(dispatcher, smb1: false, username: username, password: password)
+  client.negotiate
+  puts "ServerMaxRead:   #{client.server_max_read_size}"
+  puts "ServerMaxWrite:  #{client.server_max_write_size}"
+  puts "ServerMaxTrans:  #{client.server_max_transact_size}"
+elsif smbver == 1
+  client = RubySMB::Client.new(dispatcher, smb2: false, username: username, password: password)
+  client.negotiate
+  puts "ServerMaxBuffer: #{client.server_max_buffer_size}"
+end
+
+client.authenticate
+client.tree_connect("\\\\#{address}\\IPC$")
+pipe = client.create_pipe(pipename, nil)
+
+puts "Available:       #{pipe.peek_available}"
+puts "PipeState:       #{pipe.peek_state}" # 3 == OK
+
+pipe.close
+client.tree_connects[-1].disconnect!
+client.disconnect!

--- a/examples/pipes.rb
+++ b/examples/pipes.rb
@@ -40,5 +40,6 @@ puts "PipeState:       #{pipe.peek_state}" # 3 == OK
 puts "IsConnected:     #{pipe.is_connected?}"
 
 pipe.close
+puts "IsConnected:     #{pipe.is_connected?}"
 client.tree_connects[-1].disconnect!
 client.disconnect!

--- a/examples/pipes.rb
+++ b/examples/pipes.rb
@@ -37,6 +37,7 @@ pipe = client.create_pipe(pipename, nil)
 
 puts "Available:       #{pipe.peek_available}"
 puts "PipeState:       #{pipe.peek_state}" # 3 == OK
+puts "IsConnected:     #{pipe.is_connected?}"
 
 pipe.close
 client.tree_connects[-1].disconnect!

--- a/lib/ruby_smb/client.rb
+++ b/lib/ruby_smb/client.rb
@@ -23,7 +23,9 @@ module RubySMB
     # Dialect value for SMB2 Default (Version 2.02)
     SMB2_DIALECT_DEFAULT = 0x0202
     # The default maximum size of a SMB message that the Client accepts (in bytes)
-    MAX_BUFFER_SIZE = 4356
+    MAX_BUFFER_SIZE = 64512
+    # The default maximum size of a SMB message that the Server accepts (in bytes)
+    SERVER_MAX_BUFFER_SIZE = 4356
 
     # The dispatcher responsible for sending packets
     # @!attribute [rw] dispatcher
@@ -158,7 +160,23 @@ module RubySMB
     #   @return [Integer]
     attr_accessor :server_max_buffer_size
 
-    # @param dispatcher [RubySMB::Dispacther::Socket] the packet dispatcher to use
+    # The maximum size SMB2 write request that the Server accepts (in bytes)
+    # @!attribute [rw] server_max_write_size
+    #   @return [Integer]
+    attr_accessor :server_max_write_size
+
+    # The maximum size SMB2 read request that the Server accepts (in bytes)
+    # @!attribute [rw] server_max_read_size
+    #   @return [Integer]
+    attr_accessor :server_max_read_size
+
+    # The maximum size SMB2 transaction that the Server accepts (in bytes)
+    # For transactions that are not a read or write request
+    # @!attribute [rw] server_max_transact_size
+    #   @return [Integer]
+    attr_accessor :server_max_transact_size
+
+    # @param dispatcher [RubySMB::Dispatcher::Socket] the packet dispatcher to use
     # @param smb1 [Boolean] whether or not to enable SMB1 support
     # @param smb2 [Boolean] whether or not to enable SMB2 support
     def initialize(dispatcher, smb1: true, smb2: true, username:, password:, domain: '.', local_workstation: 'WORKSTATION')
@@ -178,7 +196,11 @@ module RubySMB
       @smb2              = smb2
       @username          = username.encode('utf-8') || ''.encode('utf-8')
       @max_buffer_size   = MAX_BUFFER_SIZE
-      @server_max_buffer_size = MAX_BUFFER_SIZE
+      # These sizes will be modifed during negotiation
+      @server_max_buffer_size = SERVER_MAX_BUFFER_SIZE
+      @server_max_read_size   = RubySMB::SMB2::File::MAX_PACKET_SIZE
+      @server_max_write_size  = RubySMB::SMB2::File::MAX_PACKET_SIZE
+      @server_max_transact_size = RubySMB::SMB2::File::MAX_PACKET_SIZE
 
       negotiate_version_flag = 0x02000000
       flags = Net::NTLM::Client::DEFAULT_FLAGS |

--- a/lib/ruby_smb/nbss/session_header.rb
+++ b/lib/ruby_smb/nbss/session_header.rb
@@ -5,9 +5,9 @@ module RubySMB
     class SessionHeader < BinData::Record
       endian :big
 
-      uint8  :session_packet_type, label: 'Session Packet Type'
-      uint8  :flags,               label: 'Flags',              initial_value: 0
-      uint16 :packet_length,       label: 'Packet Length'
+      uint8 :session_packet_type,  label: 'Session Packet Type'
+      bit7  :flags,                label: 'Flags',              initial_value: 0
+      bit17 :packet_length,        label: 'Packet Length'
     end
   end
 end

--- a/lib/ruby_smb/smb1.rb
+++ b/lib/ruby_smb/smb1.rb
@@ -18,5 +18,6 @@ module RubySMB
     require 'ruby_smb/smb1/packet'
     require 'ruby_smb/smb1/tree'
     require 'ruby_smb/smb1/file'
+    require 'ruby_smb/smb1/pipe'
   end
 end

--- a/lib/ruby_smb/smb1/bit_field.rb
+++ b/lib/ruby_smb/smb1/bit_field.rb
@@ -10,6 +10,7 @@ module RubySMB
       require 'ruby_smb/smb1/bit_field/optional_support'
       require 'ruby_smb/smb1/bit_field/directory_access_mask'
       require 'ruby_smb/smb1/bit_field/file_access_mask'
+      require 'ruby_smb/smb1/bit_field/trans_flags'
       require 'ruby_smb/smb1/bit_field/trans2_flags'
       require 'ruby_smb/smb1/bit_field/open2_flags'
       require 'ruby_smb/smb1/bit_field/open2_access_mode'

--- a/lib/ruby_smb/smb1/bit_field/trans_flags.rb
+++ b/lib/ruby_smb/smb1/bit_field/trans_flags.rb
@@ -1,0 +1,15 @@
+module RubySMB
+  module SMB1
+    module BitField
+      # The Flags bit-field for a Trans Request Packet
+      # [2.2.4.33.1 Request](https://msdn.microsoft.com/en-us/library/ee441730.aspx)
+      class TransFlags < BinData::Record
+        endian  :little
+        bit6    :reserved,              label: 'Reserved Space',             initial_value: 0
+        bit1    :no_response,           label: 'Do Not reply',               initial_value: 0
+        bit1    :disconnect,            label: 'Disconnect Tree',            initial_value: 0
+        bit8    :reserved2,             label: 'Reserved Space',             initial_value: 0
+      end
+    end
+  end
+end

--- a/lib/ruby_smb/smb1/commands.rb
+++ b/lib/ruby_smb/smb1/commands.rb
@@ -2,6 +2,7 @@ module RubySMB
   module SMB1
     module Commands
       SMB_COM_CLOSE                   = 0x04
+      SMB_COM_TRANSACTION             = 0x25
       SMB_COM_ECHO                    = 0x2B
       SMB_COM_READ_ANDX               = 0x2E
       SMB_COM_WRITE_ANDX              = 0x2F

--- a/lib/ruby_smb/smb1/packet.rb
+++ b/lib/ruby_smb/smb1/packet.rb
@@ -19,6 +19,7 @@ module RubySMB
       require 'ruby_smb/smb1/packet/logoff_response'
       require 'ruby_smb/smb1/packet/echo_request'
       require 'ruby_smb/smb1/packet/echo_response'
+      require 'ruby_smb/smb1/packet/trans'
       require 'ruby_smb/smb1/packet/trans2'
       require 'ruby_smb/smb1/packet/nt_trans'
       require 'ruby_smb/smb1/packet/nt_create_andx_request'

--- a/lib/ruby_smb/smb1/packet/trans.rb
+++ b/lib/ruby_smb/smb1/packet/trans.rb
@@ -8,8 +8,8 @@ module RubySMB
         require 'ruby_smb/smb1/packet/trans/data_block'
         require 'ruby_smb/smb1/packet/trans/request'
         require 'ruby_smb/smb1/packet/trans/response'
-        require 'ruby_smb/smb1/packet/trans/peek_named_pipe_request'
-        require 'ruby_smb/smb1/packet/trans/peek_named_pipe_response'
+        require 'ruby_smb/smb1/packet/trans/peek_nmpipe_request'
+        require 'ruby_smb/smb1/packet/trans/peek_nmpipe_response'
       end
     end
   end

--- a/lib/ruby_smb/smb1/packet/trans.rb
+++ b/lib/ruby_smb/smb1/packet/trans.rb
@@ -1,0 +1,16 @@
+module RubySMB
+  module SMB1
+    module Packet
+      # Namespace for the Transaction sub-protocol documented in
+      # [2.2.4.33 SMB_COM_TRANSACTION (0x25)](https://msdn.microsoft.com/en-us/library/ee441489.aspx)
+      module Trans
+        require 'ruby_smb/smb1/packet/trans/subcommands'
+        require 'ruby_smb/smb1/packet/trans/data_block'
+        require 'ruby_smb/smb1/packet/trans/request'
+        require 'ruby_smb/smb1/packet/trans/response'
+        require 'ruby_smb/smb1/packet/trans/peek_named_pipe_request'
+        require 'ruby_smb/smb1/packet/trans/peek_named_pipe_response'
+      end
+    end
+  end
+end

--- a/lib/ruby_smb/smb1/packet/trans/data_block.rb
+++ b/lib/ruby_smb/smb1/packet/trans/data_block.rb
@@ -1,0 +1,49 @@
+module RubySMB
+  module SMB1
+    module Packet
+      module Trans
+        # Extends the {RubySMB::SMB1::DataBlock} to include padding methods
+        # that all Trans DataBlocks will need to handle proper byte alignment.
+        class DataBlock < RubySMB::SMB1::DataBlock
+          # Controls whether the padding fields will be used
+          # @!attribute [rw] enable_padding
+          #   @return [Boolean]
+          attr_accessor :enable_padding
+
+          def initialize_instance
+            super
+            @enable_padding = true
+          end
+
+          private
+
+          # Determines the correct length for the padding in front of
+          # trans_parameters. It should always force a 4-byte alignment.
+          def pad1_length
+            if enable_padding
+              offset = if respond_to?(:name)
+                         (name.abs_offset + 1) % 4
+                       else
+                         (byte_count.abs_offset + 2) % 4
+                       end
+              (4 - offset) % 4
+            else
+              0
+            end
+          end
+
+          # Determines the correct length for the padding in front of
+          # trans_data. It should always force a 4-byte alignment.
+          def pad2_length
+            if enable_padding
+              offset = (trans_parameters.abs_offset + trans_parameters.length) % 4
+              (4 - offset) % 4
+            else
+              0
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby_smb/smb1/packet/trans/peek_named_pipe_request.rb
+++ b/lib/ruby_smb/smb1/packet/trans/peek_named_pipe_request.rb
@@ -1,0 +1,24 @@
+module RubySMB
+  module SMB1
+    module Packet
+      module Trans
+        # This class represents an SMB1 Trans PeekNamedPipe Request Packet as defined in
+        # [2.2.5.5.1 Request](https://msdn.microsoft.com/en-us/library/ee442106.aspx)
+        class PeekNamedPipeRequest < RubySMB::SMB1::Packet::Trans::Request
+
+          def fid=(file_id)
+            parameter_block.setup = [RubySMB::SMB1::Packet::Trans::Subcommands::PEEK_NAMED_PIPE, file_id]
+          end
+
+          def initialize_instance
+            super
+            smb_header.command = RubySMB::SMB1::Commands::SMB_COM_TRANSACTION
+            data_block.name = "\\PIPE\\"
+            parameter_block.setup << RubySMB::SMB1::Packet::Trans::Subcommands::PEEK_NAMED_PIPE
+            parameter_block.setup_count = 2
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby_smb/smb1/packet/trans/peek_named_pipe_response.rb
+++ b/lib/ruby_smb/smb1/packet/trans/peek_named_pipe_response.rb
@@ -1,0 +1,58 @@
+module RubySMB
+  module SMB1
+    module Packet
+      module Trans
+        # This class represents an SMB1 Trans PeekNamedPipe Response Packet as defined in
+        # [2.2.5.5.2 Response](https://msdn.microsoft.com/en-us/library/ee441883.aspx)
+        class PeekNamedPipeResponse < RubySMB::GenericPacket
+          class ParameterBlock < RubySMB::SMB1::Packet::Trans::Response::ParameterBlock
+          end
+
+          # The Trans Parameter Block for this particular Subcommand
+          class TransParameters < BinData::Record
+            endian :little
+
+            uint16 :read_data_available,     label: 'Read bytes available'
+            uint16 :message_bytes_length,    label: 'Byte length of available message'
+            uint16 :pipe_state,              label: 'Named pipe state'
+
+            # Returns the length of the TransParameters struct
+            # in number of bytes
+            def length
+              do_num_bytes
+            end
+          end
+          
+          class TransData < BinData::Record
+            string :read_data, label: 'Readable data', length: -> { parent.parameter_block.total_data_count }
+
+            # Returns the length of the TransData struct
+            # in number of bytes
+            def length
+              do_num_bytes
+            end
+          end
+
+          # The {RubySMB::SMB1::DataBlock} specific to this packet type.
+          class DataBlock < RubySMB::SMB1::Packet::Trans::DataBlock
+            string           :pad1,               length: -> { pad1_length }
+            trans_parameters :trans_parameters,   label: 'Trans Parameters'
+            # dont understand the padding on this one...
+            string           :pad2,               length: -> { parent.parameter_block.data_offset - parent.parameter_block.parameter_offset - parent.parameter_block.parameter_count }
+            trans_data       :trans_data,         label: 'Trans Data'
+          end
+
+          smb_header        :smb_header
+          parameter_block   :parameter_block
+          data_block        :data_block
+
+          def initialize_instance
+            super
+            smb_header.command = RubySMB::SMB1::Commands::SMB_COM_TRANSACTION
+            parameter_block.setup << RubySMB::SMB1::Packet::Trans::Subcommands::PEEK_NAMED_PIPE
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby_smb/smb1/packet/trans/peek_nmpipe_request.rb
+++ b/lib/ruby_smb/smb1/packet/trans/peek_nmpipe_request.rb
@@ -4,17 +4,17 @@ module RubySMB
       module Trans
         # This class represents an SMB1 Trans PeekNamedPipe Request Packet as defined in
         # [2.2.5.5.1 Request](https://msdn.microsoft.com/en-us/library/ee442106.aspx)
-        class PeekNamedPipeRequest < RubySMB::SMB1::Packet::Trans::Request
+        class PeekNmpipeRequest < RubySMB::SMB1::Packet::Trans::Request
 
           def fid=(file_id)
-            parameter_block.setup = [RubySMB::SMB1::Packet::Trans::Subcommands::PEEK_NAMED_PIPE, file_id]
+            parameter_block.setup = [RubySMB::SMB1::Packet::Trans::Subcommands::PEEK_NMPIPE, file_id]
           end
 
           def initialize_instance
             super
             smb_header.command = RubySMB::SMB1::Commands::SMB_COM_TRANSACTION
             data_block.name = "\\PIPE\\"
-            parameter_block.setup << RubySMB::SMB1::Packet::Trans::Subcommands::PEEK_NAMED_PIPE
+            parameter_block.setup << RubySMB::SMB1::Packet::Trans::Subcommands::PEEK_NMPIPE
             parameter_block.setup_count = 2
           end
         end

--- a/lib/ruby_smb/smb1/packet/trans/peek_nmpipe_response.rb
+++ b/lib/ruby_smb/smb1/packet/trans/peek_nmpipe_response.rb
@@ -49,6 +49,7 @@ module RubySMB
           def initialize_instance
             super
             smb_header.command = RubySMB::SMB1::Commands::SMB_COM_TRANSACTION
+            smb_header.flags.reply = 1
             parameter_block.setup << RubySMB::SMB1::Packet::Trans::Subcommands::PEEK_NMPIPE
           end
         end

--- a/lib/ruby_smb/smb1/packet/trans/peek_nmpipe_response.rb
+++ b/lib/ruby_smb/smb1/packet/trans/peek_nmpipe_response.rb
@@ -4,7 +4,7 @@ module RubySMB
       module Trans
         # This class represents an SMB1 Trans PeekNamedPipe Response Packet as defined in
         # [2.2.5.5.2 Response](https://msdn.microsoft.com/en-us/library/ee441883.aspx)
-        class PeekNamedPipeResponse < RubySMB::GenericPacket
+        class PeekNmpipeResponse < RubySMB::GenericPacket
           class ParameterBlock < RubySMB::SMB1::Packet::Trans::Response::ParameterBlock
           end
 
@@ -49,7 +49,7 @@ module RubySMB
           def initialize_instance
             super
             smb_header.command = RubySMB::SMB1::Commands::SMB_COM_TRANSACTION
-            parameter_block.setup << RubySMB::SMB1::Packet::Trans::Subcommands::PEEK_NAMED_PIPE
+            parameter_block.setup << RubySMB::SMB1::Packet::Trans::Subcommands::PEEK_NMPIPE
           end
         end
       end

--- a/lib/ruby_smb/smb1/packet/trans/request.rb
+++ b/lib/ruby_smb/smb1/packet/trans/request.rb
@@ -1,0 +1,50 @@
+module RubySMB
+  module SMB1
+    module Packet
+      module Trans
+      # A SMB1 SMB_COM_TRANSACTION Request Packet as defined in
+      # [2.2.4.33.1 Request](https://msdn.microsoft.com/en-us/library/ee441730.aspx)
+        class Request < RubySMB::GenericPacket
+          # A SMB1 Parameter Block
+          class ParameterBlock < RubySMB::SMB1::ParameterBlock
+            uint16        :total_parameter_count, label: 'Total Parameter Count(bytes)'
+            uint16        :total_data_count,      label: 'Total Data Count(bytes)'
+            uint16        :max_parameter_count,   label: 'Max Parameter Count(bytes)'
+            uint16        :max_data_count,        label: 'Max Data Count(bytes)'
+            uint8         :max_setup_count,       label: 'Max Setup Count'
+            uint8         :reserved,              label: 'Reserved Space',         initial_value: 0x00
+            trans_flags   :flags
+            uint32        :timeout,               label: 'Timeout',                initial_value: 0x00000000
+            uint16        :reserved2,             label: 'Reserved Space',         initial_value: 0x00
+            uint16        :parameter_count,       label: 'Parameter Count(bytes)', initial_value: -> { parent.data_block.trans_parameters.length }
+            uint16        :parameter_offset,      label: 'Parameter Offset',       initial_value: -> { parent.data_block.trans_parameters.abs_offset }
+            uint16        :data_count,            label: 'Data Count(bytes)',      initial_value: -> { parent.data_block.trans_data.length }
+            uint16        :data_offset,           label: 'Data Offset',            initial_value: -> { parent.data_block.trans_data.abs_offset }
+            uint8         :setup_count,           label: 'Setup Count',            initial_value: -> { setup.length }
+            uint8         :reserved3,             label: 'Reserved Space',         initial_value: 0x00
+
+            array :setup, type: :uint16, initial_length: 0
+          end
+
+          # The {RubySMB::SMB1::DataBlock} specific to this packet type.
+          class DataBlock < RubySMB::SMB1::Packet::Trans::DataBlock
+            stringz :name,              label: 'Name', initial_value: ""
+            string :pad1,               length: -> { pad1_length }
+            string :trans_parameters,   label: 'Trans Parameters'
+            string :pad2,               length: -> { pad2_length }
+            string :trans_data,         label: 'Trans Data'
+          end
+
+          smb_header        :smb_header
+          parameter_block   :parameter_block
+          data_block        :data_block
+
+          def initialize_instance
+            super
+            smb_header.command = RubySMB::SMB1::Commands::SMB_COM_TRANSACTION
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby_smb/smb1/packet/trans/response.rb
+++ b/lib/ruby_smb/smb1/packet/trans/response.rb
@@ -1,0 +1,46 @@
+module RubySMB
+  module SMB1
+    module Packet
+      module Trans
+      # A SMB1 SMB_COM_TRANSACTION Response Packet as defined in
+      # [2.2.4.33.2 Response](https://msdn.microsoft.com/en-us/library/ee442061.aspx)
+        class Response < RubySMB::GenericPacket
+          # A SMB1 Parameter Block
+          class ParameterBlock < RubySMB::SMB1::ParameterBlock
+            uint16 :total_parameter_count, label: 'Total Parameter Count(bytes)'
+            uint16        :total_data_count,        label: 'Total Data Count(bytes)'
+            uint16        :reserved,                label: 'Reserved Space',                 initial_value: 0x00
+            uint16        :parameter_count,         label: 'Parameter Count(bytes)',         initial_value: -> { parent.data_block.trans_parameters.length }
+            uint16        :parameter_offset,        label: 'Parameter Offset',               initial_value: -> { parent.data_block.trans_parameters.abs_offset }
+            uint16        :parameter_displacement,  label: 'Parameter Displacement'
+            uint16        :data_count,              label: 'Data Count(bytes)',              initial_value: -> { parent.data_block.trans_data.length }
+            uint16        :data_offset,             label: 'Data Offset',                    initial_value: -> { parent.data_block.trans_data.abs_offset }
+            uint16        :data_displacement,       label: 'Data Displacement'
+            uint8         :setup_count,             label: 'Setup Count',                    initial_value: -> { setup.length }
+            uint8         :reserved2,               label: 'Reserved Space',                 initial_value: 0x00
+
+            array :setup, type: :uint16, initial_length: 0
+          end
+
+          # The {RubySMB::SMB1::DataBlock} specific to this packet type.
+          class DataBlock < RubySMB::SMB1::Packet::Trans::DataBlock
+            string :pad1,               length: -> { pad1_length }
+            string :trans_parameters,   label: 'Trans Parameters'
+            string :pad2,               length: -> { pad2_length }
+            string :trans_data,         label: 'Trans Data'
+          end
+
+          smb_header        :smb_header
+          parameter_block   :parameter_block
+          data_block        :data_block
+
+          def initialize_instance
+            super
+            smb_header.command = RubySMB::SMB1::Commands::SMB_COM_TRANSACTION
+            smb_header.flags.reply = 1
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby_smb/smb1/packet/trans/subcommands.rb
+++ b/lib/ruby_smb/smb1/packet/trans/subcommands.rb
@@ -3,7 +3,7 @@ module RubySMB
     module Packet
       module Trans
         module Subcommands
-          PEEK_NAMED_PIPE        = 0x0023
+          PEEK_NMPIPE        = 0x0023
         end
       end
     end

--- a/lib/ruby_smb/smb1/packet/trans/subcommands.rb
+++ b/lib/ruby_smb/smb1/packet/trans/subcommands.rb
@@ -1,0 +1,11 @@
+module RubySMB
+  module SMB1
+    module Packet
+      module Trans
+        module Subcommands
+          PEEK_NAMED_PIPE        = 0x0023
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby_smb/smb1/packet/trans2/find_next2_response.rb
+++ b/lib/ruby_smb/smb1/packet/trans2/find_next2_response.rb
@@ -24,7 +24,7 @@ module RubySMB
             end
           end
 
-          # The Trans2 Data Blcok for this particular Subcommand
+          # The Trans2 Data Block for this particular Subcommand
           class Trans2Data < BinData::Record
             rest :buffer, label: 'Results Buffer'
 

--- a/lib/ruby_smb/smb1/pipe.rb
+++ b/lib/ruby_smb/smb1/pipe.rb
@@ -13,19 +13,15 @@ module RubySMB
       # Performs a peek operation on the named pipe
       #
       # @param peek_size [Integer] Amount of data to peek
-      # @return [RubySMB::SMB1::Packet::Trans::PeekNamedPipeResponse]
-      # @raise [RubySMB::Error::InvalidPacket] if not a valid PeekNamedPipeResponse
+      # @return [RubySMB::SMB1::Packet::Trans::PeekNmpipeResponse]
+      # @raise [RubySMB::Error::InvalidPacket] if not a valid PeekNmpipeResponse
       def peek(peek_size: 0)
-        packet = RubySMB::SMB1::Packet::Trans::PeekNamedPipeRequest.new
+        packet = RubySMB::SMB1::Packet::Trans::PeekNmpipeRequest.new
         packet.fid = @fid
         packet.parameter_block.max_data_count = peek_size
         packet = @tree.set_header_fields(packet)
         raw_response = @tree.client.send_recv(packet)
-        begin
-          response = RubySMB::SMB1::Packet::Trans::PeekNamedPipeResponse.read(raw_response)
-        rescue EOFError
-          raise RubySMB::Error::InvalidPacket, 'Failed to process PeekNamedPipeResponse packet'
-        end
+        response = RubySMB::SMB1::Packet::Trans::PeekNmpipeResponse.read(raw_response)
 
         unless response.smb_header.command == RubySMB::SMB1::Commands::SMB_COM_TRANSACTION
           raise RubySMB::Error::InvalidPacket, 'Not a TransResponse packet'

--- a/lib/ruby_smb/smb1/pipe.rb
+++ b/lib/ruby_smb/smb1/pipe.rb
@@ -42,6 +42,11 @@ module RubySMB
         packet.data_block.trans_parameters.pipe_state
       end
 
+      # @return [Boolean] True if pipe is connected, false otherwise
+      def is_connected?
+        peek_state == STATUS_OK
+      end
+
     end
   end
 end

--- a/lib/ruby_smb/smb1/pipe.rb
+++ b/lib/ruby_smb/smb1/pipe.rb
@@ -1,0 +1,39 @@
+module RubySMB
+  module SMB1
+    # Represents a pipe on the Remote server that we can perform
+    # various I/O operations on.
+    class Pipe < File
+
+      # Reference: https://msdn.microsoft.com/en-us/library/ee441883.aspx
+      STATUS_DISCONNECTED = 0x0001
+      STATUS_LISTENING    = 0x0002
+      STATUS_OK           = 0x0003
+      STATUS_CLOSED       = 0x0004
+
+      # Performs a peek operation on the named pipe
+      #
+      # @param peek_size [Integer] Amount of data to peek
+      # @return [RubySMB::SMB1::Packet::Trans::PeekNamedPipeResponse]
+      def peek(peek_size: 0)
+        packet = RubySMB::SMB1::Packet::Trans::PeekNamedPipeRequest.new
+        packet.fid = @fid
+        packet.parameter_block.max_data_count = peek_size
+        packet = @tree.set_header_fields(packet)
+        resp = @tree.client.send_recv(packet)
+        RubySMB::SMB1::Packet::Trans::PeekNamedPipeResponse.read(resp)
+      end
+
+      def peek_available
+        packet = peek
+        # Only 1 of these should be non-zero
+        packet.data_block.trans_parameters.read_data_available or packet.data_block.trans_parameters.message_bytes_length
+      end
+
+      def peek_state
+        packet = peek
+        packet.data_block.trans_parameters.pipe_state
+      end
+
+    end
+  end
+end

--- a/lib/ruby_smb/smb1/tree.rb
+++ b/lib/ruby_smb/smb1/tree.rb
@@ -120,7 +120,14 @@ module RubySMB
           raise RubySMB::Error::UnexpectedStatusCode, response.status_code.name
         end
 
-        RubySMB::SMB1::File.new(name: filename, tree: self, response: response)
+        case response.parameter_block.resource_type 
+        when RubySMB::SMB1::ResourceType::BYTE_MODE_PIPE, RubySMB::SMB1::ResourceType::MESSAGE_MODE_PIPE
+          RubySMB::SMB1::Pipe.new(name: filename, tree: self, response: response)
+        when RubySMB::SMB1::ResourceType::DISK
+          RubySMB::SMB1::File.new(name: filename, tree: self, response: response)
+        else
+          raise RubySMB::Error::RubySMBError
+        end
       end
 
       # List `directory` on the remote share.

--- a/lib/ruby_smb/smb2.rb
+++ b/lib/ruby_smb/smb2.rb
@@ -14,5 +14,6 @@ module RubySMB
     require 'ruby_smb/smb2/packet'
     require 'ruby_smb/smb2/tree'
     require 'ruby_smb/smb2/file'
+    require 'ruby_smb/smb2/pipe'
   end
 end

--- a/lib/ruby_smb/smb2/file.rb
+++ b/lib/ruby_smb/smb2/file.rb
@@ -94,8 +94,8 @@ module RubySMB
       # @param offset [Integer] the byte offset in the file to start reading from
       # @return [String] the data read from the file
       def read(bytes: size, offset: 0)
-        atomic_read_size = if bytes > MAX_PACKET_SIZE
-                             MAX_PACKET_SIZE
+        atomic_read_size = if bytes > tree.client.server_max_read_size
+                             tree.client.server_max_read_size
                            else
                              bytes
                            end
@@ -110,7 +110,7 @@ module RubySMB
 
         while remaining_bytes > 0
           offset += atomic_read_size
-          atomic_read_size = remaining_bytes if remaining_bytes < MAX_PACKET_SIZE
+          atomic_read_size = remaining_bytes if remaining_bytes < tree.client.server_max_read_size
 
           read_request = read_packet(read_length: atomic_read_size, offset: offset)
           raw_response = tree.client.send_recv(read_request)
@@ -184,9 +184,9 @@ module RubySMB
       def write(data:'', offset: 0)
         buffer            = data.dup
         bytes             = data.length
-        atomic_write_size = if bytes > MAX_PACKET_SIZE
-                             MAX_PACKET_SIZE
-                           else
+        atomic_write_size = if bytes > tree.client.server_max_write_size
+                              tree.client.server_max_write_size
+                            else
                              bytes
                             end
 

--- a/lib/ruby_smb/smb2/packet/tree_disconnect_request.rb
+++ b/lib/ruby_smb/smb2/packet/tree_disconnect_request.rb
@@ -7,6 +7,7 @@ module RubySMB
         endian       :little
         smb2_header  :smb2_header
         uint16       :structure_size, label: 'Structure Size', initial_value: 4
+        uint16       :reserved, label: 'Reserved', initial_value: 0
 
         def initialize_instance
           super

--- a/lib/ruby_smb/smb2/pipe.rb
+++ b/lib/ruby_smb/smb2/pipe.rb
@@ -20,18 +20,10 @@ module RubySMB
         packet.max_output_response = 16 + peek_size
         packet = set_header_fields(packet)
         raw_response = @tree.client.send_recv(packet)
-        begin
-          response = RubySMB::SMB2::Packet::IoctlResponse.read(raw_response)
-        rescue EOFError
-          raise RubySMB::Error::InvalidPacket, 'Failed to process IoctlResponse packet'
-        end
+        response = RubySMB::SMB2::Packet::IoctlResponse.read(raw_response)
 
         unless response.smb2_header.command == RubySMB::SMB2::Commands::IOCTL
           raise RubySMB::Error::InvalidPacket, 'Not an IoctlResponse packet'
-        end
-
-        unless response.ctl_code == RubySMB::Fscc::ControlCodes::FSCTL_PIPE_PEEK
-          raise RubySMB::Error::InvalidPacket, 'Not a FSCTL_PIPE_PEEK response packet'
         end
         response
       end

--- a/lib/ruby_smb/smb2/pipe.rb
+++ b/lib/ruby_smb/smb2/pipe.rb
@@ -12,6 +12,7 @@ module RubySMB
       # @param peek_size [Integer] Amount of data to peek
       # @return [RubySMB::SMB2::Packet::IoctlResponse]
       # @raise [RubySMB::Error::InvalidPacket] if not a valid FSCTL_PIPE_PEEK response
+      # @raise [RubySMB::Error::UnexpectedStatusCode] If status is not STATUS_BUFFER_OVERFLOW or STATUS_SUCCESS
       def peek(peek_size: 0)
         packet = RubySMB::SMB2::Packet::IoctlRequest.new
         packet.ctl_code = RubySMB::Fscc::ControlCodes::FSCTL_PIPE_PEEK
@@ -20,7 +21,15 @@ module RubySMB
         packet.max_output_response = 16 + peek_size
         packet = set_header_fields(packet)
         raw_response = @tree.client.send_recv(packet)
-        response = RubySMB::SMB2::Packet::IoctlResponse.read(raw_response)
+        begin
+          response = RubySMB::SMB2::Packet::IoctlResponse.read(raw_response)
+        rescue IOError
+          response = RubySMB::SMB2::Packet::ErrorPacket.read(raw_response)
+        end
+
+        unless response.status_code == WindowsError::NTStatus::STATUS_BUFFER_OVERFLOW or response.status_code == WindowsError::NTStatus::STATUS_SUCCESS
+          raise RubySMB::Error::UnexpectedStatusCode, response.status_code.name
+        end
 
         unless response.smb2_header.command == RubySMB::SMB2::Commands::IOCTL
           raise RubySMB::Error::InvalidPacket, 'Not an IoctlResponse packet'
@@ -44,7 +53,15 @@ module RubySMB
 
       # @return [Boolean] True if pipe is connected, false otherwise
       def is_connected?
-        peek_state == STATUS_CONNECTED
+        begin
+          state = peek_state
+        rescue RubySMB::Error::UnexpectedStatusCode => e
+          if e.message == 'STATUS_FILE_CLOSED'
+            return false
+          end
+          raise e
+        end
+        state == STATUS_CONNECTED
       end
 
     end

--- a/lib/ruby_smb/smb2/pipe.rb
+++ b/lib/ruby_smb/smb2/pipe.rb
@@ -1,0 +1,39 @@
+module RubySMB
+  module SMB2
+    # Represents a pipe on the Remote server that we can perform
+    # various I/O operations on.
+    class Pipe < File
+
+      STATUS_CONNECTED = 0x00000003
+      STATUS_CLOSING   = 0x00000004
+
+      # Performs a peek operation on the named pipe
+      #
+      # @param peek_size [Integer] Amount of data to peek
+      # @return [RubySMB::SMB2::Packet::IoctlResponse]
+      def peek(peek_size: 0)
+        packet = RubySMB::SMB2::Packet::IoctlRequest.new
+        packet.ctl_code = RubySMB::Fscc::ControlCodes::FSCTL_PIPE_PEEK
+        packet.flags.is_fsctl = true
+        # read at least 16 bytes for state, avail, msg_count, first_msg_len
+        packet.max_output_response = 16 + peek_size
+        packet = set_header_fields(packet)
+        resp = @tree.client.send_recv(packet)
+        RubySMB::SMB2::Packet::IoctlResponse.read(resp)
+      end
+
+      def peek_available
+        packet = peek
+        state, avail, msg_count, first_msg_len = packet.buffer.unpack('VVVV')
+        # Only 1 of these should be non-zero
+        avail or first_msg_len
+      end
+
+      def peek_state
+        packet = peek
+        packet.buffer.unpack('V')[0]
+      end
+
+    end
+  end
+end

--- a/lib/ruby_smb/smb2/pipe.rb
+++ b/lib/ruby_smb/smb2/pipe.rb
@@ -42,6 +42,11 @@ module RubySMB
         packet.buffer.unpack('V')[0]
       end
 
+      # @return [Boolean] True if pipe is connected, false otherwise
+      def is_connected?
+        peek_state == STATUS_CONNECTED
+      end
+
     end
   end
 end

--- a/spec/lib/ruby_smb/nbss/session_header_spec.rb
+++ b/spec/lib/ruby_smb/nbss/session_header_spec.rb
@@ -16,14 +16,14 @@ RSpec.describe RubySMB::Nbss::SessionHeader do
   end
 
   describe '#flags' do
-    it 'is a 8-bit Unsigned Integer' do
-      expect(session_header.flags).to be_a BinData::Uint8
+    it 'is a 7-bit Unsigned Integer' do
+      expect(session_header.flags).to be_a BinData::Bit7
     end
   end
 
   describe '#packet_length' do
-    it 'is a 16-bit Unsigned Integer' do
-      expect(session_header.packet_length).to be_a BinData::Uint16be
+    it 'is a 17-bit Unsigned Integer' do
+      expect(session_header.packet_length).to be_a BinData::Bit17
     end
   end
 end

--- a/spec/lib/ruby_smb/smb1/bit_field/trans_flags_spec.rb
+++ b/spec/lib/ruby_smb/smb1/bit_field/trans_flags_spec.rb
@@ -1,0 +1,26 @@
+RSpec.describe RubySMB::SMB1::BitField::TransFlags do
+  subject(:flags) { described_class.new }
+
+  it { is_expected.to respond_to :no_response }
+  it { is_expected.to respond_to :disconnect }
+
+  it 'is little endian' do
+    expect(described_class.fields.instance_variable_get(:@hints)[:endian]).to eq :little
+  end
+
+  describe '#no_response' do
+    it 'should be a 1-bit field per the SMB spec' do
+      expect(flags.no_response).to be_a BinData::Bit1
+    end
+
+    it_behaves_like 'bit field with one flag set', :no_response, 'C', 0x02
+  end
+
+  describe '#disconnect' do
+    it 'should be a 1-bit field per the SMB spec' do
+      expect(flags.disconnect).to be_a BinData::Bit1
+    end
+
+    it_behaves_like 'bit field with one flag set', :disconnect, 'C', 0x01
+  end
+end

--- a/spec/lib/ruby_smb/smb1/packet/trans/peek_nmpipe_request_spec.rb
+++ b/spec/lib/ruby_smb/smb1/packet/trans/peek_nmpipe_request_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+RSpec.describe RubySMB::SMB1::Packet::Trans::PeekNmpipeRequest do
+
+  subject(:packet) { described_class.new }
+
+  describe '#smb_header' do
+    subject(:header) { packet.smb_header }
+
+    it 'is a standard SMB Header' do
+      expect(header).to be_a RubySMB::SMB1::SMBHeader
+    end
+
+    it 'should have the command set to SMB_COM_TRANSACTION' do
+      expect(header.command).to eq RubySMB::SMB1::Commands::SMB_COM_TRANSACTION
+    end
+
+    it 'should not have the response flag set' do
+      expect(header.flags.reply).to eq 0
+    end
+  end
+
+  describe '#parameter_block' do
+    subject(:parameter_block) { packet.parameter_block }
+
+    it 'is a standard Trans ParameterBlock' do
+      expect(parameter_block).to be_a RubySMB::SMB1::Packet::Trans::Request::ParameterBlock
+    end
+
+    it 'should have a setup_count of 2' do
+      expect(parameter_block.setup_count).to eq 2
+    end
+
+    it 'should have subcommand PEEK_NMPIPE' do
+      expect(parameter_block.setup[0]).to eq RubySMB::SMB1::Packet::Trans::Subcommands::PEEK_NMPIPE
+    end
+  end
+
+  describe '#data_block' do
+    subject(:data_block) { packet.data_block }
+
+    it 'should have a name of \\PIPE\\' do
+      expect(data_block.name).to eq "\\PIPE\\"
+    end
+  end
+
+end

--- a/spec/lib/ruby_smb/smb1/packet/trans/peek_nmpipe_response_spec.rb
+++ b/spec/lib/ruby_smb/smb1/packet/trans/peek_nmpipe_response_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+RSpec.describe RubySMB::SMB1::Packet::Trans::PeekNmpipeResponse do
+
+  subject(:packet) { described_class.new }
+
+  describe '#smb_header' do
+    subject(:header) { packet.smb_header }
+
+    it 'is a standard SMB Header' do
+      expect(header).to be_a RubySMB::SMB1::SMBHeader
+    end
+
+    it 'should have the command set to SMB_COM_TRANSACTION' do
+      expect(header.command).to eq RubySMB::SMB1::Commands::SMB_COM_TRANSACTION
+    end
+
+    it 'should have the response flag set' do
+      expect(header.flags.reply).to eq 1
+    end
+  end
+
+  describe '#parameter_block' do
+    subject(:parameter_block) { packet.parameter_block }
+
+    it 'is a standard Trans ParameterBlock' do
+      expect(parameter_block).to be_a RubySMB::SMB1::Packet::Trans::Response::ParameterBlock
+    end
+  end
+
+end

--- a/spec/lib/ruby_smb/smb1/packet/trans/request_spec.rb
+++ b/spec/lib/ruby_smb/smb1/packet/trans/request_spec.rb
@@ -1,0 +1,94 @@
+require 'spec_helper'
+
+RSpec.describe RubySMB::SMB1::Packet::Trans::Request do
+  subject(:packet) { described_class.new }
+
+  describe '#smb_header' do
+    subject(:header) { packet.smb_header }
+
+    it 'is a standard SMB Header' do
+      expect(header).to be_a RubySMB::SMB1::SMBHeader
+    end
+
+    it 'should have the command set to SMB_COM_NEGOTIATE' do
+      expect(header.command).to eq RubySMB::SMB1::Commands::SMB_COM_TRANSACTION
+    end
+
+    it 'should not have the response flag set' do
+      expect(header.flags.reply).to eq 0
+    end
+  end
+
+  describe '#parameter_block' do
+    subject(:parameter_block) { packet.parameter_block }
+
+    it 'is a standard ParameterBlock' do
+      expect(parameter_block).to be_a RubySMB::SMB1::ParameterBlock
+    end
+
+    it { is_expected.to respond_to :total_parameter_count }
+    it { is_expected.to respond_to :total_data_count }
+    it { is_expected.to respond_to :max_parameter_count }
+    it { is_expected.to respond_to :max_data_count }
+    it { is_expected.to respond_to :max_setup_count }
+    it { is_expected.to respond_to :timeout }
+    it { is_expected.to respond_to :parameter_count }
+    it { is_expected.to respond_to :parameter_offset }
+    it { is_expected.to respond_to :data_count }
+    it { is_expected.to respond_to :data_offset }
+    it { is_expected.to respond_to :setup_count }
+
+    describe 'flags' do
+      it 'is a trans_flags BitField' do
+        expect(parameter_block.flags).to be_a RubySMB::SMB1::BitField::TransFlags
+      end
+    end
+
+    describe 'parameter_count' do
+      it 'is a count of bytes in the data_block trans_parameters field' do
+        packet.data_block.trans_parameters = "\x00\x01\x02\x03"
+        expect(parameter_block.parameter_count).to eq 4
+      end
+    end
+
+    describe 'parameter_offset' do
+      it ' contains the absolute_offset to the data_block trans_parameters field' do
+        expect(parameter_block.parameter_offset).to eq packet.data_block.trans_parameters.abs_offset
+      end
+    end
+
+    describe 'data_count' do
+      it 'is a count of bytes in the data_block trans_data field' do
+        packet.data_block.trans_data = "\x00\x01\x02\x03"
+        expect(parameter_block.data_count).to eq 4
+      end
+    end
+
+    describe 'data_offset' do
+      it 'contains the absolute_offset to the data_block trans_data field' do
+        expect(parameter_block.data_offset).to eq packet.data_block.trans_data.abs_offset
+      end
+    end
+  end
+
+  describe '#data_block' do
+    subject(:data_block) { packet.data_block }
+
+    it 'is a standard DataBlock' do
+      expect(data_block).to be_a RubySMB::SMB1::DataBlock
+    end
+
+    it { is_expected.to respond_to :name }
+    it { is_expected.to respond_to :trans_parameters }
+    it { is_expected.to respond_to :trans_data }
+
+    it 'should keep #trans_parameters 4-byte aligned' do
+      expect(data_block.trans_parameters.abs_offset % 4).to eq 0
+    end
+
+    it 'should keep #trans_data 4-byte aligned' do
+      data_block.trans_parameters = 'a'
+      expect(data_block.trans_data.abs_offset % 4).to eq 0
+    end
+  end
+end

--- a/spec/lib/ruby_smb/smb1/packet/trans/response_spec.rb
+++ b/spec/lib/ruby_smb/smb1/packet/trans/response_spec.rb
@@ -1,0 +1,85 @@
+require 'spec_helper'
+
+RSpec.describe RubySMB::SMB1::Packet::Trans::Response do
+  subject(:packet) { described_class.new }
+
+  describe '#smb_header' do
+    subject(:header) { packet.smb_header }
+
+    it 'is a standard SMB Header' do
+      expect(header).to be_a RubySMB::SMB1::SMBHeader
+    end
+
+    it 'should have the command set to SMB_COM_NEGOTIATE' do
+      expect(header.command).to eq RubySMB::SMB1::Commands::SMB_COM_TRANSACTION
+    end
+
+    it 'should have the response flag set' do
+      expect(header.flags.reply).to eq 1
+    end
+  end
+
+  describe '#parameter_block' do
+    subject(:parameter_block) { packet.parameter_block }
+
+    it 'is a standard ParameterBlock' do
+      expect(parameter_block).to be_a RubySMB::SMB1::ParameterBlock
+    end
+
+    it { is_expected.to respond_to :total_parameter_count }
+    it { is_expected.to respond_to :total_data_count }
+    it { is_expected.to respond_to :parameter_count }
+    it { is_expected.to respond_to :parameter_offset }
+    it { is_expected.to respond_to :parameter_displacement }
+    it { is_expected.to respond_to :data_count }
+    it { is_expected.to respond_to :data_offset }
+    it { is_expected.to respond_to :parameter_displacement }
+    it { is_expected.to respond_to :setup_count }
+
+    describe 'parameter_count' do
+      it 'is a count of bytes in the data_block trans_parameters field' do
+        packet.data_block.trans_parameters = "\x00\x01\x02\x03"
+        expect(parameter_block.parameter_count).to eq 4
+      end
+    end
+
+    describe 'parameter_offset' do
+      it ' contains the absolute_offset to the data_block trans_parameters field' do
+        expect(parameter_block.parameter_offset).to eq packet.data_block.trans_parameters.abs_offset
+      end
+    end
+
+    describe 'data_count' do
+      it 'is a count of bytes in the data_block trans_data field' do
+        packet.data_block.trans_data = "\x00\x01\x02\x03"
+        expect(parameter_block.data_count).to eq 4
+      end
+    end
+
+    describe 'data_offset' do
+      it 'contains the absolute_offset to the data_block trans_data field' do
+        expect(parameter_block.data_offset).to eq packet.data_block.trans_data.abs_offset
+      end
+    end
+  end
+
+  describe '#data_block' do
+    subject(:data_block) { packet.data_block }
+
+    it 'is a Trans DataBlock' do
+      expect(data_block).to be_a RubySMB::SMB1::Packet::Trans::DataBlock
+    end
+
+    it { is_expected.to respond_to :trans_parameters }
+    it { is_expected.to respond_to :trans_data }
+
+    it 'should keep #trans_parameters 4-byte aligned' do
+      expect(data_block.trans_parameters.abs_offset % 4).to eq 0
+    end
+
+    it 'should keep #trans_data 4-byte aligned' do
+      data_block.trans_parameters = 'a'
+      expect(data_block.trans_data.abs_offset % 4).to eq 0
+    end
+  end
+end

--- a/spec/lib/ruby_smb/smb1/packet/trans2/open2_response_spec.rb
+++ b/spec/lib/ruby_smb/smb1/packet/trans2/open2_response_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe RubySMB::SMB1::Packet::Trans2::Open2Response do
       expect(header).to be_a RubySMB::SMB1::SMBHeader
     end
 
-    it 'should have the command set to SMB_COM_NEGOTIATE' do
+    it 'should have the command set to SMB_COM_TRANSACTION2' do
       expect(header.command).to eq RubySMB::SMB1::Commands::SMB_COM_TRANSACTION2
     end
 

--- a/spec/lib/ruby_smb/smb1/pipe_spec.rb
+++ b/spec/lib/ruby_smb/smb1/pipe_spec.rb
@@ -1,0 +1,65 @@
+RSpec.describe RubySMB::SMB1::Pipe do
+
+  let(:peek_nmpipe_response) {
+    packet = RubySMB::SMB1::Packet::Trans::PeekNmpipeResponse.new
+    packet.data_block.trans_parameters.read("\x10\x20\x00\x00\x03\x00")
+    packet
+  }
+
+  describe RubySMB::SMB1::Pipe do
+    it { expect(described_class).to be < RubySMB::SMB1::File }
+  end
+
+  let(:dispatcher) { RubySMB::Dispatcher::Socket.new(double('socket')) }
+  let(:client) { RubySMB::Client.new(dispatcher, username: 'msfadmin', password: 'msfadmin') }
+  let(:connect_response) {
+    packet = RubySMB::SMB1::Packet::TreeConnectResponse.new
+    packet.smb_header.tid = 2051
+    packet.parameter_block.guest_access_rights.read("\xff\x01\x1f\x00")
+    packet.parameter_block.access_rights.read("\xff\x01\x1f\x01")
+    packet
+  }
+  let(:tree) { RubySMB::SMB1::Tree.new(client: client, share: '\\1.2.3.4\IPC$', response: connect_response) }
+  let(:nt_create_andx_response) {
+    response = RubySMB::SMB1::Packet::NtCreateAndxResponse.new
+    response.parameter_block.ext_file_attributes = { normal: 1 }
+    response.parameter_block.fid = 0x4000
+    response.parameter_block.last_access_time = DateTime.parse("2017-09-20T1:1:1")
+    response.parameter_block.last_change_time = DateTime.parse("2017-09-22T2:2:2")
+    response.parameter_block.last_write_time  = DateTime.parse("2017-09-25T3:3:3")
+    response.parameter_block.end_of_file = 53
+    response.parameter_block.allocation_size = 4096
+    response
+  }
+  let(:filename) { 'msf-pipe' }
+
+  subject(:pipe) {
+    described_class.new(tree: tree, response: nt_create_andx_response, name: filename)
+  }
+
+  describe '#peek_available' do
+    it 'reads the correct number of bytes available' do
+      allow(pipe).to receive(:peek) { peek_nmpipe_response }
+      allow(pipe).to receive(:peek_available) { pipe.peek.data_block.trans_parameters.read_data_available }
+      expect(pipe.peek_available).to eq(0x2010)
+    end
+  end
+
+  describe '#peek_state' do
+    it 'reads the correct state of the pipe' do
+      allow(pipe).to receive(:peek) { peek_nmpipe_response }
+      allow(pipe).to receive(:peek_state) { pipe.peek.data_block.trans_parameters.pipe_state }
+      expect(pipe.peek_state).to eq(RubySMB::SMB1::Pipe::STATUS_OK)
+    end
+  end
+
+  describe '#is_connected?' do
+    it 'identifies that the pipe is connected from the status' do
+      allow(pipe).to receive(:peek) { peek_nmpipe_response }
+      allow(pipe).to receive(:peek_state) { pipe.peek.data_block.trans_parameters.pipe_state }
+      allow(pipe).to receive(:is_connected?) { pipe.peek_state == RubySMB::SMB1::Pipe::STATUS_OK }
+      expect(pipe.is_connected?).to eq(true)
+    end
+  end
+
+end

--- a/spec/lib/ruby_smb/smb2/pipe_spec.rb
+++ b/spec/lib/ruby_smb/smb2/pipe_spec.rb
@@ -1,0 +1,64 @@
+RSpec.describe RubySMB::SMB2::Pipe do
+
+  let(:sock) { double('Socket', peeraddr: '192.168.1.5') }
+  let(:dispatcher) { RubySMB::Dispatcher::Socket.new(sock) }
+
+  let(:client) { RubySMB::Client.new(dispatcher, username: 'msfadmin', password: 'msfadmin') }
+  let(:tree_id) { 2049 }
+  let(:path) { '\\192.168.1.1\IPC$' }
+  let(:connect_response) {
+    packet = RubySMB::SMB2::Packet::TreeConnectResponse.new
+    packet.smb2_header.tree_id = tree_id
+    packet.maximal_access.read("\xff\x01\x1f\x00")
+    packet.share_type = 0x01
+    packet
+  }
+
+  let(:tree) { RubySMB::SMB2::Tree.new(client: client, share: path, response: connect_response) }
+  let(:file_id) { RubySMB::Field::Smb2Fileid.read('\x6d\x01\x00\x00\x00\x00\x00\x00\x\x01\x00\x00\x00\xff\xff\xff\xff') }
+  let(:time) { DateTime.now }
+  let(:create_response) {
+    RubySMB::SMB2::Packet::CreateResponse.new(
+      file_id: file_id,
+      end_of_file: 108,
+      allocation_size: 112,
+      last_access: time,
+      last_change: time,
+      last_write: time
+    )
+  }
+
+  let(:ioctl_response) {
+    packet = RubySMB::SMB2::Packet::IoctlResponse.new
+    packet.buffer = "\x03\x00\x00\x00" + "\x10\x20\x30\x40" + "\x00\x00\x00\x00" + "\x00\x00\x00\x00"
+    packet
+  }
+
+  subject(:pipe) { described_class.new(name: 'msf-pipe', response: create_response, tree: tree) }
+
+  describe '#peek_available' do
+    it 'reads the correct number of bytes available' do
+      allow(pipe).to receive(:peek) { ioctl_response }
+      allow(pipe).to receive(:peek_available) { pipe.peek.buffer.unpack('VV')[1] }
+      expect(pipe.peek_available).to eq(0x40302010)
+    end
+  end
+  
+  describe '#peek_state' do
+    it 'reads the correct state of the pipe' do
+      allow(pipe).to receive(:peek) { ioctl_response }
+      allow(pipe).to receive(:peek_state)  { pipe.peek.buffer.unpack('V')[0] }
+      expect(pipe.peek_state).to eq(RubySMB::SMB2::Pipe::STATUS_CONNECTED)
+    end
+  end
+
+  describe '#is_connected?' do
+    it 'identifies that the pipe is connected from the status' do
+      allow(pipe).to receive(:peek) { ioctl_response }
+      allow(pipe).to receive(:peek_state)  { pipe.peek.buffer.unpack('V')[0] }
+      allow(pipe).to receive(:is_connected?) { pipe.peek_state == RubySMB::SMB2::Pipe::STATUS_CONNECTED }
+      expect(pipe.is_connected?).to eq(true)
+    end
+  end
+
+end


### PR DESCRIPTION
This PR contains progress towards replacing Rex in simpleclient. Specifically, it adds pipe functionality for the bind_named_pipe payload.

## Changes
1) Added missing "reserved" field to SMB2 TREE_DISCONNECT Requests
2) Added SMB1::Pipe and SMB2::Pipe which subclass File and provide pipe specific operations such as "peek". Correct instance of File or Pipe is returned by Tree.open_file.
3) Nbss::SessionHeader length field increased from 16 to 17 bits. For SMB2 this field can be 24 bits. This change allows server max read/write/transact sizes to be used as is (they are typically 64KiB).
   References
      SMB1 https://msdn.microsoft.com/en-us/library/cc246249.aspx
      SMB2 https://msdn.microsoft.com/en-us/library/cc246496.aspx
4) Save off max read/write/transact sizes from SMB2 negotiation. It isn't clear to me how/if these apply differently to files vs pipes. For files, larger requests can be issued (observed with smbclient). Enforcing this limit for both, for now at least.
5) Added examples/pipes.rb to demonstrate new functionality.

## Future Improvements
1) Async read/writes. This should improve bind_named_pipe comms by not having to constantly poll metsrv (get rid of peeking). The current model is to send a request then wait for the response, as it is in Rex. This is an issue for the bind_named_pipe payload because the packet dispatcher has multiple threads trying to read and write. Pipe reads/writes must be synchronized to get bind_named_pipe comms to work. I still need a better understanding of this issue.

## Refs
https://github.com/rapid7/metasploit-framework/pull/9365