### PR TITLE
Error fixes

### DIFF
--- a/lib/ruby_smb/generic_packet.rb
+++ b/lib/ruby_smb/generic_packet.rb
@@ -42,7 +42,7 @@ module RubySMB
     def self.read(val)
       begin
         super(val)
-      rescue EOFError, IOError => e
+      rescue IOError => e
         case self.to_s
           when /EmptyPacket|ErrorPacket/
             raise e

--- a/lib/ruby_smb/generic_packet.rb
+++ b/lib/ruby_smb/generic_packet.rb
@@ -42,7 +42,7 @@ module RubySMB
     def self.read(val)
       begin
         super(val)
-      rescue EOFError => e
+      rescue EOFError, IOError => e
         case self.to_s
           when /EmptyPacket|ErrorPacket/
             raise e

--- a/lib/ruby_smb/smb1/file.rb
+++ b/lib/ruby_smb/smb1/file.rb
@@ -225,7 +225,7 @@ module RubySMB
       def write_packet(data:'', offset: 0)
         write_request = set_header_fields(RubySMB::SMB1::Packet::WriteAndxRequest.new)
         write_request.parameter_block.offset = offset
-        write_request.parameter_block.write_mode.writethrough_mode = 1
+        write_request.parameter_block.write_mode.msg_start = 1
         write_request.data_block.data = data
         write_request.parameter_block.remaining = write_request.parameter_block.data_length
         write_request
@@ -233,6 +233,7 @@ module RubySMB
       
       def send_recv_write(data:'', offset: 0)
         pkt = write_packet(data: data, offset: offset)
+        pkt.set_64_bit_offset(true)
         raw_response = @tree.client.send_recv(pkt)
         response = RubySMB::SMB1::Packet::WriteAndxResponse.read(raw_response)
         response.parameter_block.count_low

--- a/lib/ruby_smb/smb1/file.rb
+++ b/lib/ruby_smb/smb1/file.rb
@@ -225,7 +225,7 @@ module RubySMB
       def write_packet(data:'', offset: 0)
         write_request = set_header_fields(RubySMB::SMB1::Packet::WriteAndxRequest.new)
         write_request.parameter_block.offset = offset
-        write_request.parameter_block.write_mode.msg_start = 1
+        write_request.parameter_block.write_mode.writethrough_mode = 1
         write_request.data_block.data = data
         write_request.parameter_block.remaining = write_request.parameter_block.data_length
         write_request

--- a/lib/ruby_smb/smb2/file.rb
+++ b/lib/ruby_smb/smb2/file.rb
@@ -219,7 +219,10 @@ module RubySMB
         pkt = write_packet(data: data, offset: offset)
         raw_response = tree.client.send_recv(pkt)
         response = RubySMB::SMB2::Packet::WriteResponse.read(raw_response)
-        if response.status_code != WindowsError::NTStatus::STATUS_SUCCESS
+        if response.status_code == WindowsError::NTStatus::STATUS_PENDING
+          sleep 1
+          return send_recv_write(data: data, offset: offset)
+        elsif response.status_code != WindowsError::NTStatus::STATUS_SUCCESS
           raise RubySMB::Error::UnexpectedStatusCode, response.status_code.name
         end
         response.write_count

--- a/lib/ruby_smb/smb2/file.rb
+++ b/lib/ruby_smb/smb2/file.rb
@@ -140,7 +140,8 @@ module RubySMB
         response = RubySMB::SMB2::Packet::ReadResponse.read(raw_response)
         if response.status_code == WindowsError::NTStatus::STATUS_PENDING
           sleep 1
-          return send_recv_read(read_length: read_length, offset: offset)
+          raw_response = tree.client.dispatcher.recv_packet
+          response = RubySMB::SMB2::Packet::ReadResponse.read(raw_response)
         elsif response.status_code != WindowsError::NTStatus::STATUS_SUCCESS
           raise RubySMB::Error::UnexpectedStatusCode, response.status_code.name
         end
@@ -221,7 +222,8 @@ module RubySMB
         response = RubySMB::SMB2::Packet::WriteResponse.read(raw_response)
         if response.status_code == WindowsError::NTStatus::STATUS_PENDING
           sleep 1
-          return send_recv_write(data: data, offset: offset)
+          raw_response = tree.client.dispatcher.recv_packet
+          response = RubySMB::SMB2::Packet::WriteResponse.read(raw_response)
         elsif response.status_code != WindowsError::NTStatus::STATUS_SUCCESS
           raise RubySMB::Error::UnexpectedStatusCode, response.status_code.name
         end

--- a/lib/ruby_smb/smb2/tree.rb
+++ b/lib/ruby_smb/smb2/tree.rb
@@ -90,6 +90,10 @@ module RubySMB
         raw_response  = client.send_recv(create_request)
         response      = RubySMB::SMB2::Packet::CreateResponse.read(raw_response)
 
+        if response.is_a?(RubySMB::SMB2::Packet::ErrorPacket)
+          raise RubySMB::Error::RubySMBError
+        end
+
         case @share_type
         when 0x01
           RubySMB::SMB2::File.new(name: filename, tree: self, response: response)


### PR DESCRIPTION
Catch IOError that occurs when parsing an ErrorPacket as ResponsePacket.
Remove unused access variable in utils open.
Add STATUS_PENDING checks.