### PR TITLE
don't pass a socket straight into bindata read

### DIFF
--- a/lib/ruby_smb/dispatcher/socket.rb
+++ b/lib/ruby_smb/dispatcher/socket.rb
@@ -66,7 +66,7 @@ module RubySMB
         end
 
         begin
-          nbss_header = RubySMB::Nbss::SessionHeader.read(@tcp_socket)
+          nbss_header = RubySMB::Nbss::SessionHeader.read(@tcp_socket.read(4))
         rescue IOError
           raise ::RubySMB::Error::NetBiosSessionService, 'NBSS Header is missing'
         end

--- a/lib/ruby_smb/dispatcher/socket.rb
+++ b/lib/ruby_smb/dispatcher/socket.rb
@@ -66,7 +66,9 @@ module RubySMB
         end
 
         begin
-          nbss_header = RubySMB::Nbss::SessionHeader.read(@tcp_socket.read(4))
+          nbss_data = @tcp_socket.read(4)
+          raise IOError if nbss_data.nil?
+          nbss_header = RubySMB::Nbss::SessionHeader.read(nbss_data)
         rescue IOError
           raise ::RubySMB::Error::NetBiosSessionService, 'NBSS Header is missing'
         end

--- a/spec/lib/ruby_smb/dispatcher/socket_spec.rb
+++ b/spec/lib/ruby_smb/dispatcher/socket_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe RubySMB::Dispatcher::Socket do
       end
 
       it 'reads the nbss header using Nbss::SessionHeader structure' do
-        expect(RubySMB::Nbss::SessionHeader).to receive(:read).with(response_socket).and_return(session_header)
+        expect(RubySMB::Nbss::SessionHeader).to receive(:read).with(nbss).and_return(session_header)
         smb_socket.recv_packet
       end
 
@@ -105,6 +105,7 @@ RSpec.describe RubySMB::Dispatcher::Socket do
         packet_length = 10
         session_header.packet_length = packet_length
         allow(RubySMB::Nbss::SessionHeader).to receive(:read).and_return(session_header)
+        expect(response_socket).to receive(:read).with(4).and_return(session_header)
         expect(response_socket).to receive(:read).with(packet_length).and_return('A' * packet_length)
         smb_socket.recv_packet
       end
@@ -116,6 +117,7 @@ RSpec.describe RubySMB::Dispatcher::Socket do
           session_header.packet_length = packet_length
           allow(RubySMB::Nbss::SessionHeader).to receive(:read).and_return(session_header)
 
+          expect(response_socket).to receive(:read).with(4).and_return(session_header)
           loop do
             expect(response_socket).to receive(:read).with(packet_length).and_return('A' * returned_length).once
             packet_length -= returned_length


### PR DESCRIPTION
Seekability on a _socket_ is OS-dependent, so we should instead read what we want into a string/buffer and pass that in instead. This was the only occurence I could find. Fixes support on Windows. Without this, we get the following backtrace on the first send_recv call on a Windows host:

```
c:/metasploit-framework/embedded/lib/ruby/gems/2.3.0/gems/bindata-2.4.3/lib/bindata/io.rb:31:in `pos'
c:/metasploit-framework/embedded/lib/ruby/gems/2.3.0/gems/bindata-2.4.3/lib/bindata/io.rb:31:in `seekable?'
c:/metasploit-framework/embedded/lib/ruby/gems/2.3.0/gems/bindata-2.4.3/lib/bindata/io.rb:23:in `initialize'
c:/metasploit-framework/embedded/lib/ruby/gems/2.3.0/gems/bindata-2.4.3/lib/bindata/io.rb:240:in `initialize'
c:/metasploit-framework/embedded/lib/ruby/gems/2.3.0/gems/bindata-2.4.3/lib/bindata/base.rb:143:in `new'
c:/metasploit-framework/embedded/lib/ruby/gems/2.3.0/gems/bindata-2.4.3/lib/bindata/base.rb:143:in `read'
c:/metasploit-framework/embedded/lib/ruby/gems/2.3.0/gems/bindata-2.4.3/lib/bindata/base.rb:21:in `read'
c:/metasploit-framework/embedded/lib/ruby/gems/2.3.0/gems/ruby_smb-1.0.2/lib/ruby_smb/dispatcher/socket.rb:69:in `recv_packet'
c:/metasploit-framework/embedded/lib/ruby/gems/2.3.0/gems/ruby_smb-1.0.2/lib/ruby_smb/client.rb:334:in `send_recv'
c:/metasploit-framework/embedded/lib/ruby/gems/2.3.0/gems/ruby_smb-1.0.2/lib/ruby_smb/client/negotiation.rb:14:in `negotiate'
c:/metasploit-framework/embedded/framework/lib/rex/proto/smb/simpleclient.rb:77:in `login'
c:/metasploit-framework/embedded/framework/lib/msf/core/exploit/smb/client.rb:132:in `smb_login'
c:/metasploit-framework/embedded/framework/modules/exploits/windows/smb/psexec.rb:94:in `exploit'
```