### PR TITLE
Fix TreeConnectResponse Packet for Old Samba Versions

### DIFF
--- a/lib/ruby_smb/smb1/packet/tree_connect_response.rb
+++ b/lib/ruby_smb/smb1/packet/tree_connect_response.rb
@@ -8,8 +8,8 @@ module RubySMB
         class ParameterBlock < RubySMB::SMB1::ParameterBlock
           and_x_block                :andx_block
           optional_support           :optional_support
-          directory_access_mask      :access_rights,       label: 'Maximal Share Access Rights'
-          directory_access_mask      :guest_access_rights, label: 'Guest Share Access Rights'
+          directory_access_mask      :access_rights,       label: 'Maximal Share Access Rights', onlyif: -> { word_count >= 5 }
+          directory_access_mask      :guest_access_rights, label: 'Guest Share Access Rights',   onlyif: -> { word_count == 7 }
         end
 
         # Represents the specific layout of the DataBlock for a {SessionSetupResponse} Packet.

--- a/spec/lib/ruby_smb/smb1/packet/tree_connect_response_spec.rb
+++ b/spec/lib/ruby_smb/smb1/packet/tree_connect_response_spec.rb
@@ -34,6 +34,32 @@ RSpec.describe RubySMB::SMB1::Packet::TreeConnectResponse do
     it 'has an AndXBlock' do
       expect(parameter_block.andx_block).to be_a RubySMB::SMB1::AndXBlock
     end
+
+    context 'when #word_count is less than 5' do
+      before :example do
+        parameter_block.word_count = 3
+      end
+
+      it 'has #access_rights and #guest_access_rights fields disabled' do
+        expect(parameter_block.andx_block?). to be true
+        expect(parameter_block.optional_support?). to be true
+        expect(parameter_block.access_rights?). to be false
+        expect(parameter_block.guest_access_rights?). to be false
+      end
+    end
+
+    context 'when #word_count is 5' do
+      before :example do
+        parameter_block.word_count = 5
+      end
+
+      it 'has the #guest_access_rights field disabled' do
+        expect(parameter_block.andx_block?). to be true
+        expect(parameter_block.optional_support?). to be true
+        expect(parameter_block.access_rights?). to be true
+        expect(parameter_block.guest_access_rights?). to be false
+      end
+    end
   end
 
   describe '#data_block' do


### PR DESCRIPTION
## Description
Old versions of Samba does not respect the SMB extension protocol for TreeConnectResponse packets (https://msdn.microsoft.com/en-us/library/cc246331.aspx). Comparing to CIFS (https://msdn.microsoft.com/en-us/library/ee441613.aspx), SMB specifies two new fields in the SMBParameter block: `MaximalShareAccessRights` and `GuestMaximalShareAccessRights`. However, old versions of Samba are not sending these fields, which breaks RubySMB (tested with Samba 3.0.22). Newer versions correctly include these two fields (tested with Samba 3.4.7).

This PR adds conditional statements for these fields to avoid breaking when these packets are parsed.

## Verification Steps
- [x] `bundle install`
- [x] Verify you can connect to a remote share with SMB1 and SMB2on an old Samba version (3.0.22): `ruby examples/tree_connect.rb <ip-address> <username> <password> <share>`

## rake spec
- [x] `rake spec`
- [x] VERIFY no failures
