### PR TITLE
Fix SMB2 DCERPC bind request with Windows 10

### DIFF
--- a/lib/ruby_smb/smb2/dcerpc.rb
+++ b/lib/ruby_smb/smb2/dcerpc.rb
@@ -13,9 +13,11 @@ module RubySMB
 
       def bind(options={})
         bind_req = RubySMB::Dcerpc::Bind.new(options)
-        ioctl_response = ioctl_send_recv(bind_req, options)
+        write(data: bind_req.to_binary_s)
+        @size = 1024
+        dcerpc_raw_response = read()
         begin
-          dcerpc_response = RubySMB::Dcerpc::BindAck.read(ioctl_response.output_data)
+          dcerpc_response = RubySMB::Dcerpc::BindAck.read(dcerpc_raw_response)
         rescue IOError
           raise RubySMB::Dcerpc::Error::InvalidPacket, "Error reading the DCERPC response"
         end

--- a/lib/ruby_smb/smb2/packet/ioctl_request.rb
+++ b/lib/ruby_smb/smb2/packet/ioctl_request.rb
@@ -16,7 +16,7 @@ module RubySMB
         uint32        :max_input_response,  label: 'Max Input Response'
         uint32        :output_offset,       label: 'Output Offset',       initial_value: -> { input_offset + output_count }
         uint32        :output_count,        label: 'Output Count'
-        uint32        :max_output_response, label: 'Max Output response', initial_value: 65536
+        uint32        :max_output_response, label: 'Max Output response', initial_value: 1024
 
         struct :flags do
           bit7  :reserved1, label: 'Reserved Space'


### PR DESCRIPTION
This PR includes:

**1. Use SMB2 Write/Read instead of IOCTL request to send the DCERPC Bind request**
After multiple tests with different Windows versions, I noticed that the Bind request use a standard SMB2 Write/Read function to send the Bind request and retrieve the BindAck response.

**2. Change the default value of `max_output_response` for `IoctlRequest`**
This was causing issue with recent Windows (STATUS_INVALID_PARAMETER).