### PR TITLE
Improve Error Handling

### DIFF
--- a/lib/ruby_smb/client.rb
+++ b/lib/ruby_smb/client.rb
@@ -303,13 +303,26 @@ module RubySMB
         request      = RubySMB::SMB2::Packet::LogoffRequest.new
         raw_response = send_recv(request)
         response     = RubySMB::SMB2::Packet::LogoffResponse.read(raw_response)
+        unless response.valid?
+          raise RubySMB::Error::InvalidPacket.new(
+            expected_proto: RubySMB::SMB2::SMB2_PROTOCOL_ID,
+            expected_cmd:   RubySMB::SMB2::Packet::LogoffResponse::COMMAND,
+            received_proto: response.smb2_header.protocol,
+            received_cmd:   response.smb2_header.command
+          )
+        end
       else
         request      = RubySMB::SMB1::Packet::LogoffRequest.new
         raw_response = send_recv(request)
         response     = RubySMB::SMB1::Packet::LogoffResponse.read(raw_response)
-      end
-      unless response.valid?
-        raise RubySMB::Error::InvalidPacket, 'Not a LogoffResponse packet'
+        unless response.valid?
+          raise RubySMB::Error::InvalidPacket.new(
+            expected_proto: RubySMB::SMB1::SMB_PROTOCOL_ID,
+            expected_cmd:   RubySMB::SMB1::Packet::LogoffResponse::COMMAND,
+            received_proto: response.smb_header.protocol,
+            received_cmd:   response.smb_header.command
+          )
+        end
       end
       wipe_state!
       response.status_code

--- a/lib/ruby_smb/client.rb
+++ b/lib/ruby_smb/client.rb
@@ -297,6 +297,7 @@ module RubySMB
     # Sends a LOGOFF command to the remote server to terminate the session
     #
     # @return [WindowsError::ErrorCode] the NTStatus of the response
+    # @raise [RubySMB::Error::InvalidPacket] if the response packet is not a LogoffResponse packet
     def logoff!
       if smb2
         request      = RubySMB::SMB2::Packet::LogoffRequest.new
@@ -306,6 +307,9 @@ module RubySMB
         request      = RubySMB::SMB1::Packet::LogoffRequest.new
         raw_response = send_recv(request)
         response     = RubySMB::SMB1::Packet::LogoffResponse.read(raw_response)
+      end
+      unless response.valid?
+        raise RubySMB::Error::InvalidPacket, 'Not a LogoffResponse packet'
       end
       wipe_state!
       response.status_code
@@ -380,14 +384,19 @@ module RubySMB
     # @param name [String] the NetBIOS name to request
     # @return [TrueClass] if session request is granted
     # @raise [RubySMB::Error::NetBiosSessionService] if session request is refused
+    # @raise [RubySMB::Error::InvalidPacket] if the response packet is not a NBSS packet
     def session_request(name = '*SMBSERVER')
       session_request = session_request_packet(name)
       dispatcher.send_packet(session_request, nbss_header: false)
       raw_response = dispatcher.recv_packet(full_response: true)
-      session_header =  RubySMB::Nbss::SessionHeader.read(raw_response)
-      if session_header.session_packet_type == RubySMB::Nbss::NEGATIVE_SESSION_RESPONSE
-        negative_session_response =  RubySMB::Nbss::NegativeSessionResponse.read(raw_response)
-        raise RubySMB::Error::NetBiosSessionService, "Session Request failed: #{negative_session_response.error_msg}"
+      begin
+        session_header = RubySMB::Nbss::SessionHeader.read(raw_response)
+        if session_header.session_packet_type == RubySMB::Nbss::NEGATIVE_SESSION_RESPONSE
+          negative_session_response =  RubySMB::Nbss::NegativeSessionResponse.read(raw_response)
+          raise RubySMB::Error::NetBiosSessionService, "Session Request failed: #{negative_session_response.error_msg}"
+        end
+      rescue IOError
+        raise RubySMB::Error::InvalidPacket, 'Not a NBSS packet'
       end
 
       return true

--- a/lib/ruby_smb/client/authentication.rb
+++ b/lib/ruby_smb/client/authentication.rb
@@ -57,7 +57,12 @@ module RubySMB
         packet = RubySMB::SMB1::Packet::SessionSetupLegacyResponse.read(raw_response)
 
         unless packet.valid?
-          raise RubySMB::Error::InvalidPacket, 'Not a SessionSetupLegacyResponse packet'
+          raise RubySMB::Error::InvalidPacket.new(
+            expected_proto: RubySMB::SMB1::SMB_PROTOCOL_ID,
+            expected_cmd:   RubySMB::SMB1::Packet::SessionSetupLegacyResponse::COMMAND,
+            received_proto: packet.smb_header.protocol,
+            received_cmd:   packet.smb_header.command
+          )
         end
         packet
       end
@@ -146,7 +151,12 @@ module RubySMB
         packet = RubySMB::SMB1::Packet::SessionSetupResponse.read(raw_response)
 
         unless packet.valid?
-          raise RubySMB::Error::InvalidPacket, 'Not a SessionSetupResponse packet'
+          raise RubySMB::Error::InvalidPacket.new(
+            expected_proto: RubySMB::SMB1::SMB_PROTOCOL_ID,
+            expected_cmd:   RubySMB::SMB1::Packet::SessionSetupResponse::COMMAND,
+            received_proto: packet.smb_header.protocol,
+            received_cmd:   packet.smb_header.command
+          )
         end
         packet
       end
@@ -155,7 +165,12 @@ module RubySMB
       def smb1_ntlmssp_challenge_packet(raw_response)
         packet = RubySMB::SMB1::Packet::SessionSetupResponse.read(raw_response)
         unless packet.valid?
-          raise RubySMB::Error::InvalidPacket, 'Not a SessionSetupResponse packet'
+          raise RubySMB::Error::InvalidPacket.new(
+            expected_proto: RubySMB::SMB1::SMB_PROTOCOL_ID,
+            expected_cmd:   RubySMB::SMB1::Packet::SessionSetupResponse::COMMAND,
+            received_proto: packet.smb_header.protocol,
+            received_cmd:   packet.smb_header.command
+          )
         end
 
         status_code = packet.status_code
@@ -205,7 +220,12 @@ module RubySMB
       def smb2_ntlmssp_final_packet(raw_response)
         packet = RubySMB::SMB2::Packet::SessionSetupResponse.read(raw_response)
         unless packet.valid?
-          raise RubySMB::Error::InvalidPacket, 'Not a SessionSetup packet'
+          raise RubySMB::Error::InvalidPacket.new(
+            expected_proto: RubySMB::SMB2::SMB2_PROTOCOL_ID,
+            expected_cmd:   RubySMB::SMB2::Packet::SessionSetupResponse::COMMAND,
+            received_proto: packet.smb2_header.protocol,
+            received_cmd:   packet.smb2_header.command
+          )
         end
 
         packet
@@ -215,7 +235,12 @@ module RubySMB
       def smb2_ntlmssp_challenge_packet(raw_response)
         packet = RubySMB::SMB2::Packet::SessionSetupResponse.read(raw_response)
         unless packet.valid?
-          raise RubySMB::Error::InvalidPacket, 'Not a SessionSetupResponse packet'
+          raise RubySMB::Error::InvalidPacket.new(
+            expected_proto: RubySMB::SMB2::SMB2_PROTOCOL_ID,
+            expected_cmd:   RubySMB::SMB2::Packet::SessionSetupResponse::COMMAND,
+            received_proto: packet.smb2_header.protocol,
+            received_cmd:   packet.smb2_header.command
+          )
         end
 
         status_code = packet.status_code

--- a/lib/ruby_smb/client/authentication.rb
+++ b/lib/ruby_smb/client/authentication.rb
@@ -54,14 +54,10 @@ module RubySMB
       end
 
       def smb1_anonymous_auth_response(raw_response)
-        begin
-          packet = RubySMB::SMB1::Packet::SessionSetupLegacyResponse.read(raw_response)
-        rescue
-          packet = RubySMB::SMB1::Packet::EmptyPacket.read(raw_response)
-        end
+        packet = RubySMB::SMB1::Packet::SessionSetupLegacyResponse.read(raw_response)
 
-        unless packet.smb_header.command == RubySMB::SMB1::Commands::SMB_COM_SESSION_SETUP
-          raise RubySMB::Error::InvalidPacket, "Command was #{packet.smb_header.command} and not #{RubySMB::SMB1::Commands::SMB_COM_SESSION_SETUP}"
+        unless packet.valid?
+          raise RubySMB::Error::InvalidPacket, 'Not a SessionSetupLegacyResponse packet'
         end
         packet
       end
@@ -147,14 +143,10 @@ module RubySMB
 
       # Takes the raw binary string and returns a {RubySMB::SMB1::Packet::SessionSetupResponse}
       def smb1_ntlmssp_final_packet(raw_response)
-        begin
-          packet = RubySMB::SMB1::Packet::SessionSetupResponse.read(raw_response)
-        rescue
-          packet = RubySMB::SMB1::Packet::EmptyPacket.read(raw_response)
-        end
+        packet = RubySMB::SMB1::Packet::SessionSetupResponse.read(raw_response)
 
-        unless packet.smb_header.command == RubySMB::SMB1::Commands::SMB_COM_SESSION_SETUP
-          raise RubySMB::Error::InvalidPacket, "Command was #{packet.smb_header.command} and not #{RubySMB::SMB1::Commands::SMB_COM_SESSION_SETUP}"
+        unless packet.valid?
+          raise RubySMB::Error::InvalidPacket, 'Not a SessionSetupResponse packet'
         end
         packet
       end
@@ -162,15 +154,15 @@ module RubySMB
       # Takes the raw binary string and returns a {RubySMB::SMB1::Packet::SessionSetupResponse}
       def smb1_ntlmssp_challenge_packet(raw_response)
         packet = RubySMB::SMB1::Packet::SessionSetupResponse.read(raw_response)
-        status_code = packet.status_code
+        unless packet.valid?
+          raise RubySMB::Error::InvalidPacket, 'Not a SessionSetupResponse packet'
+        end
 
+        status_code = packet.status_code
         unless status_code.name == 'STATUS_MORE_PROCESSING_REQUIRED'
           raise RubySMB::Error::UnexpectedStatusCode, status_code.to_s
         end
 
-        unless packet.smb_header.command == RubySMB::SMB1::Commands::SMB_COM_SESSION_SETUP
-          raise RubySMB::Error::InvalidPacket, "Command was #{packet.smb_header.command} and not #{RubySMB::SMB1::Commands::SMB_COM_SESSION_SETUP}"
-        end
         packet
       end
 
@@ -212,22 +204,23 @@ module RubySMB
       # Takes the raw binary string and returns a {RubySMB::SMB2::Packet::SessionSetupResponse}
       def smb2_ntlmssp_final_packet(raw_response)
         packet = RubySMB::SMB2::Packet::SessionSetupResponse.read(raw_response)
-        unless packet.smb2_header.command == RubySMB::SMB2::Commands::SESSION_SETUP
-          raise RubySMB::Error::InvalidPacket, "Command was #{packet.smb2_header.command} and not #{RubySMB::SMB2::Commands::SESSION_SETUP}"
+        unless packet.valid?
+          raise RubySMB::Error::InvalidPacket, 'Not a SessionSetup packet'
         end
+
         packet
       end
 
       # Takes the raw binary string and returns a {RubySMB::SMB2::Packet::SessionSetupResponse}
       def smb2_ntlmssp_challenge_packet(raw_response)
         packet = RubySMB::SMB2::Packet::SessionSetupResponse.read(raw_response)
+        unless packet.valid?
+          raise RubySMB::Error::InvalidPacket, 'Not a SessionSetupResponse packet'
+        end
+
         status_code = packet.status_code
         unless status_code.name == 'STATUS_MORE_PROCESSING_REQUIRED'
           raise RubySMB::Error::UnexpectedStatusCode, status_code.to_s
-        end
-
-        unless packet.smb2_header.command == RubySMB::SMB2::Commands::SESSION_SETUP
-          raise RubySMB::Error::InvalidPacket, "Command was #{packet.smb2_header.command} and not #{RubySMB::SMB2::Commands::SESSION_SETUP}"
         end
         packet
       end

--- a/lib/ruby_smb/client/echo.rb
+++ b/lib/ruby_smb/client/echo.rb
@@ -16,7 +16,11 @@ module RubySMB
         (count - 1).times do
           raw_response = dispatcher.recv_packet
         end
-        RubySMB::SMB1::Packet::EchoResponse.read(raw_response)
+        response = RubySMB::SMB1::Packet::EchoResponse.read(raw_response)
+        unless response.valid?
+          raise RubySMB::Error::InvalidPacket, 'Not a EchoResponse packet'
+        end
+        response
       end
 
       # Sends an ECHO request packet and returns the
@@ -26,7 +30,11 @@ module RubySMB
       def smb2_echo
         request      = RubySMB::SMB2::Packet::EchoRequest.new
         raw_response = send_recv(request)
-        RubySMB::SMB2::Packet::EchoResponse.read(raw_response)
+        response = RubySMB::SMB2::Packet::EchoResponse.read(raw_response)
+        unless response.valid?
+          raise RubySMB::Error::InvalidPacket, 'Not a EchoResponse packet'
+        end
+        response
       end
     end
   end

--- a/lib/ruby_smb/client/echo.rb
+++ b/lib/ruby_smb/client/echo.rb
@@ -18,7 +18,12 @@ module RubySMB
         end
         response = RubySMB::SMB1::Packet::EchoResponse.read(raw_response)
         unless response.valid?
-          raise RubySMB::Error::InvalidPacket, 'Not a EchoResponse packet'
+          raise RubySMB::Error::InvalidPacket.new(
+            expected_proto: RubySMB::SMB1::SMB_PROTOCOL_ID,
+            expected_cmd:   RubySMB::SMB1::Packet::EchoResponse::COMMAND,
+            received_proto: response.smb_header.protocol,
+            received_cmd:   response.smb_header.command
+          )
         end
         response
       end
@@ -32,7 +37,12 @@ module RubySMB
         raw_response = send_recv(request)
         response = RubySMB::SMB2::Packet::EchoResponse.read(raw_response)
         unless response.valid?
-          raise RubySMB::Error::InvalidPacket, 'Not a EchoResponse packet'
+          raise RubySMB::Error::InvalidPacket.new(
+            expected_proto: RubySMB::SMB2::SMB2_PROTOCOL_ID,
+            expected_cmd:   RubySMB::SMB2::Packet::EchoResponse::COMMAND,
+            received_proto: response.smb2_header.protocol,
+            received_cmd:   response.smb2_header.command
+          )
         end
         response
       end

--- a/lib/ruby_smb/client/negotiation.rb
+++ b/lib/ruby_smb/client/negotiation.rb
@@ -47,23 +47,15 @@ module RubySMB
       def negotiate_response(raw_data)
         response = nil
         if smb1
-          begin
-            packet = RubySMB::SMB1::Packet::NegotiateResponseExtended.read raw_data
-          rescue StandardError => e
-            raise RubySMB::Error::InvalidPacket, "Not a Valid SMB1 Negoitate Response #{e.message}"
-          end
+          packet = RubySMB::SMB1::Packet::NegotiateResponseExtended.read raw_data
           response = packet if packet.valid?
         end
         if smb2 && response.nil?
-          begin
-            packet = RubySMB::SMB2::Packet::NegotiateResponse.read raw_data
-          rescue StandardError => e
-            raise RubySMB::Error::InvalidPacket, "Not a Valid SMB2 Negoitate Response #{e.message}"
-          end
-          response = packet
+          packet = RubySMB::SMB2::Packet::NegotiateResponse.read raw_data
+          response = packet if packet.valid?
         end
         if response.nil?
-          raise RubySMB::Error::InvalidPacket, 'No Valid Negotiate Response found'
+          raise RubySMB::Error::InvalidPacket, 'No valid Negotiate Response found'
         end
         response
       end

--- a/lib/ruby_smb/client/tree_connect.rb
+++ b/lib/ruby_smb/client/tree_connect.rb
@@ -30,7 +30,12 @@ module RubySMB
       # @raise [RubySMB::Error::UnexpectedStatusCode] if the response status code is not STATUS_SUCCESS
       def smb1_tree_from_response(share, response)
         unless response.valid?
-          raise RubySMB::Error::InvalidPacket, 'Not a TreeConnectResponse packet'
+          raise RubySMB::Error::InvalidPacket.new(
+            expected_proto: RubySMB::SMB1::SMB_PROTOCOL_ID,
+            expected_cmd:   RubySMB::SMB1::Packet::TreeConnectResponse::COMMAND,
+            received_proto: response.smb_header.protocol,
+            received_cmd:   response.smb_header.command
+          )
         end
         unless response.status_code == WindowsError::NTStatus::STATUS_SUCCESS
           raise RubySMB::Error::UnexpectedStatusCode, response.status_code.name
@@ -65,7 +70,12 @@ module RubySMB
       # @raise [RubySMB::Error::UnexpectedStatusCode] if the response status code is not STATUS_SUCCESS
       def smb2_tree_from_response(share, response)
         unless response.valid?
-          raise RubySMB::Error::InvalidPacket, 'Not a TreeConnectResponse packet'
+          raise RubySMB::Error::InvalidPacket.new(
+            expected_proto: RubySMB::SMB2::SMB2_PROTOCOL_ID,
+            expected_cmd:   RubySMB::SMB2::Packet::TreeConnectResponse::COMMAND,
+            received_proto: response.smb2_header.protocol,
+            received_cmd:   response.smb2_header.command
+          )
         end
         unless response.status_code == WindowsError::NTStatus::STATUS_SUCCESS
           raise RubySMB::Error::UnexpectedStatusCode, response.status_code.name

--- a/lib/ruby_smb/client/tree_connect.rb
+++ b/lib/ruby_smb/client/tree_connect.rb
@@ -17,11 +17,7 @@ module RubySMB
         request.smb_header.tid = 65_535
         request.data_block.path = share
         raw_response = send_recv(request)
-        begin
-          response = RubySMB::SMB1::Packet::TreeConnectResponse.read(raw_response)
-        rescue EOFError
-          response = RubySMB::SMB1::Packet::EmptyPacket.read(raw_response)
-        end
+        response = RubySMB::SMB1::Packet::TreeConnectResponse.read(raw_response)
         smb1_tree_from_response(share, response)
       end
 
@@ -30,9 +26,11 @@ module RubySMB
       # @param share [String] the share path to connect to
       # @param response [RubySMB::SMB1::Packet::TreeConnectResponse] the response packet to parse into our Tree
       # @return [RubySMB::SMB1::Tree]
+      # @raise [RubySMB::Error::InvalidPacket] if the response command is not a TreeConnectResponse packet
+      # @raise [RubySMB::Error::UnexpectedStatusCode] if the response status code is not STATUS_SUCCESS
       def smb1_tree_from_response(share, response)
-        unless response.smb_header.command == RubySMB::SMB1::Commands::SMB_COM_TREE_CONNECT
-          raise RubySMB::Error::InvalidPacket, 'Not a TreeConnectResponse'
+        unless response.valid?
+          raise RubySMB::Error::InvalidPacket, 'Not a TreeConnectResponse packet'
         end
         unless response.status_code == WindowsError::NTStatus::STATUS_SUCCESS
           raise RubySMB::Error::UnexpectedStatusCode, response.status_code.name
@@ -54,11 +52,7 @@ module RubySMB
         request.smb2_header.tree_id = 65_535
         request.encode_path(share)
         raw_response = send_recv(request)
-        begin
-          response = RubySMB::SMB2::Packet::TreeConnectResponse.read(raw_response)
-        rescue EOFError
-          response = RubySMB::SMB2::Packet::ErrorPacket.read(raw_response)
-        end
+        response = RubySMB::SMB2::Packet::TreeConnectResponse.read(raw_response)
         smb2_tree_from_response(share, response)
       end
 
@@ -67,9 +61,11 @@ module RubySMB
       # @param share [String] the share path to connect to
       # @param response [RubySMB::SMB2::Packet::TreeConnectResponse] the response packet to parse into our Tree
       # @return [RubySMB::SMB2::Tree]
+      # @raise [RubySMB::Error::InvalidPacket] if the response command is not a TreeConnectResponse packet
+      # @raise [RubySMB::Error::UnexpectedStatusCode] if the response status code is not STATUS_SUCCESS
       def smb2_tree_from_response(share, response)
-        unless response.smb2_header.command == RubySMB::SMB2::Commands::TREE_CONNECT
-          raise RubySMB::Error::InvalidPacket, 'Not a TreeConnectResponse'
+        unless response.valid?
+          raise RubySMB::Error::InvalidPacket, 'Not a TreeConnectResponse packet'
         end
         unless response.status_code == WindowsError::NTStatus::STATUS_SUCCESS
           raise RubySMB::Error::UnexpectedStatusCode, response.status_code.name

--- a/lib/ruby_smb/error.rb
+++ b/lib/ruby_smb/error.rb
@@ -15,7 +15,42 @@ module RubySMB
 
     # Raised when trying to parse raw binary into a Packet and the data
     # is invalid.
-    class InvalidPacket < RubySMBError; end
+    class InvalidPacket < RubySMBError
+      def initialize(args = nil)
+        if args.nil?
+          super
+        elsif args.is_a? String
+          super(args)
+        elsif args.is_a? Hash
+          expected_proto = args[:expected_proto] ? translate_protocol(args[:expected_proto]) : "???"
+          expected_cmd = args[:expected_cmd] || "???"
+          received_proto = args[:received_proto] ? translate_protocol(args[:received_proto]) : "???"
+          received_cmd = args[:received_cmd] || "???"
+          super(
+            "Expecting #{expected_proto} protocol "\
+            "with command=#{expected_cmd}"\
+            "#{(" (" + args[:expected_custom] + ")") if args[:expected_custom]}, "\
+            "got #{received_proto} protocol "\
+            "with command=#{received_cmd}"\
+            "#{(" (" + args[:received_custom] + ")") if args[:received_custom]}"
+          )
+        else
+          raise ArgumentError, "InvalidPacket expects a String or a Hash, got a #{args.class}"
+        end
+      end
+
+      def translate_protocol(proto)
+        case proto
+        when RubySMB::SMB1::SMB_PROTOCOL_ID
+          'SMB1'
+        when RubySMB::SMB2::SMB2_PROTOCOL_ID
+          'SMB2'
+        else
+          raise ArgumentError, 'Unknown SMB protocol'
+        end
+      end
+      private :translate_protocol
+    end
 
     # Raised when a response packet has a NTStatus code that was unexpected.
     class UnexpectedStatusCode < RubySMBError; end

--- a/lib/ruby_smb/error.rb
+++ b/lib/ruby_smb/error.rb
@@ -26,5 +26,9 @@ module RubySMB
     # Raised when Protocol Negotiation fails, possibly due to an
     # unsupported protocol.
     class NegotiationFailure < RubySMBError; end
+
+    # Raised when trying to parse raw binary into a BitField and the data
+    # is invalid.
+    class InvalidBitField < RubySMBError; end
   end
 end

--- a/lib/ruby_smb/generic_packet.rb
+++ b/lib/ruby_smb/generic_packet.rb
@@ -88,6 +88,19 @@ module RubySMB
       end
     end
 
+    def initialize_instance
+      super
+
+      unless [RubySMB::SMB1::Packet::EmptyPacket, RubySMB::SMB2::Packet::ErrorPacket].any? {|klass| self.is_a? klass}
+        case packet_smb_version
+        when 'SMB1'
+          smb_header.command = self.class::COMMAND
+        when 'SMB2'
+          smb2_header.command = self.class::COMMAND
+        end
+      end
+    end
+
     # Returns an array of hashes representing the
     # fields for this record.
     #

--- a/lib/ruby_smb/smb1/dcerpc.rb
+++ b/lib/ruby_smb/smb1/dcerpc.rb
@@ -44,7 +44,12 @@ module RubySMB
         trans_nmpipe_raw_response = @tree.client.send_recv(request)
         trans_nmpipe_response = RubySMB::SMB1::Packet::Trans::TransactNmpipeResponse.read(trans_nmpipe_raw_response)
         unless trans_nmpipe_response.valid?
-          raise RubySMB::Error::InvalidPacket, 'Not a Trans packet'
+          raise RubySMB::Error::InvalidPacket.new(
+            expected_proto: RubySMB::SMB1::SMB_PROTOCOL_ID,
+            expected_cmd:   RubySMB::SMB1::Packet::Trans::TransactNmpipeResponse::COMMAND,
+            received_proto: trans_nmpipe_response.smb_header.protocol,
+            received_cmd:   trans_nmpipe_response.smb_header.command
+          )
         end
         unless trans_nmpipe_response.status_code == WindowsError::NTStatus::STATUS_SUCCESS
           raise RubySMB::Error::UnexpectedStatusCode, trans_nmpipe_response.status_code.name

--- a/lib/ruby_smb/smb1/dcerpc.rb
+++ b/lib/ruby_smb/smb1/dcerpc.rb
@@ -43,7 +43,7 @@ module RubySMB
 
         trans_nmpipe_raw_response = @tree.client.send_recv(request)
         trans_nmpipe_response = RubySMB::SMB1::Packet::Trans::TransactNmpipeResponse.read(trans_nmpipe_raw_response)
-        unless trans_nmpipe_response.smb_header.command == RubySMB::SMB1::Commands::SMB_COM_TRANSACTION
+        unless trans_nmpipe_response.valid?
           raise RubySMB::Error::InvalidPacket, 'Not a Trans packet'
         end
         unless trans_nmpipe_response.status_code == WindowsError::NTStatus::STATUS_SUCCESS

--- a/lib/ruby_smb/smb1/file.rb
+++ b/lib/ruby_smb/smb1/file.rb
@@ -83,7 +83,12 @@ module RubySMB
         raw_response  = @tree.client.send_recv(close_request)
         response = RubySMB::SMB1::Packet::CloseResponse.read(raw_response)
         unless response.valid?
-          raise RubySMB::Error::InvalidPacket, 'Not a CloseResponse packet'
+          raise RubySMB::Error::InvalidPacket.new(
+            expected_proto: RubySMB::SMB1::SMB_PROTOCOL_ID,
+            expected_cmd:   RubySMB::SMB1::Packet::CloseResponse::COMMAND,
+            received_proto: response.smb_header.protocol,
+            received_cmd:   response.smb_header.command
+          )
         end
         unless response.status_code == WindowsError::NTStatus::STATUS_SUCCESS
           raise RubySMB::Error::UnexpectedStatusCode, response.status_code.name
@@ -114,7 +119,12 @@ module RubySMB
           raw_response = @tree.client.send_recv(read_request)
           response = RubySMB::SMB1::Packet::ReadAndxResponse.read(raw_response)
           unless response.valid?
-            raise RubySMB::Error::InvalidPacket, 'Not a ReadAndxResponse packet'
+            raise RubySMB::Error::InvalidPacket.new(
+              expected_proto: RubySMB::SMB1::SMB_PROTOCOL_ID,
+              expected_cmd:   RubySMB::SMB1::Packet::ReadAndxResponse::COMMAND,
+              received_proto: response.smb_header.protocol,
+              received_cmd:   response.smb_header.command
+            )
           end
           unless response.status_code == WindowsError::NTStatus::STATUS_SUCCESS
             raise RubySMB::Error::UnexpectedStatusCode, response.status_code.name
@@ -156,7 +166,12 @@ module RubySMB
 
         response = RubySMB::SMB1::Packet::ReadAndxResponse.read(raw_response)
         unless response.valid?
-          raise RubySMB::Error::InvalidPacket, 'Not a ReadAndxResponse packet'
+          raise RubySMB::Error::InvalidPacket.new(
+            expected_proto: RubySMB::SMB1::SMB_PROTOCOL_ID,
+            expected_cmd:   RubySMB::SMB1::Packet::ReadAndxResponse::COMMAND,
+            received_proto: response.smb_header.protocol,
+            received_cmd:   response.smb_header.command
+          )
         end
         unless response.status_code == WindowsError::NTStatus::STATUS_SUCCESS
           raise RubySMB::Error::UnexpectedStatusCode, response.status_code.name
@@ -173,7 +188,12 @@ module RubySMB
         raw_response = @tree.client.send_recv(delete_packet)
         response = RubySMB::SMB1::Packet::Trans2::SetFileInformationResponse.read(raw_response)
         unless response.valid?
-          raise RubySMB::Error::InvalidPacket, 'Not a SetFileInformationResponse packet'
+          raise RubySMB::Error::InvalidPacket.new(
+            expected_proto: RubySMB::SMB1::SMB_PROTOCOL_ID,
+            expected_cmd:   RubySMB::SMB1::Packet::Trans2::SetFileInformationResponse::COMMAND,
+            received_proto: response.smb_header.protocol,
+            received_cmd:   response.smb_header.command
+          )
         end
         response.status_code
       end
@@ -214,7 +234,12 @@ module RubySMB
           raw_response = @tree.client.send_recv(write_request)
           response = RubySMB::SMB1::Packet::WriteAndxResponse.read(raw_response)
           unless response.valid?
-            raise RubySMB::Error::InvalidPacket, 'Not a WriteAndxResponse packet'
+            raise RubySMB::Error::InvalidPacket.new(
+              expected_proto: RubySMB::SMB1::SMB_PROTOCOL_ID,
+              expected_cmd:   RubySMB::SMB1::Packet::WriteAndxResponse::COMMAND,
+              received_proto: response.smb_header.protocol,
+              received_cmd:   response.smb_header.command
+            )
           end
           unless response.status_code == WindowsError::NTStatus::STATUS_SUCCESS
             raise RubySMB::Error::UnexpectedStatusCode, response.status_code.name
@@ -249,7 +274,12 @@ module RubySMB
         raw_response = @tree.client.send_recv(pkt)
         response = RubySMB::SMB1::Packet::WriteAndxResponse.read(raw_response)
         unless response.valid?
-          raise RubySMB::Error::InvalidPacket, 'Not a WriteAndxResponse packet'
+          raise RubySMB::Error::InvalidPacket.new(
+            expected_proto: RubySMB::SMB1::SMB_PROTOCOL_ID,
+            expected_cmd:   RubySMB::SMB1::Packet::WriteAndxResponse::COMMAND,
+            received_proto: response.smb_header.protocol,
+            received_cmd:   response.smb_header.command
+          )
         end
         response.parameter_block.count_low
       end
@@ -263,7 +293,12 @@ module RubySMB
         raw_response = tree.client.send_recv(rename_packet(new_file_name))
         response = RubySMB::SMB1::Packet::Trans2::SetFileInformationResponse.read(raw_response)
         unless response.valid?
-          raise RubySMB::Error::InvalidPacket, 'Not a SetFileInformationResponse packet'
+          raise RubySMB::Error::InvalidPacket.new(
+            expected_proto: RubySMB::SMB1::SMB_PROTOCOL_ID,
+            expected_cmd:   RubySMB::SMB1::Packet::Trans2::SetFileInformationResponse::COMMAND,
+            received_proto: response.smb_header.protocol,
+            received_cmd:   response.smb_header.command
+          )
         end
         response.status_code
       end

--- a/lib/ruby_smb/smb1/file.rb
+++ b/lib/ruby_smb/smb1/file.rb
@@ -76,13 +76,13 @@ module RubySMB
       # Closes the handle to the remote file.
       #
       # @return [WindowsError::ErrorCode] the NTStatus code returned by the operation
-      # @raise [RubySMB::Error::InvalidPacket] if the response command is not SMB_COM_CLOSE
+      # @raise [RubySMB::Error::InvalidPacket] if the response packet is not valid
       # @raise [RubySMB::Error::UnexpectedStatusCode] if the response NTStatus is not STATUS_SUCCESS
       def close
         close_request = set_header_fields(RubySMB::SMB1::Packet::CloseRequest.new)
         raw_response  = @tree.client.send_recv(close_request)
         response = RubySMB::SMB1::Packet::CloseResponse.read(raw_response)
-        unless response.smb_header.command == RubySMB::SMB1::Commands::SMB_COM_CLOSE
+        unless response.valid?
           raise RubySMB::Error::InvalidPacket, 'Not a CloseResponse packet'
         end
         unless response.status_code == WindowsError::NTStatus::STATUS_SUCCESS
@@ -98,7 +98,7 @@ module RubySMB
       # @param bytes [Integer] the number of bytes to read
       # @param offset [Integer] the byte offset in the file to start reading from
       # @return [String] the data read from the file
-      # @raise [RubySMB::Error::InvalidPacket] if the response command is not SMB_COM_READ_ANDX
+      # @raise [RubySMB::Error::InvalidPacket] if the response packet is not valid
       # @raise [RubySMB::Error::UnexpectedStatusCode] if the response NTStatus is not STATUS_SUCCESS
       def read(bytes: @size, offset: 0)
         atomic_read_size = if bytes > @tree.client.max_buffer_size
@@ -113,7 +113,7 @@ module RubySMB
           read_request = read_packet(read_length: atomic_read_size, offset: offset)
           raw_response = @tree.client.send_recv(read_request)
           response = RubySMB::SMB1::Packet::ReadAndxResponse.read(raw_response)
-          unless response.smb_header.command == RubySMB::SMB1::Commands::SMB_COM_READ_ANDX
+          unless response.valid?
             raise RubySMB::Error::InvalidPacket, 'Not a ReadAndxResponse packet'
           end
           unless response.status_code == WindowsError::NTStatus::STATUS_SUCCESS
@@ -149,12 +149,15 @@ module RubySMB
         read_request.parameter_block.offset = offset
         read_request
       end
-      
+
       def send_recv_read(read_length: 0, offset: 0)
         read_request = read_packet(read_length: read_length, offset: offset)
         raw_response = tree.client.send_recv(read_request)
 
         response = RubySMB::SMB1::Packet::ReadAndxResponse.read(raw_response)
+        unless response.valid?
+          raise RubySMB::Error::InvalidPacket, 'Not a ReadAndxResponse packet'
+        end
         unless response.status_code == WindowsError::NTStatus::STATUS_SUCCESS
           raise RubySMB::Error::UnexpectedStatusCode, response.status_code.name
         end
@@ -165,9 +168,13 @@ module RubySMB
       # Delete a file on close
       #
       # @return [WindowsError::ErrorCode] the NTStatus Response code
+      # @raise [RubySMB::Error::InvalidPacket] if the response packet is not valid
       def delete
         raw_response = @tree.client.send_recv(delete_packet)
         response = RubySMB::SMB1::Packet::Trans2::SetFileInformationResponse.read(raw_response)
+        unless response.valid?
+          raise RubySMB::Error::InvalidPacket, 'Not a SetFileInformationResponse packet'
+        end
         response.status_code
       end
 
@@ -190,7 +197,7 @@ module RubySMB
       # @param data [String] the data to write to the file
       # @param offset [Integer] the offset in the file to start writing from
       # @return [Integer] the count of bytes written
-      # @raise [RubySMB::Error::InvalidPacket] if the response command is not SMB_COM_WRITE_ANDX
+      # @raise [RubySMB::Error::InvalidPacket] if the response packet is not valid
       # @raise [RubySMB::Error::UnexpectedStatusCode] if the response NTStatus is not STATUS_SUCCESS
       def write(data:, offset: 0)
         buffer = data.dup
@@ -206,7 +213,7 @@ module RubySMB
           write_request = write_packet(data: buffer.slice!(0, atomic_write_size), offset: offset)
           raw_response = @tree.client.send_recv(write_request)
           response = RubySMB::SMB1::Packet::WriteAndxResponse.read(raw_response)
-          unless response.smb_header.command == RubySMB::SMB1::Commands::SMB_COM_WRITE_ANDX
+          unless response.valid?
             raise RubySMB::Error::InvalidPacket, 'Not a WriteAndxResponse packet'
           end
           unless response.status_code == WindowsError::NTStatus::STATUS_SUCCESS
@@ -235,12 +242,15 @@ module RubySMB
         write_request.parameter_block.remaining = write_request.parameter_block.data_length
         write_request
       end
-      
+
       def send_recv_write(data:'', offset: 0)
         pkt = write_packet(data: data, offset: offset)
         pkt.set_64_bit_offset(true)
         raw_response = @tree.client.send_recv(pkt)
         response = RubySMB::SMB1::Packet::WriteAndxResponse.read(raw_response)
+        unless response.valid?
+          raise RubySMB::Error::InvalidPacket, 'Not a WriteAndxResponse packet'
+        end
         response.parameter_block.count_low
       end
 
@@ -248,9 +258,13 @@ module RubySMB
       #
       # @param new_file_name [String] the new name
       # @return [WindowsError::ErrorCode] the NTStatus Response code
+      # @raise [RubySMB::Error::InvalidPacket] if the response packet is not valid
       def rename(new_file_name)
         raw_response = tree.client.send_recv(rename_packet(new_file_name))
         response = RubySMB::SMB1::Packet::Trans2::SetFileInformationResponse.read(raw_response)
+        unless response.valid?
+          raise RubySMB::Error::InvalidPacket, 'Not a SetFileInformationResponse packet'
+        end
         response.status_code
       end
 

--- a/lib/ruby_smb/smb1/packet/close_request.rb
+++ b/lib/ruby_smb/smb1/packet/close_request.rb
@@ -4,6 +4,8 @@ module RubySMB
       # A SMB1 SMB_COM_CLOSE Request Packet as defined in
       # [2.2.4.5.1 Request](https://msdn.microsoft.com/en-us/library/ee442151.aspx)
       class CloseRequest < RubySMB::GenericPacket
+        COMMAND = RubySMB::SMB1::Commands::SMB_COM_CLOSE
+
         # A SMB1 Parameter Block as defined by the {CloseRequest}
         class ParameterBlock < RubySMB::SMB1::ParameterBlock
           endian  :little
@@ -22,7 +24,7 @@ module RubySMB
 
         def initialize_instance
           super
-          smb_header.command = RubySMB::SMB1::Commands::SMB_COM_CLOSE
+          smb_header.command = COMMAND
         end
 
       end

--- a/lib/ruby_smb/smb1/packet/close_request.rb
+++ b/lib/ruby_smb/smb1/packet/close_request.rb
@@ -22,11 +22,6 @@ module RubySMB
         parameter_block   :parameter_block
         data_block        :data_block
 
-        def initialize_instance
-          super
-          smb_header.command = COMMAND
-        end
-
       end
     end
   end

--- a/lib/ruby_smb/smb1/packet/close_response.rb
+++ b/lib/ruby_smb/smb1/packet/close_response.rb
@@ -20,7 +20,6 @@ module RubySMB
 
         def initialize_instance
           super
-          smb_header.command     = COMMAND
           smb_header.flags.reply = 1
         end
 

--- a/lib/ruby_smb/smb1/packet/close_response.rb
+++ b/lib/ruby_smb/smb1/packet/close_response.rb
@@ -4,6 +4,8 @@ module RubySMB
       # A SMB1 SMB_COM_CLOSE Response Packet as defined in
       # [2.2.4.5.2 Response](https://msdn.microsoft.com/en-us/library/ee441667.aspx)
       class CloseResponse < RubySMB::GenericPacket
+        COMMAND = RubySMB::SMB1::Commands::SMB_COM_CLOSE
+
         # A SMB1 Parameter Block as defined by the {CloseResponse}
         class ParameterBlock < RubySMB::SMB1::ParameterBlock
         end
@@ -18,7 +20,7 @@ module RubySMB
 
         def initialize_instance
           super
-          smb_header.command     = RubySMB::SMB1::Commands::SMB_COM_CLOSE
+          smb_header.command     = COMMAND
           smb_header.flags.reply = 1
         end
 

--- a/lib/ruby_smb/smb1/packet/echo_request.rb
+++ b/lib/ruby_smb/smb1/packet/echo_request.rb
@@ -4,6 +4,8 @@ module RubySMB
       # This class represents an SMB1 Echo Request Packet as defined in
       # [2.2.4.39.1 Request](https://msdn.microsoft.com/en-us/library/ee441746.aspx)
       class EchoRequest < RubySMB::GenericPacket
+        COMMAND = RubySMB::SMB1::Commands::SMB_COM_ECHO
+
         # The {RubySMB::SMB1::ParameterBlock} specific to this packet type.
         class ParameterBlock < RubySMB::SMB1::ParameterBlock
           uint16 :echo_count, label: 'Echo Count', initial_value: 1
@@ -20,7 +22,7 @@ module RubySMB
 
         def initialize_instance
           super
-          smb_header.command = RubySMB::SMB1::Commands::SMB_COM_ECHO
+          smb_header.command = COMMAND
         end
       end
     end

--- a/lib/ruby_smb/smb1/packet/echo_request.rb
+++ b/lib/ruby_smb/smb1/packet/echo_request.rb
@@ -20,10 +20,6 @@ module RubySMB
         parameter_block   :parameter_block
         data_block        :data_block
 
-        def initialize_instance
-          super
-          smb_header.command = COMMAND
-        end
       end
     end
   end

--- a/lib/ruby_smb/smb1/packet/echo_response.rb
+++ b/lib/ruby_smb/smb1/packet/echo_response.rb
@@ -4,6 +4,8 @@ module RubySMB
       # This class represents an SMB1 Echo Request Packet as defined in
       # [2.2.4.39.2 Response](https://msdn.microsoft.com/en-us/library/ee441626.aspx)
       class EchoResponse < RubySMB::GenericPacket
+        COMMAND = RubySMB::SMB1::Commands::SMB_COM_ECHO
+
         # The {RubySMB::SMB1::ParameterBlock} specific to this packet type.
         class ParameterBlock < RubySMB::SMB1::ParameterBlock
           uint16 :sequence_number, label: 'Sequence Number'
@@ -20,7 +22,7 @@ module RubySMB
 
         def initialize_instance
           super
-          smb_header.command = RubySMB::SMB1::Commands::SMB_COM_ECHO
+          smb_header.command = COMMAND
           smb_header.flags.reply = 1
         end
       end

--- a/lib/ruby_smb/smb1/packet/echo_response.rb
+++ b/lib/ruby_smb/smb1/packet/echo_response.rb
@@ -22,7 +22,6 @@ module RubySMB
 
         def initialize_instance
           super
-          smb_header.command = COMMAND
           smb_header.flags.reply = 1
         end
       end

--- a/lib/ruby_smb/smb1/packet/empty_packet.rb
+++ b/lib/ruby_smb/smb1/packet/empty_packet.rb
@@ -4,9 +4,16 @@ module RubySMB
       # This packet represent an SMB1 Response Packet when the parameter and
       # data blocks will be empty.
       class EmptyPacket < RubySMB::GenericPacket
+        attr_accessor :original_command
+
         smb_header        :smb_header
         parameter_block   :parameter_block
         data_block        :data_block
+
+        def valid?
+          return smb_header.protocol == RubySMB::SMB1::SMB_PROTOCOL_ID &&
+            smb_header.command == @original_command
+        end
       end
     end
   end

--- a/lib/ruby_smb/smb1/packet/logoff_request.rb
+++ b/lib/ruby_smb/smb1/packet/logoff_request.rb
@@ -19,10 +19,6 @@ module RubySMB
         parameter_block   :parameter_block
         data_block        :data_block
 
-        def initialize_instance
-          super
-          smb_header.command = COMMAND
-        end
       end
     end
   end

--- a/lib/ruby_smb/smb1/packet/logoff_request.rb
+++ b/lib/ruby_smb/smb1/packet/logoff_request.rb
@@ -4,6 +4,8 @@ module RubySMB
       # This class represents an SMB1 LOGOFF Request Packet as defined in
       # [2.2.4.54.1 Request](https://msdn.microsoft.com/en-us/library/ee442167.aspx)
       class LogoffRequest < RubySMB::GenericPacket
+        COMMAND = RubySMB::SMB1::Commands::SMB_COM_LOGOFF
+
         # The Parameter Block for this packet is empty save the Word Count and ANDX Block
         class ParameterBlock < RubySMB::SMB1::ParameterBlock
           and_x_block :andx_block
@@ -19,7 +21,7 @@ module RubySMB
 
         def initialize_instance
           super
-          smb_header.command = RubySMB::SMB1::Commands::SMB_COM_LOGOFF
+          smb_header.command = COMMAND
         end
       end
     end

--- a/lib/ruby_smb/smb1/packet/logoff_response.rb
+++ b/lib/ruby_smb/smb1/packet/logoff_response.rb
@@ -4,6 +4,8 @@ module RubySMB
       # This class represents an SMB1 LOGOFF Response Packet as defined in
       # [2.2.4.54.2 Response](https://msdn.microsoft.com/en-us/library/ee441488.aspx)
       class LogoffResponse < RubySMB::GenericPacket
+        COMMAND = RubySMB::SMB1::Commands::SMB_COM_LOGOFF
+
         # The Parameter Block for this packet is empty save the Word Count and ANDX Block
         class ParameterBlock < RubySMB::SMB1::ParameterBlock
           and_x_block :andx_block
@@ -19,7 +21,7 @@ module RubySMB
 
         def initialize_instance
           super
-          smb_header.command = RubySMB::SMB1::Commands::SMB_COM_LOGOFF
+          smb_header.command = COMMAND
           smb_header.flags.reply = 1
         end
       end

--- a/lib/ruby_smb/smb1/packet/logoff_response.rb
+++ b/lib/ruby_smb/smb1/packet/logoff_response.rb
@@ -21,7 +21,6 @@ module RubySMB
 
         def initialize_instance
           super
-          smb_header.command = COMMAND
           smb_header.flags.reply = 1
         end
       end

--- a/lib/ruby_smb/smb1/packet/negotiate_request.rb
+++ b/lib/ruby_smb/smb1/packet/negotiate_request.rb
@@ -15,11 +15,6 @@ module RubySMB
         parameter_block   :parameter_block
         data_block        :data_block
 
-        def initialize_instance
-          super
-          smb_header.command = COMMAND
-        end
-
         # Add an individual Dialect string to the list of
         # Dialects in the packet.
         #

--- a/lib/ruby_smb/smb1/packet/negotiate_request.rb
+++ b/lib/ruby_smb/smb1/packet/negotiate_request.rb
@@ -4,6 +4,8 @@ module RubySMB
       # A SMB1 SMB_COM_NEGOTIATE Request Packet as defined in
       # [2.2.4.52.1](https://msdn.microsoft.com/en-us/library/ee441572.aspx)
       class NegotiateRequest < RubySMB::GenericPacket
+        COMMAND = RubySMB::SMB1::Commands::SMB_COM_NEGOTIATE
+
         # Represents the specific layout of the DataBlock for a NegotiateRequest Packet.
         class DataBlock < RubySMB::SMB1::DataBlock
           array :dialects, label: 'Dialects', type: :dialect, read_until: :eof
@@ -15,7 +17,7 @@ module RubySMB
 
         def initialize_instance
           super
-          smb_header.command = RubySMB::SMB1::Commands::SMB_COM_NEGOTIATE
+          smb_header.command = COMMAND
         end
 
         # Add an individual Dialect string to the list of

--- a/lib/ruby_smb/smb1/packet/negotiate_response.rb
+++ b/lib/ruby_smb/smb1/packet/negotiate_response.rb
@@ -34,7 +34,6 @@ module RubySMB
 
         def initialize_instance
           super
-          smb_header.command = COMMAND
           smb_header.flags.reply = 1
         end
 

--- a/lib/ruby_smb/smb1/packet/negotiate_response.rb
+++ b/lib/ruby_smb/smb1/packet/negotiate_response.rb
@@ -4,6 +4,8 @@ module RubySMB
       # A SMB1 SMB_COM_NEGOTIATE Non-Extended Security Response Packet as defined in
       # [2.2.4.5.2.2 Non-Extended Security Response](https://msdn.microsoft.com/en-us/library/cc246327.aspx)
       class NegotiateResponse < RubySMB::GenericPacket
+        COMMAND = RubySMB::SMB1::Commands::SMB_COM_NEGOTIATE
+
         # An SMB_Parameters Block as defined by the {NegotiateResponse}.
         class ParameterBlock < RubySMB::SMB1::ParameterBlock
           uint16          :dialect_index, label: 'Dialect Index'
@@ -32,13 +34,8 @@ module RubySMB
 
         def initialize_instance
           super
-          header = smb_header
-          header.command = RubySMB::SMB1::Commands::SMB_COM_NEGOTIATE
-          header.flags.reply = 1
-        end
-
-        def valid?
-          smb_header.command == RubySMB::SMB1::Commands::SMB_COM_NEGOTIATE
+          smb_header.command = COMMAND
+          smb_header.flags.reply = 1
         end
 
         # Stores the list of {RubySMB::SMB1::Dialect} that were sent to the

--- a/lib/ruby_smb/smb1/packet/negotiate_response_extended.rb
+++ b/lib/ruby_smb/smb1/packet/negotiate_response_extended.rb
@@ -4,6 +4,8 @@ module RubySMB
       # A SMB1 SMB_COM_NEGOTIATE Extended Security Response Packet as defined in
       # [2.2.4.5.2.1 Extended Security Response](https://msdn.microsoft.com/en-us/library/cc246326.aspx)
       class NegotiateResponseExtended < RubySMB::GenericPacket
+        COMMAND = RubySMB::SMB1::Commands::SMB_COM_NEGOTIATE
+
         # An SMB_Parameters Block as defined by the {NegotiateResponseExtended}.
         class ParameterBlock < RubySMB::SMB1::ParameterBlock
           uint16          :dialect_index, label: 'Dialect Index'
@@ -31,13 +33,12 @@ module RubySMB
 
         def initialize_instance
           super
-          header = smb_header
-          header.command = RubySMB::SMB1::Commands::SMB_COM_NEGOTIATE
-          header.flags.reply = 1
+          smb_header.command = COMMAND
+          smb_header.flags.reply = 1
         end
 
         def valid?
-          return false unless smb_header.command == RubySMB::SMB1::Commands::SMB_COM_NEGOTIATE
+          return false unless super
           return false unless parameter_block.capabilities.extended_security == 1
           true
         end

--- a/lib/ruby_smb/smb1/packet/negotiate_response_extended.rb
+++ b/lib/ruby_smb/smb1/packet/negotiate_response_extended.rb
@@ -33,7 +33,6 @@ module RubySMB
 
         def initialize_instance
           super
-          smb_header.command = COMMAND
           smb_header.flags.reply = 1
         end
 

--- a/lib/ruby_smb/smb1/packet/nt_create_andx_request.rb
+++ b/lib/ruby_smb/smb1/packet/nt_create_andx_request.rb
@@ -5,6 +5,8 @@ module RubySMB
       # [2.2.4.64.1 Request](https://msdn.microsoft.com/en-us/library/ee442175.aspx) and
       # [2.2.4.9.1 Client Request Extensions](https://msdn.microsoft.com/en-us/library/cc246332.aspx)
       class NtCreateAndxRequest < RubySMB::GenericPacket
+        COMMAND = RubySMB::SMB1::Commands::SMB_COM_NT_CREATE_ANDX
+
         # A SMB1 Parameter Block as defined by the {NtCreateAndxRequest}
         class ParameterBlock < RubySMB::SMB1::ParameterBlock
           endian :little
@@ -54,7 +56,7 @@ module RubySMB
 
         def initialize_instance
           super
-          smb_header.command = RubySMB::SMB1::Commands::SMB_COM_NT_CREATE_ANDX
+          smb_header.command = COMMAND
         end
       end
     end

--- a/lib/ruby_smb/smb1/packet/nt_create_andx_request.rb
+++ b/lib/ruby_smb/smb1/packet/nt_create_andx_request.rb
@@ -54,10 +54,6 @@ module RubySMB
         parameter_block   :parameter_block
         data_block        :data_block
 
-        def initialize_instance
-          super
-          smb_header.command = COMMAND
-        end
       end
     end
   end

--- a/lib/ruby_smb/smb1/packet/nt_create_andx_response.rb
+++ b/lib/ruby_smb/smb1/packet/nt_create_andx_response.rb
@@ -5,6 +5,8 @@ module RubySMB
       # [2.2.4.64.2 Response](https://msdn.microsoft.com/en-us/library/ee441612.aspx) and
       # [2.2.4.9.2 Server Response Extensions](https://msdn.microsoft.com/en-us/library/cc246334.aspx)
       class NtCreateAndxResponse < RubySMB::GenericPacket
+        COMMAND = RubySMB::SMB1::Commands::SMB_COM_NT_CREATE_ANDX
+
         # A SMB1 Parameter Block as defined by the {NtCreateAndxResponse}
         class ParameterBlock < RubySMB::SMB1::ParameterBlock
           endian :little
@@ -57,7 +59,7 @@ module RubySMB
 
         def initialize_instance
           super
-          smb_header.command = RubySMB::SMB1::Commands::SMB_COM_NT_CREATE_ANDX
+          smb_header.command = COMMAND
           smb_header.flags.reply = 1
         end
       end

--- a/lib/ruby_smb/smb1/packet/nt_create_andx_response.rb
+++ b/lib/ruby_smb/smb1/packet/nt_create_andx_response.rb
@@ -59,7 +59,6 @@ module RubySMB
 
         def initialize_instance
           super
-          smb_header.command = COMMAND
           smb_header.flags.reply = 1
         end
       end

--- a/lib/ruby_smb/smb1/packet/nt_trans/create_request.rb
+++ b/lib/ruby_smb/smb1/packet/nt_trans/create_request.rb
@@ -5,6 +5,8 @@ module RubySMB
         # Class representing a generic NT Transaction request packet as defined in
         # [2.2.4.62.1 Request](https://msdn.microsoft.com/en-us/library/ee441534.aspx)
         class CreateRequest < RubySMB::GenericPacket
+          COMMAND = RubySMB::SMB1::Commands::SMB_COM_NT_TRANSACT
+
           class ParameterBlock < RubySMB::SMB1::Packet::NtTrans::Request::ParameterBlock
           end
 
@@ -81,7 +83,7 @@ module RubySMB
 
           def initialize_instance
             super
-            smb_header.command = RubySMB::SMB1::Commands::SMB_COM_NT_TRANSACT
+            smb_header.command = COMMAND
             parameter_block.function = RubySMB::SMB1::Packet::NtTrans::Subcommands::CREATE
           end
         end

--- a/lib/ruby_smb/smb1/packet/nt_trans/create_request.rb
+++ b/lib/ruby_smb/smb1/packet/nt_trans/create_request.rb
@@ -83,7 +83,6 @@ module RubySMB
 
           def initialize_instance
             super
-            smb_header.command = COMMAND
             parameter_block.function = RubySMB::SMB1::Packet::NtTrans::Subcommands::CREATE
           end
         end

--- a/lib/ruby_smb/smb1/packet/nt_trans/create_response.rb
+++ b/lib/ruby_smb/smb1/packet/nt_trans/create_response.rb
@@ -5,6 +5,8 @@ module RubySMB
         # Class representing a NT Transaction Create response packet as defined in
         # [2.2.7.1.2 Response](https://msdn.microsoft.com/en-us/library/ee441961.aspx)
         class CreateResponse < RubySMB::GenericPacket
+          COMMAND = RubySMB::SMB1::Commands::SMB_COM_NT_TRANSACT
+
           class ParameterBlock < RubySMB::SMB1::Packet::NtTrans::Response::ParameterBlock
           end
 
@@ -49,7 +51,7 @@ module RubySMB
 
           def initialize_instance
             super
-            smb_header.command = RubySMB::SMB1::Commands::SMB_COM_NT_TRANSACT
+            smb_header.command = COMMAND
             smb_header.flags.reply = 1
           end
         end

--- a/lib/ruby_smb/smb1/packet/nt_trans/create_response.rb
+++ b/lib/ruby_smb/smb1/packet/nt_trans/create_response.rb
@@ -51,7 +51,6 @@ module RubySMB
 
           def initialize_instance
             super
-            smb_header.command = COMMAND
             smb_header.flags.reply = 1
           end
         end

--- a/lib/ruby_smb/smb1/packet/nt_trans/request.rb
+++ b/lib/ruby_smb/smb1/packet/nt_trans/request.rb
@@ -5,6 +5,8 @@ module RubySMB
         # Class representing a generic NT Transaction request packet as defined in
         # [2.2.4.62.1 Request](https://msdn.microsoft.com/en-us/library/ee441534.aspx)
         class Request < RubySMB::GenericPacket
+          COMMAND = RubySMB::SMB1::Commands::SMB_COM_NT_TRANSACT
+
           # The {RubySMB::SMB1::ParameterBlock} specific to this packet type.
           class ParameterBlock < RubySMB::SMB1::ParameterBlock
             endian :little
@@ -38,7 +40,7 @@ module RubySMB
 
           def initialize_instance
             super
-            smb_header.command = RubySMB::SMB1::Commands::SMB_COM_NT_TRANSACT
+            smb_header.command = COMMAND
           end
         end
       end

--- a/lib/ruby_smb/smb1/packet/nt_trans/request.rb
+++ b/lib/ruby_smb/smb1/packet/nt_trans/request.rb
@@ -38,10 +38,6 @@ module RubySMB
           parameter_block   :parameter_block
           data_block        :data_block
 
-          def initialize_instance
-            super
-            smb_header.command = COMMAND
-          end
         end
       end
     end

--- a/lib/ruby_smb/smb1/packet/nt_trans/response.rb
+++ b/lib/ruby_smb/smb1/packet/nt_trans/response.rb
@@ -36,7 +36,6 @@ module RubySMB
 
           def initialize_instance
             super
-            smb_header.command = COMMAND
             smb_header.flags.reply = 1
           end
         end

--- a/lib/ruby_smb/smb1/packet/nt_trans/response.rb
+++ b/lib/ruby_smb/smb1/packet/nt_trans/response.rb
@@ -5,6 +5,8 @@ module RubySMB
         # Class representing a generic NT Transaction response packet as defined in
         # [2.2.4.62.2 Response](https://msdn.microsoft.com/en-us/library/ee442112.aspx)
         class Response < RubySMB::GenericPacket
+          COMMAND = RubySMB::SMB1::Commands::SMB_COM_NT_TRANSACT
+
           # The {RubySMB::SMB1::ParameterBlock} specific to this packet type.
           class ParameterBlock < RubySMB::SMB1::ParameterBlock
             endian :little
@@ -34,7 +36,7 @@ module RubySMB
 
           def initialize_instance
             super
-            smb_header.command = RubySMB::SMB1::Commands::SMB_COM_NT_TRANSACT
+            smb_header.command = COMMAND
             smb_header.flags.reply = 1
           end
         end

--- a/lib/ruby_smb/smb1/packet/read_andx_request.rb
+++ b/lib/ruby_smb/smb1/packet/read_andx_request.rb
@@ -5,6 +5,8 @@ module RubySMB
       # [2.2.4.42.1 Request](https://msdn.microsoft.com/en-us/library/ee441839.aspx)
       # [2.2.4.2.1 Client Request Extensions](https://msdn.microsoft.com/en-us/library/ff470250.aspx)
       class ReadAndxRequest < RubySMB::GenericPacket
+        COMMAND = RubySMB::SMB1::Commands::SMB_COM_READ_ANDX
+
         # A SMB1 Parameter Block as defined by the {ReadAndxRequest}
         class ParameterBlock < RubySMB::SMB1::ParameterBlock
           endian :little
@@ -56,7 +58,7 @@ module RubySMB
 
         def initialize_instance
           super
-          smb_header.command = RubySMB::SMB1::Commands::SMB_COM_READ_ANDX
+          smb_header.command = COMMAND
         end
 
         # Sets the read_from_named_pipe flag to `read_from_named_pipe` value (true or false).

--- a/lib/ruby_smb/smb1/packet/read_andx_request.rb
+++ b/lib/ruby_smb/smb1/packet/read_andx_request.rb
@@ -56,11 +56,6 @@ module RubySMB
         parameter_block   :parameter_block
         data_block        :data_block
 
-        def initialize_instance
-          super
-          smb_header.command = COMMAND
-        end
-
         # Sets the read_from_named_pipe flag to `read_from_named_pipe` value (true or false).
         # When reading from a named pipe, this flag needs to be set to true, which forces
         # the use of Timeout field in Timeout_or_MaxCountHigh. When set to false (default),

--- a/lib/ruby_smb/smb1/packet/read_andx_response.rb
+++ b/lib/ruby_smb/smb1/packet/read_andx_response.rb
@@ -5,6 +5,8 @@ module RubySMB
       # [2.2.4.42.2 Response](https://msdn.microsoft.com/en-us/library/ee441872.aspx)
       # [2.2.4.2.2 Server Response Extensions](https://msdn.microsoft.com/en-us/library/ff470017.aspx)
       class ReadAndxResponse < RubySMB::GenericPacket
+        COMMAND = RubySMB::SMB1::Commands::SMB_COM_READ_ANDX
+
         # A SMB1 Parameter Block as defined by the {ReadAndxResponse}
         class ParameterBlock < RubySMB::SMB1::ParameterBlock
           endian :little
@@ -38,7 +40,7 @@ module RubySMB
 
         def initialize_instance
           super
-          smb_header.command = RubySMB::SMB1::Commands::SMB_COM_READ_ANDX
+          smb_header.command = COMMAND
           smb_header.flags.reply = 1
         end
       end

--- a/lib/ruby_smb/smb1/packet/read_andx_response.rb
+++ b/lib/ruby_smb/smb1/packet/read_andx_response.rb
@@ -40,7 +40,6 @@ module RubySMB
 
         def initialize_instance
           super
-          smb_header.command = COMMAND
           smb_header.flags.reply = 1
         end
       end

--- a/lib/ruby_smb/smb1/packet/session_setup_legacy_request.rb
+++ b/lib/ruby_smb/smb1/packet/session_setup_legacy_request.rb
@@ -39,7 +39,6 @@ module RubySMB
 
         def initialize_instance
           super
-          smb_header.command = COMMAND
           parameter_block.capabilities.extended_security = 0
         end
       end

--- a/lib/ruby_smb/smb1/packet/session_setup_legacy_request.rb
+++ b/lib/ruby_smb/smb1/packet/session_setup_legacy_request.rb
@@ -4,6 +4,8 @@ module RubySMB
       # A SMB1 SMB_COM_SESSION_SETUP_ANDX Request Packet, without NTLMSSP as defined in
       # [2.2.4.53.1 Request](https://msdn.microsoft.com/en-us/library/ee441849.aspx)
       class SessionSetupLegacyRequest < RubySMB::GenericPacket
+        COMMAND = RubySMB::SMB1::Commands::SMB_COM_SESSION_SETUP
+
         # A SMB1 Parameter Block as defined by the {SessionSetupRequest}
         class ParameterBlock < RubySMB::SMB1::ParameterBlock
           and_x_block   :andx_block
@@ -37,7 +39,7 @@ module RubySMB
 
         def initialize_instance
           super
-          smb_header.command = RubySMB::SMB1::Commands::SMB_COM_SESSION_SETUP
+          smb_header.command = COMMAND
           parameter_block.capabilities.extended_security = 0
         end
       end

--- a/lib/ruby_smb/smb1/packet/session_setup_legacy_response.rb
+++ b/lib/ruby_smb/smb1/packet/session_setup_legacy_response.rb
@@ -4,6 +4,8 @@ module RubySMB
       # A SMB1 SMB_COM_SESSION_SETUP Legacy Response Packet as defined in
       # [2.2.4.53.2 Response](https://msdn.microsoft.com/en-us/library/ee442143.aspx)
       class SessionSetupLegacyResponse < RubySMB::GenericPacket
+        COMMAND = RubySMB::SMB1::Commands::SMB_COM_SESSION_SETUP
+
         # A SMB1 Parameter Block as defined by the {SessionSetupResponse}
         class ParameterBlock < RubySMB::SMB1::ParameterBlock
           and_x_block   :andx_block
@@ -24,7 +26,7 @@ module RubySMB
 
         def initialize_instance
           super
-          smb_header.command = RubySMB::SMB1::Commands::SMB_COM_SESSION_SETUP
+          smb_header.command = COMMAND
           smb_header.flags.reply = 1
         end
       end

--- a/lib/ruby_smb/smb1/packet/session_setup_legacy_response.rb
+++ b/lib/ruby_smb/smb1/packet/session_setup_legacy_response.rb
@@ -26,7 +26,6 @@ module RubySMB
 
         def initialize_instance
           super
-          smb_header.command = COMMAND
           smb_header.flags.reply = 1
         end
       end

--- a/lib/ruby_smb/smb1/packet/session_setup_request.rb
+++ b/lib/ruby_smb/smb1/packet/session_setup_request.rb
@@ -32,11 +32,6 @@ module RubySMB
         parameter_block   :parameter_block
         data_block        :data_block
 
-        def initialize_instance
-          super
-          smb_header.command = COMMAND
-        end
-
         # Takes an NTLM Type 1 Message and creates the GSS Security Blob
         # for it and sets it in the {RubySMB::SMB1::Packet::SessionSetupRequest::DataBlock#security_blob}
         # field. It also automaticaly sets the length in

--- a/lib/ruby_smb/smb1/packet/session_setup_request.rb
+++ b/lib/ruby_smb/smb1/packet/session_setup_request.rb
@@ -4,6 +4,8 @@ module RubySMB
       # A SMB1 SMB_COM_SESSION_SETUP_ANDX Request Packet as defined in
       # [2.2.4.6.1](https://msdn.microsoft.com/en-us/library/cc246328.aspx)
       class SessionSetupRequest < RubySMB::GenericPacket
+        COMMAND = RubySMB::SMB1::Commands::SMB_COM_SESSION_SETUP
+
         # A SMB1 Parameter Block as defined by the {SessionSetupRequest}
         class ParameterBlock < RubySMB::SMB1::ParameterBlock
           and_x_block   :andx_block
@@ -32,7 +34,7 @@ module RubySMB
 
         def initialize_instance
           super
-          smb_header.command = RubySMB::SMB1::Commands::SMB_COM_SESSION_SETUP
+          smb_header.command = COMMAND
         end
 
         # Takes an NTLM Type 1 Message and creates the GSS Security Blob

--- a/lib/ruby_smb/smb1/packet/session_setup_response.rb
+++ b/lib/ruby_smb/smb1/packet/session_setup_response.rb
@@ -4,6 +4,8 @@ module RubySMB
       # A SMB1 SMB_COM_SESSION_SETUP Response Packet as defined in
       # [2.2.4.6.2](https://msdn.microsoft.com/en-us/library/cc246329.aspx)
       class SessionSetupResponse < RubySMB::GenericPacket
+        COMMAND = RubySMB::SMB1::Commands::SMB_COM_SESSION_SETUP
+
         # A SMB1 Parameter Block as defined by the {SessionSetupResponse}
         class ParameterBlock < RubySMB::SMB1::ParameterBlock
           and_x_block   :andx_block
@@ -24,7 +26,7 @@ module RubySMB
 
         def initialize_instance
           super
-          smb_header.command = RubySMB::SMB1::Commands::SMB_COM_SESSION_SETUP
+          smb_header.command = COMMAND
           smb_header.flags.reply = 1
         end
 

--- a/lib/ruby_smb/smb1/packet/session_setup_response.rb
+++ b/lib/ruby_smb/smb1/packet/session_setup_response.rb
@@ -26,7 +26,6 @@ module RubySMB
 
         def initialize_instance
           super
-          smb_header.command = COMMAND
           smb_header.flags.reply = 1
         end
 

--- a/lib/ruby_smb/smb1/packet/trans/peek_nmpipe_request.rb
+++ b/lib/ruby_smb/smb1/packet/trans/peek_nmpipe_request.rb
@@ -12,7 +12,6 @@ module RubySMB
 
           def initialize_instance
             super
-            smb_header.command = RubySMB::SMB1::Commands::SMB_COM_TRANSACTION
             data_block.name = "\\PIPE\\"
             parameter_block.setup << RubySMB::SMB1::Packet::Trans::Subcommands::PEEK_NMPIPE
             parameter_block.setup_count = 2

--- a/lib/ruby_smb/smb1/packet/trans/peek_nmpipe_response.rb
+++ b/lib/ruby_smb/smb1/packet/trans/peek_nmpipe_response.rb
@@ -50,7 +50,6 @@ module RubySMB
 
           def initialize_instance
             super
-            smb_header.command = COMMAND
             smb_header.flags.reply = 1
             parameter_block.setup << RubySMB::SMB1::Packet::Trans::Subcommands::PEEK_NMPIPE
           end

--- a/lib/ruby_smb/smb1/packet/trans/peek_nmpipe_response.rb
+++ b/lib/ruby_smb/smb1/packet/trans/peek_nmpipe_response.rb
@@ -5,6 +5,8 @@ module RubySMB
         # This class represents an SMB1 Trans PeekNamedPipe Response Packet as defined in
         # [2.2.5.5.2 Response](https://msdn.microsoft.com/en-us/library/ee441883.aspx)
         class PeekNmpipeResponse < RubySMB::GenericPacket
+          COMMAND = RubySMB::SMB1::Commands::SMB_COM_TRANSACTION
+
           class ParameterBlock < RubySMB::SMB1::Packet::Trans::Response::ParameterBlock
           end
 
@@ -22,7 +24,7 @@ module RubySMB
               do_num_bytes
             end
           end
-          
+
           class TransData < BinData::Record
             string :read_data, label: 'Readable data', length: -> { parent.parameter_block.total_data_count }
 
@@ -48,7 +50,7 @@ module RubySMB
 
           def initialize_instance
             super
-            smb_header.command = RubySMB::SMB1::Commands::SMB_COM_TRANSACTION
+            smb_header.command = COMMAND
             smb_header.flags.reply = 1
             parameter_block.setup << RubySMB::SMB1::Packet::Trans::Subcommands::PEEK_NMPIPE
           end

--- a/lib/ruby_smb/smb1/packet/trans/request.rb
+++ b/lib/ruby_smb/smb1/packet/trans/request.rb
@@ -50,11 +50,6 @@ module RubySMB
           parameter_block   :parameter_block
           data_block        :data_block
 
-          def initialize_instance
-            super
-            smb_header.command = COMMAND
-          end
-
         end
       end
     end

--- a/lib/ruby_smb/smb1/packet/trans/request.rb
+++ b/lib/ruby_smb/smb1/packet/trans/request.rb
@@ -6,6 +6,8 @@ module RubySMB
         # This class represents a generic SMB1 Trans Request Packet as defined in
         # [2.2.4.33.1 Request](https://msdn.microsoft.com/en-us/library/ee441730.aspx)
         class Request < RubySMB::GenericPacket
+          COMMAND = RubySMB::SMB1::Commands::SMB_COM_TRANSACTION
+
           # A SMB1 Parameter Block
           class ParameterBlock < RubySMB::SMB1::ParameterBlock
             uint16      :total_parameter_count, label: 'Total Parameter Count(bytes)', initial_value: -> { parameter_count }
@@ -50,7 +52,7 @@ module RubySMB
 
           def initialize_instance
             super
-            smb_header.command = RubySMB::SMB1::Commands::SMB_COM_TRANSACTION
+            smb_header.command = COMMAND
           end
 
         end

--- a/lib/ruby_smb/smb1/packet/trans/response.rb
+++ b/lib/ruby_smb/smb1/packet/trans/response.rb
@@ -6,6 +6,8 @@ module RubySMB
         # This class represents a generic SMB1 Trans Response Packet as defined in
         # [2.2.4.33.2 Response](https://msdn.microsoft.com/en-us/library/ee442061.aspx)
         class Response < RubySMB::GenericPacket
+          COMMAND = RubySMB::SMB1::Commands::SMB_COM_TRANSACTION
+
           # A SMB1 Parameter Block
           class ParameterBlock < RubySMB::SMB1::ParameterBlock
             uint16 :total_parameter_count,  label: 'Total Parameter Count(bytes)', initial_value: -> { parameter_count }
@@ -35,7 +37,7 @@ module RubySMB
 
           def initialize_instance
             super
-            smb_header.command = RubySMB::SMB1::Commands::SMB_COM_TRANSACTION
+            smb_header.command = COMMAND
             smb_header.flags.reply = 1
           end
 

--- a/lib/ruby_smb/smb1/packet/trans/response.rb
+++ b/lib/ruby_smb/smb1/packet/trans/response.rb
@@ -37,7 +37,6 @@ module RubySMB
 
           def initialize_instance
             super
-            smb_header.command = COMMAND
             smb_header.flags.reply = 1
           end
 

--- a/lib/ruby_smb/smb1/packet/trans/transact_nmpipe_request.rb
+++ b/lib/ruby_smb/smb1/packet/trans/transact_nmpipe_request.rb
@@ -6,6 +6,7 @@ module RubySMB
         # A Trans TRANSACT_NMPIPE Request Packet as defined in
         # [2.2.5.6.1 Request](https://msdn.microsoft.com/en-us/library/ee441832.aspx)
         class TransactNmpipeRequest < RubySMB::GenericPacket
+          COMMAND = RubySMB::SMB1::Commands::SMB_COM_TRANSACTION
 
           class ParameterBlock < RubySMB::SMB1::Packet::Trans::Request::ParameterBlock
           end
@@ -42,7 +43,7 @@ module RubySMB
 
           def initialize_instance
             super
-            smb_header.command = RubySMB::SMB1::Commands::SMB_COM_TRANSACTION
+            smb_header.command = COMMAND
             parameter_block.max_parameter_count = 0x0000
             parameter_block.max_setup_count = 0x00
             parameter_block.setup << RubySMB::SMB1::Packet::Trans::Subcommands::TRANSACT_NMPIPE

--- a/lib/ruby_smb/smb1/packet/trans/transact_nmpipe_request.rb
+++ b/lib/ruby_smb/smb1/packet/trans/transact_nmpipe_request.rb
@@ -43,7 +43,6 @@ module RubySMB
 
           def initialize_instance
             super
-            smb_header.command = COMMAND
             parameter_block.max_parameter_count = 0x0000
             parameter_block.max_setup_count = 0x00
             parameter_block.setup << RubySMB::SMB1::Packet::Trans::Subcommands::TRANSACT_NMPIPE

--- a/lib/ruby_smb/smb1/packet/trans/transact_nmpipe_response.rb
+++ b/lib/ruby_smb/smb1/packet/trans/transact_nmpipe_response.rb
@@ -6,6 +6,7 @@ module RubySMB
         # A Trans TRANSACT_NMPIPE Response Packet as defined in
         # [2.2.5.6.2 Response](https://msdn.microsoft.com/en-us/library/ee442003.aspx)
         class TransactNmpipeResponse < RubySMB::GenericPacket
+          COMMAND = RubySMB::SMB1::Commands::SMB_COM_TRANSACTION
 
           class ParameterBlock < RubySMB::SMB1::Packet::Trans::Response::ParameterBlock
           end
@@ -33,7 +34,7 @@ module RubySMB
 
           def initialize_instance
             super
-            smb_header.command = RubySMB::SMB1::Commands::SMB_COM_TRANSACTION
+            smb_header.command = COMMAND
             smb_header.flags.reply = 1
           end
 

--- a/lib/ruby_smb/smb1/packet/trans/transact_nmpipe_response.rb
+++ b/lib/ruby_smb/smb1/packet/trans/transact_nmpipe_response.rb
@@ -34,7 +34,6 @@ module RubySMB
 
           def initialize_instance
             super
-            smb_header.command = COMMAND
             smb_header.flags.reply = 1
           end
 

--- a/lib/ruby_smb/smb1/packet/trans2/find_first2_request.rb
+++ b/lib/ruby_smb/smb1/packet/trans2/find_first2_request.rb
@@ -69,7 +69,6 @@ module RubySMB
 
           def initialize_instance
             super
-            smb_header.command = COMMAND
             parameter_block.setup << RubySMB::SMB1::Packet::Trans2::Subcommands::FIND_FIRST2
           end
         end

--- a/lib/ruby_smb/smb1/packet/trans2/find_first2_request.rb
+++ b/lib/ruby_smb/smb1/packet/trans2/find_first2_request.rb
@@ -5,6 +5,8 @@ module RubySMB
         # A Trans2 FIND_FIRST2 Request Packet as defined in
         # [2.2.6.2.1](https://msdn.microsoft.com/en-us/library/ee441987.aspx)
         class FindFirst2Request < RubySMB::GenericPacket
+          COMMAND = RubySMB::SMB1::Commands::SMB_COM_TRANSACTION2
+
           class ParameterBlock < RubySMB::SMB1::Packet::Trans2::Request::ParameterBlock
           end
 
@@ -67,7 +69,7 @@ module RubySMB
 
           def initialize_instance
             super
-            smb_header.command = RubySMB::SMB1::Commands::SMB_COM_TRANSACTION2
+            smb_header.command = COMMAND
             parameter_block.setup << RubySMB::SMB1::Packet::Trans2::Subcommands::FIND_FIRST2
           end
         end

--- a/lib/ruby_smb/smb1/packet/trans2/find_first2_response.rb
+++ b/lib/ruby_smb/smb1/packet/trans2/find_first2_response.rb
@@ -53,7 +53,6 @@ module RubySMB
 
           def initialize_instance
             super
-            smb_header.command = COMMAND
             parameter_block.setup << RubySMB::SMB1::Packet::Trans2::Subcommands::FIND_FIRST2
             smb_header.flags.reply = 1
           end

--- a/lib/ruby_smb/smb1/packet/trans2/find_first2_response.rb
+++ b/lib/ruby_smb/smb1/packet/trans2/find_first2_response.rb
@@ -5,6 +5,8 @@ module RubySMB
         # This class represents an SMB1 Trans2 FIND_FIRST2 Response Packet as defined in
         # [2.2.6.2.2 Response](https://msdn.microsoft.com/en-us/library/ee441704.aspx)
         class FindFirst2Response < RubySMB::GenericPacket
+          COMMAND = RubySMB::SMB1::Commands::SMB_COM_TRANSACTION2
+
           class ParameterBlock < RubySMB::SMB1::Packet::Trans2::Response::ParameterBlock
           end
 
@@ -51,7 +53,7 @@ module RubySMB
 
           def initialize_instance
             super
-            smb_header.command = RubySMB::SMB1::Commands::SMB_COM_TRANSACTION2
+            smb_header.command = COMMAND
             parameter_block.setup << RubySMB::SMB1::Packet::Trans2::Subcommands::FIND_FIRST2
             smb_header.flags.reply = 1
           end
@@ -62,6 +64,7 @@ module RubySMB
           #
           # @param klass [Class] the FileInformationClass class to read the data as
           # @return [array<BinData::Record>] An array of structs holding the requested information
+          # @raise [RubySMB::Error::InvalidPacket] if the string buffer is not a valid File Information packet
           def results(klass, unicode:)
             information_classes = []
             blob = data_block.trans2_data.buffer.to_binary_s.dup
@@ -76,7 +79,11 @@ module RubySMB
 
               file_info = klass.new
               file_info.unicode = unicode
-              information_classes << file_info.read(data)
+              begin
+                information_classes << file_info.read(data)
+              rescue IOError
+                raise RubySMB::Error::InvalidPacket, "Invalid #{klass} File Information packet in the string buffer"
+              end
             end
             information_classes
           end

--- a/lib/ruby_smb/smb1/packet/trans2/find_next2_request.rb
+++ b/lib/ruby_smb/smb1/packet/trans2/find_next2_request.rb
@@ -5,6 +5,8 @@ module RubySMB
         # A Trans2 FIND_NEXT2 Request Packet as defined in
         # [2.2.6.3.1 Request](https://msdn.microsoft.com/en-us/library/ee441844.aspx)
         class FindNext2Request < RubySMB::GenericPacket
+          COMMAND = RubySMB::SMB1::Commands::SMB_COM_TRANSACTION2
+
           class ParameterBlock < RubySMB::SMB1::Packet::Trans2::Request::ParameterBlock
           end
 
@@ -67,7 +69,7 @@ module RubySMB
 
           def initialize_instance
             super
-            smb_header.command = RubySMB::SMB1::Commands::SMB_COM_TRANSACTION2
+            smb_header.command = COMMAND
             parameter_block.setup << RubySMB::SMB1::Packet::Trans2::Subcommands::FIND_NEXT2
           end
         end

--- a/lib/ruby_smb/smb1/packet/trans2/find_next2_request.rb
+++ b/lib/ruby_smb/smb1/packet/trans2/find_next2_request.rb
@@ -69,7 +69,6 @@ module RubySMB
 
           def initialize_instance
             super
-            smb_header.command = COMMAND
             parameter_block.setup << RubySMB::SMB1::Packet::Trans2::Subcommands::FIND_NEXT2
           end
         end

--- a/lib/ruby_smb/smb1/packet/trans2/find_next2_response.rb
+++ b/lib/ruby_smb/smb1/packet/trans2/find_next2_response.rb
@@ -52,7 +52,6 @@ module RubySMB
 
           def initialize_instance
             super
-            smb_header.command = COMMAND
             parameter_block.setup << RubySMB::SMB1::Packet::Trans2::Subcommands::FIND_NEXT2
             smb_header.flags.reply = 1
           end

--- a/lib/ruby_smb/smb1/packet/trans2/open2_request.rb
+++ b/lib/ruby_smb/smb1/packet/trans2/open2_request.rb
@@ -52,7 +52,6 @@ module RubySMB
 
           def initialize_instance
             super
-            smb_header.command = COMMAND
             parameter_block.setup << RubySMB::SMB1::Packet::Trans2::Subcommands::OPEN2
           end
         end

--- a/lib/ruby_smb/smb1/packet/trans2/open2_request.rb
+++ b/lib/ruby_smb/smb1/packet/trans2/open2_request.rb
@@ -5,6 +5,8 @@ module RubySMB
         # A Trans2 OPEN2 Request Packet as defined in
         # [2.2.6.1.1 Request](https://msdn.microsoft.com/en-us/library/ee441733.aspx)
         class Open2Request < RubySMB::GenericPacket
+          COMMAND = RubySMB::SMB1::Commands::SMB_COM_TRANSACTION2
+
           class ParameterBlock < RubySMB::SMB1::Packet::Trans2::Request::ParameterBlock
           end
 
@@ -50,7 +52,7 @@ module RubySMB
 
           def initialize_instance
             super
-            smb_header.command = RubySMB::SMB1::Commands::SMB_COM_TRANSACTION2
+            smb_header.command = COMMAND
             parameter_block.setup << RubySMB::SMB1::Packet::Trans2::Subcommands::OPEN2
           end
         end

--- a/lib/ruby_smb/smb1/packet/trans2/open2_response.rb
+++ b/lib/ruby_smb/smb1/packet/trans2/open2_response.rb
@@ -54,7 +54,6 @@ module RubySMB
 
           def initialize_instance
             super
-            smb_header.command = COMMAND
             parameter_block.setup << RubySMB::SMB1::Packet::Trans2::Subcommands::OPEN2
             smb_header.flags.reply = 1
           end

--- a/lib/ruby_smb/smb1/packet/trans2/open2_response.rb
+++ b/lib/ruby_smb/smb1/packet/trans2/open2_response.rb
@@ -5,6 +5,8 @@ module RubySMB
         # This class represents an SMB1 Trans2 Open2 Response Packet as defined in
         # [2.2.6.1.2 Response](https://msdn.microsoft.com/en-us/library/ee441545.aspx)
         class Open2Response < RubySMB::GenericPacket
+          COMMAND = RubySMB::SMB1::Commands::SMB_COM_TRANSACTION2
+
           class ParameterBlock < RubySMB::SMB1::Packet::Trans2::Response::ParameterBlock
           end
 
@@ -52,7 +54,7 @@ module RubySMB
 
           def initialize_instance
             super
-            smb_header.command = RubySMB::SMB1::Commands::SMB_COM_TRANSACTION2
+            smb_header.command = COMMAND
             parameter_block.setup << RubySMB::SMB1::Packet::Trans2::Subcommands::OPEN2
             smb_header.flags.reply = 1
           end

--- a/lib/ruby_smb/smb1/packet/trans2/request.rb
+++ b/lib/ruby_smb/smb1/packet/trans2/request.rb
@@ -41,10 +41,6 @@ module RubySMB
           parameter_block   :parameter_block
           data_block        :data_block
 
-          def initialize_instance
-            super
-            smb_header.command = COMMAND
-          end
         end
       end
     end

--- a/lib/ruby_smb/smb1/packet/trans2/request.rb
+++ b/lib/ruby_smb/smb1/packet/trans2/request.rb
@@ -5,6 +5,8 @@ module RubySMB
         # This class represents a generic SMB1 Trans2 Request Packet as defined in
         # [2.2.4.46.1 Request](https://msdn.microsoft.com/en-us/library/ee442192.aspx)
         class Request < RubySMB::GenericPacket
+          COMMAND = RubySMB::SMB1::Commands::SMB_COM_TRANSACTION2
+
           # The {RubySMB::SMB1::ParameterBlock} specific to this packet type.
           class ParameterBlock < RubySMB::SMB1::ParameterBlock
             uint16        :total_parameter_count, label: 'Total Parameter Count(bytes)'
@@ -41,7 +43,7 @@ module RubySMB
 
           def initialize_instance
             super
-            smb_header.command = RubySMB::SMB1::Commands::SMB_COM_TRANSACTION2
+            smb_header.command = COMMAND
           end
         end
       end

--- a/lib/ruby_smb/smb1/packet/trans2/request_secondary.rb
+++ b/lib/ruby_smb/smb1/packet/trans2/request_secondary.rb
@@ -5,6 +5,8 @@ module RubySMB
         # This class represents a generic SMB1 Trans2 Secondary Request Packet as defined in
         # [2.2.4.47.1 Request](https://msdn.microsoft.com/en-us/library/ee442105.aspx)
         class RequestSecondary < RubySMB::GenericPacket
+          COMMAND = RubySMB::SMB1::Commands::SMB_COM_TRANSACTION2_SECONDARY
+
           # The {RubySMB::SMB1::ParameterBlock} specific to this packet type.
           class ParameterBlock < RubySMB::SMB1::ParameterBlock
             uint16 :total_parameter_count, label: 'Total Parameter Count(bytes)'
@@ -28,7 +30,7 @@ module RubySMB
 
           def initialize_instance
             super
-            smb_header.command = RubySMB::SMB1::Commands::SMB_COM_TRANSACTION2_SECONDARY
+            smb_header.command = COMMAND
           end
         end
       end

--- a/lib/ruby_smb/smb1/packet/trans2/request_secondary.rb
+++ b/lib/ruby_smb/smb1/packet/trans2/request_secondary.rb
@@ -28,10 +28,6 @@ module RubySMB
           parameter_block   :parameter_block
           data_block        :data_block
 
-          def initialize_instance
-            super
-            smb_header.command = COMMAND
-          end
         end
       end
     end

--- a/lib/ruby_smb/smb1/packet/trans2/response.rb
+++ b/lib/ruby_smb/smb1/packet/trans2/response.rb
@@ -5,6 +5,8 @@ module RubySMB
         # This class represents a generic SMB1 Trans2 Response Packet as defined in
         # [2.2.4.46.2 Response](https://msdn.microsoft.com/en-us/library/ee441550.aspx)
         class Response < RubySMB::GenericPacket
+          COMMAND = RubySMB::SMB1::Commands::SMB_COM_TRANSACTION2
+
           # The {RubySMB::SMB1::ParameterBlock} specific to this packet type.
           class ParameterBlock < RubySMB::SMB1::ParameterBlock
             uint16 :total_parameter_count, label: 'Total Parameter Count(bytes)'
@@ -36,7 +38,7 @@ module RubySMB
 
           def initialize_instance
             super
-            smb_header.command = RubySMB::SMB1::Commands::SMB_COM_TRANSACTION2
+            smb_header.command = COMMAND
             smb_header.flags.reply = 1
           end
         end

--- a/lib/ruby_smb/smb1/packet/trans2/response.rb
+++ b/lib/ruby_smb/smb1/packet/trans2/response.rb
@@ -38,7 +38,6 @@ module RubySMB
 
           def initialize_instance
             super
-            smb_header.command = COMMAND
             smb_header.flags.reply = 1
           end
         end

--- a/lib/ruby_smb/smb1/packet/trans2/set_file_information_request.rb
+++ b/lib/ruby_smb/smb1/packet/trans2/set_file_information_request.rb
@@ -58,7 +58,6 @@ module RubySMB
 
           def initialize_instance
             super
-            smb_header.command = COMMAND
             parameter_block.setup << RubySMB::SMB1::Packet::Trans2::Subcommands::SET_FILE_INFORMATION
           end
         end

--- a/lib/ruby_smb/smb1/packet/trans2/set_file_information_request.rb
+++ b/lib/ruby_smb/smb1/packet/trans2/set_file_information_request.rb
@@ -5,6 +5,8 @@ module RubySMB
         # A Trans2 SET_FILE_INFORMATION Request Packet as defined in
         # [2.2.6.9.1 Request](https://msdn.microsoft.com/en-us/library/ee441527.aspx)
         class SetFileInformationRequest < RubySMB::GenericPacket
+          COMMAND = RubySMB::SMB1::Commands::SMB_COM_TRANSACTION2
+
           class ParameterBlock < RubySMB::SMB1::Packet::Trans2::Request::ParameterBlock
           end
 
@@ -56,7 +58,7 @@ module RubySMB
 
           def initialize_instance
             super
-            smb_header.command = RubySMB::SMB1::Commands::SMB_COM_TRANSACTION2
+            smb_header.command = COMMAND
             parameter_block.setup << RubySMB::SMB1::Packet::Trans2::Subcommands::SET_FILE_INFORMATION
           end
         end

--- a/lib/ruby_smb/smb1/packet/trans2/set_file_information_response.rb
+++ b/lib/ruby_smb/smb1/packet/trans2/set_file_information_response.rb
@@ -5,6 +5,8 @@ module RubySMB
         # A Trans2 SET_FILE_INFORMATION Response Packet as defined in
         # [2.2.6.9.2 Response](https://msdn.microsoft.com/en-us/library/ff469853.aspx)
         class SetFileInformationResponse < RubySMB::GenericPacket
+          COMMAND = RubySMB::SMB1::Commands::SMB_COM_TRANSACTION2
+
           class ParameterBlock < RubySMB::SMB1::Packet::Trans2::Response::ParameterBlock
           end
 
@@ -46,7 +48,7 @@ module RubySMB
 
           def initialize_instance
             super
-            smb_header.command = RubySMB::SMB1::Commands::SMB_COM_TRANSACTION2
+            smb_header.command = COMMAND
             parameter_block.setup << RubySMB::SMB1::Packet::Trans2::Subcommands::SET_FILE_INFORMATION
             smb_header.flags.reply = 1
           end

--- a/lib/ruby_smb/smb1/packet/trans2/set_file_information_response.rb
+++ b/lib/ruby_smb/smb1/packet/trans2/set_file_information_response.rb
@@ -48,7 +48,6 @@ module RubySMB
 
           def initialize_instance
             super
-            smb_header.command = COMMAND
             parameter_block.setup << RubySMB::SMB1::Packet::Trans2::Subcommands::SET_FILE_INFORMATION
             smb_header.flags.reply = 1
           end

--- a/lib/ruby_smb/smb1/packet/tree_connect_request.rb
+++ b/lib/ruby_smb/smb1/packet/tree_connect_request.rb
@@ -4,6 +4,8 @@ module RubySMB
       # This class represents an SMB1 TreeConnect Request Packet as defined in
       # [2.2.4.7.1 Client Request Extensions](https://msdn.microsoft.com/en-us/library/cc246330.aspx)
       class TreeConnectRequest < RubySMB::GenericPacket
+        COMMAND = RubySMB::SMB1::Commands::SMB_COM_TREE_CONNECT
+
         # A SMB1 Parameter Block as defined by the {TreeConnectRequest}
         class ParameterBlock < RubySMB::SMB1::ParameterBlock
           and_x_block          :andx_block
@@ -24,7 +26,7 @@ module RubySMB
 
         def initialize_instance
           super
-          smb_header.command = RubySMB::SMB1::Commands::SMB_COM_TREE_CONNECT
+          smb_header.command = COMMAND
         end
       end
     end

--- a/lib/ruby_smb/smb1/packet/tree_connect_request.rb
+++ b/lib/ruby_smb/smb1/packet/tree_connect_request.rb
@@ -24,10 +24,6 @@ module RubySMB
         parameter_block   :parameter_block
         data_block        :data_block
 
-        def initialize_instance
-          super
-          smb_header.command = COMMAND
-        end
       end
     end
   end

--- a/lib/ruby_smb/smb1/packet/tree_connect_response.rb
+++ b/lib/ruby_smb/smb1/packet/tree_connect_response.rb
@@ -26,7 +26,6 @@ module RubySMB
 
         def initialize_instance
           super
-          smb_header.command = COMMAND
           smb_header.flags.reply = 1
         end
 

--- a/lib/ruby_smb/smb1/packet/tree_connect_response.rb
+++ b/lib/ruby_smb/smb1/packet/tree_connect_response.rb
@@ -4,6 +4,8 @@ module RubySMB
       # A SMB1 TreeConnect Response Packet as defined in
       # [2.2.4.7.2 Server Response Extensions](https://msdn.microsoft.com/en-us/library/cc246331.aspx)
       class TreeConnectResponse < RubySMB::GenericPacket
+        COMMAND = RubySMB::SMB1::Commands::SMB_COM_TREE_CONNECT
+
         # A SMB1 Parameter Block as defined by the {SessionSetupResponse}
         class ParameterBlock < RubySMB::SMB1::ParameterBlock
           and_x_block                :andx_block
@@ -24,7 +26,7 @@ module RubySMB
 
         def initialize_instance
           super
-          smb_header.command = RubySMB::SMB1::Commands::SMB_COM_TREE_CONNECT
+          smb_header.command = COMMAND
           smb_header.flags.reply = 1
         end
 
@@ -34,12 +36,17 @@ module RubySMB
         #
         # @return [RubySMB::SMB1::BitField::DirectoryAccessMask] if a directory was connected to
         # @return [RubySMB::SMB1::BitField::FileAccessMask] if anything else was connected to
+        # @raise [RubySMB::Error::InvalidBitField] if ACCESS_MASK bit field is not valid
         def access_rights
           if is_directory?
             parameter_block.access_rights
           else
             mask = parameter_block.access_rights.to_binary_s
-            RubySMB::SMB1::BitField::FileAccessMask.read(mask)
+            begin
+              RubySMB::SMB1::BitField::FileAccessMask.read(mask)
+            rescue IOError
+              raise RubySMB::Error::InvalidBitField, 'Invalid ACCESS_MASK for the Maximal Share Access Rights'
+            end
           end
         end
 
@@ -54,7 +61,11 @@ module RubySMB
             parameter_block.guest_access_rights
           else
             mask = parameter_block.guest_access_rights.to_binary_s
-            RubySMB::SMB1::BitField::FileAccessMask.read(mask)
+            begin
+              RubySMB::SMB1::BitField::FileAccessMask.read(mask)
+            rescue IOError
+              raise RubySMB::Error::InvalidBitField, 'Invalid ACCESS_MASK for the Guest Share Access Rights'
+            end
           end
         end
 

--- a/lib/ruby_smb/smb1/packet/tree_disconnect_request.rb
+++ b/lib/ruby_smb/smb1/packet/tree_disconnect_request.rb
@@ -4,6 +4,8 @@ module RubySMB
       # This class represents an SMB1 TreeDisonnect Request Packet as defined in
       # [2.2.4.51.1 Request](https://msdn.microsoft.com/en-us/library/ee441622.aspx)
       class TreeDisconnectRequest < RubySMB::GenericPacket
+        COMMAND = RubySMB::SMB1::Commands::SMB_COM_TREE_DISCONNECT
+
         # The Parameter Block for this packet is empty save the Word Count
         # The {RubySMB::SMB1::ParameterBlock} specific to this packet type.
         class ParameterBlock < RubySMB::SMB1::ParameterBlock
@@ -19,7 +21,7 @@ module RubySMB
 
         def initialize_instance
           super
-          smb_header.command = RubySMB::SMB1::Commands::SMB_COM_TREE_DISCONNECT
+          smb_header.command = COMMAND
         end
       end
     end

--- a/lib/ruby_smb/smb1/packet/tree_disconnect_request.rb
+++ b/lib/ruby_smb/smb1/packet/tree_disconnect_request.rb
@@ -19,10 +19,6 @@ module RubySMB
         parameter_block   :parameter_block
         data_block        :data_block
 
-        def initialize_instance
-          super
-          smb_header.command = COMMAND
-        end
       end
     end
   end

--- a/lib/ruby_smb/smb1/packet/tree_disconnect_response.rb
+++ b/lib/ruby_smb/smb1/packet/tree_disconnect_response.rb
@@ -4,6 +4,8 @@ module RubySMB
       # This class represents an SMB1 TreeDisonnect Response Packet as defined in
       # [2.2.4.51.2 Response](https://msdn.microsoft.com/en-us/library/ee441823.aspx)
       class TreeDisconnectResponse < RubySMB::GenericPacket
+        COMMAND = RubySMB::SMB1::Commands::SMB_COM_TREE_DISCONNECT
+
         # The Parameter Block for this packet is empty save the Word Count
         # The {RubySMB::SMB1::ParameterBlock} specific to this packet type.
         class ParameterBlock < RubySMB::SMB1::ParameterBlock
@@ -19,7 +21,7 @@ module RubySMB
 
         def initialize_instance
           super
-          smb_header.command = RubySMB::SMB1::Commands::SMB_COM_TREE_DISCONNECT
+          smb_header.command = COMMAND
           smb_header.flags.reply = 1
         end
       end

--- a/lib/ruby_smb/smb1/packet/tree_disconnect_response.rb
+++ b/lib/ruby_smb/smb1/packet/tree_disconnect_response.rb
@@ -21,7 +21,6 @@ module RubySMB
 
         def initialize_instance
           super
-          smb_header.command = COMMAND
           smb_header.flags.reply = 1
         end
       end

--- a/lib/ruby_smb/smb1/packet/write_andx_request.rb
+++ b/lib/ruby_smb/smb1/packet/write_andx_request.rb
@@ -51,11 +51,6 @@ module RubySMB
         parameter_block   :parameter_block
         data_block        :data_block
 
-        def initialize_instance
-          super
-          smb_header.command = COMMAND
-        end
-
         # Specifies whether the offset is a 32-bit (default) or 64-bit value. When `is_64_bit`
         # is true, a 64-bit offset will be used and the OffsetHigh field will be added to the structure.
         #

--- a/lib/ruby_smb/smb1/packet/write_andx_request.rb
+++ b/lib/ruby_smb/smb1/packet/write_andx_request.rb
@@ -5,6 +5,8 @@ module RubySMB
       # [2.2.4.43.1 Request](https://msdn.microsoft.com/en-us/library/ee441954.aspx)
       # [2.2.4.3.1 Client Request Extensions](https://msdn.microsoft.com/en-us/library/ff469893.aspx)
       class WriteAndxRequest < RubySMB::GenericPacket
+        COMMAND = RubySMB::SMB1::Commands::SMB_COM_WRITE_ANDX
+
         # A SMB1 Parameter Block as defined by the {WriteAndxRequest}
         class ParameterBlock < RubySMB::SMB1::ParameterBlock
           endian      :little
@@ -51,7 +53,7 @@ module RubySMB
 
         def initialize_instance
           super
-          smb_header.command = RubySMB::SMB1::Commands::SMB_COM_WRITE_ANDX
+          smb_header.command = COMMAND
         end
 
         # Specifies whether the offset is a 32-bit (default) or 64-bit value. When `is_64_bit`

--- a/lib/ruby_smb/smb1/packet/write_andx_response.rb
+++ b/lib/ruby_smb/smb1/packet/write_andx_response.rb
@@ -28,7 +28,6 @@ module RubySMB
 
         def initialize_instance
           super
-          smb_header.command = COMMAND
           smb_header.flags.reply = 1
         end
       end

--- a/lib/ruby_smb/smb1/packet/write_andx_response.rb
+++ b/lib/ruby_smb/smb1/packet/write_andx_response.rb
@@ -5,6 +5,8 @@ module RubySMB
       # [2.2.4.43.2 Response](https://msdn.microsoft.com/en-us/library/ee441673.aspx)
       # [2.2.4.3.2 Server Response Extensions](https://msdn.microsoft.com/en-us/library/ff469858.aspx)
       class WriteAndxResponse < RubySMB::GenericPacket
+        COMMAND = RubySMB::SMB1::Commands::SMB_COM_WRITE_ANDX
+
         # A SMB1 Parameter Block as defined by the {WriteAndxResponse}
         class ParameterBlock < RubySMB::SMB1::ParameterBlock
           endian      :little
@@ -26,7 +28,7 @@ module RubySMB
 
         def initialize_instance
           super
-          smb_header.command = RubySMB::SMB1::Commands::SMB_COM_WRITE_ANDX
+          smb_header.command = COMMAND
           smb_header.flags.reply = 1
         end
       end

--- a/lib/ruby_smb/smb1/pipe.rb
+++ b/lib/ruby_smb/smb1/pipe.rb
@@ -26,14 +26,14 @@ module RubySMB
         packet = @tree.set_header_fields(packet)
         raw_response = @tree.client.send_recv(packet)
         response = RubySMB::SMB1::Packet::Trans::PeekNmpipeResponse.read(raw_response)
+        unless response.valid?
+          raise RubySMB::Error::InvalidPacket, 'Not a PeekNmpipeResponse packet'
+        end
 
         unless response.status_code == WindowsError::NTStatus::STATUS_BUFFER_OVERFLOW or response.status_code == WindowsError::NTStatus::STATUS_SUCCESS
           raise RubySMB::Error::UnexpectedStatusCode, response.status_code.name
         end
 
-        unless response.smb_header.command == RubySMB::SMB1::Commands::SMB_COM_TRANSACTION
-          raise RubySMB::Error::InvalidPacket, 'Not a TransResponse packet'
-        end
         response
       end
 

--- a/lib/ruby_smb/smb1/pipe.rb
+++ b/lib/ruby_smb/smb1/pipe.rb
@@ -27,7 +27,12 @@ module RubySMB
         raw_response = @tree.client.send_recv(packet)
         response = RubySMB::SMB1::Packet::Trans::PeekNmpipeResponse.read(raw_response)
         unless response.valid?
-          raise RubySMB::Error::InvalidPacket, 'Not a PeekNmpipeResponse packet'
+          raise RubySMB::Error::InvalidPacket.new(
+            expected_proto: RubySMB::SMB1::SMB_PROTOCOL_ID,
+            expected_cmd:   RubySMB::SMB1::Packet::Trans::PeekNmpipeRequest::COMMAND,
+            received_proto: response.smb_header.protocol,
+            received_cmd:   response.smb_header.command
+          )
         end
 
         unless response.status_code == WindowsError::NTStatus::STATUS_BUFFER_OVERFLOW or response.status_code == WindowsError::NTStatus::STATUS_SUCCESS

--- a/lib/ruby_smb/smb1/tree.rb
+++ b/lib/ruby_smb/smb1/tree.rb
@@ -46,7 +46,12 @@ module RubySMB
         raw_response = client.send_recv(request)
         response = RubySMB::SMB1::Packet::TreeDisconnectResponse.read(raw_response)
         unless response.valid?
-          raise RubySMB::Error::InvalidPacket, 'Not a TreeDisconnectResponse packet'
+          raise RubySMB::Error::InvalidPacket.new(
+            expected_proto: RubySMB::SMB1::SMB_PROTOCOL_ID,
+            expected_cmd:   RubySMB::SMB1::Packet::TreeDisconnectResponse::COMMAND,
+            received_proto: response.smb_header.protocol,
+            received_cmd:   response.smb_header.command
+          )
         end
         response.status_code
       end
@@ -118,7 +123,12 @@ module RubySMB
         raw_response = @client.send_recv(nt_create_andx_request)
         response = RubySMB::SMB1::Packet::NtCreateAndxResponse.read(raw_response)
         unless response.valid?
-          raise RubySMB::Error::InvalidPacket, 'Not a NtCreateAndxResponse packet'
+          raise RubySMB::Error::InvalidPacket.new(
+            expected_proto: RubySMB::SMB1::SMB_PROTOCOL_ID,
+            expected_cmd:   RubySMB::SMB1::Packet::NtCreateAndxResponse::COMMAND,
+            received_proto: response.smb_header.protocol,
+            received_cmd:   response.smb_header.command
+          )
         end
         unless response.status_code == WindowsError::NTStatus::STATUS_SUCCESS
           raise RubySMB::Error::UnexpectedStatusCode, response.status_code.name
@@ -173,7 +183,12 @@ module RubySMB
         raw_response  = client.send_recv(find_first_request)
         response      = RubySMB::SMB1::Packet::Trans2::FindFirst2Response.read(raw_response)
         unless response.valid?
-          raise RubySMB::Error::InvalidPacket, 'Not a Trans2 packet'
+          raise RubySMB::Error::InvalidPacket.new(
+            expected_proto: RubySMB::SMB1::SMB_PROTOCOL_ID,
+            expected_cmd:   RubySMB::SMB1::Packet::Trans2::FindFirst2Response::COMMAND,
+            received_proto: response.smb_header.protocol,
+            received_cmd:   response.smb_header.command
+          )
         end
         unless response.status_code == WindowsError::NTStatus::STATUS_SUCCESS
           raise RubySMB::Error::UnexpectedStatusCode, response.status_code.name
@@ -203,7 +218,12 @@ module RubySMB
           raw_response  = client.send_recv(find_next_request)
           response      = RubySMB::SMB1::Packet::Trans2::FindNext2Response.read(raw_response)
           unless response.valid?
-            raise RubySMB::Error::InvalidPacket, 'Not a Trans2 packet'
+            raise RubySMB::Error::InvalidPacket.new(
+              expected_proto: RubySMB::SMB1::SMB_PROTOCOL_ID,
+              expected_cmd:   RubySMB::SMB1::Packet::Trans2::FindNext2Response::COMMAND,
+              received_proto: response.smb_header.protocol,
+              received_cmd:   response.smb_header.command
+            )
           end
           unless response.status_code == WindowsError::NTStatus::STATUS_SUCCESS
             raise RubySMB::Error::UnexpectedStatusCode, response.status_code.name

--- a/lib/ruby_smb/smb2/dcerpc.rb
+++ b/lib/ruby_smb/smb2/dcerpc.rb
@@ -56,7 +56,12 @@ module RubySMB
         ioctl_raw_response = @tree.client.send_recv(request)
         ioctl_response = RubySMB::SMB2::Packet::IoctlResponse.read(ioctl_raw_response)
         unless ioctl_response.valid?
-          raise RubySMB::Error::InvalidPacket, 'Not a IoctlResponse packet'
+          raise RubySMB::Error::InvalidPacket.new(
+            expected_proto: RubySMB::SMB2::SMB2_PROTOCOL_ID,
+            expected_cmd:   RubySMB::SMB2::Packet::IoctlRequest::COMMAND,
+            received_proto: ioctl_response.smb2_header.protocol,
+            received_cmd:   ioctl_response.smb2_header.command
+          )
         end
         unless ioctl_response.status_code == WindowsError::NTStatus::STATUS_SUCCESS
           raise RubySMB::Error::UnexpectedStatusCode, ioctl_response.status_code.name

--- a/lib/ruby_smb/smb2/dcerpc.rb
+++ b/lib/ruby_smb/smb2/dcerpc.rb
@@ -55,7 +55,7 @@ module RubySMB
         request.buffer = action.to_binary_s
         ioctl_raw_response = @tree.client.send_recv(request)
         ioctl_response = RubySMB::SMB2::Packet::IoctlResponse.read(ioctl_raw_response)
-        unless ioctl_response.smb2_header.command == RubySMB::SMB2::Commands::IOCTL
+        unless ioctl_response.valid?
           raise RubySMB::Error::InvalidPacket, 'Not a IoctlResponse packet'
         end
         unless ioctl_response.status_code == WindowsError::NTStatus::STATUS_SUCCESS

--- a/lib/ruby_smb/smb2/file.rb
+++ b/lib/ruby_smb/smb2/file.rb
@@ -86,7 +86,12 @@ module RubySMB
         raw_response  = tree.client.send_recv(close_request)
         response = RubySMB::SMB2::Packet::CloseResponse.read(raw_response)
         unless response.valid?
-          raise RubySMB::Error::InvalidPacket, 'Not a CloseResponse packet'
+          raise RubySMB::Error::InvalidPacket.new(
+            expected_proto: RubySMB::SMB2::SMB2_PROTOCOL_ID,
+            expected_cmd:   RubySMB::SMB2::Packet::CloseResponse::COMMAND,
+            received_proto: response.smb2_header.protocol,
+            received_cmd:   response.smb2_header.command
+          )
         end
         unless response.status_code == WindowsError::NTStatus::STATUS_SUCCESS
           raise RubySMB::Error::UnexpectedStatusCode, response.status_code.name
@@ -114,7 +119,12 @@ module RubySMB
         raw_response = tree.client.send_recv(read_request)
         response     = RubySMB::SMB2::Packet::ReadResponse.read(raw_response)
         unless response.valid?
-          raise RubySMB::Error::InvalidPacket, 'Not a ReadResponse packet'
+          raise RubySMB::Error::InvalidPacket.new(
+            expected_proto: RubySMB::SMB2::SMB2_PROTOCOL_ID,
+            expected_cmd:   RubySMB::SMB2::Packet::ReadResponse::COMMAND,
+            received_proto: response.smb2_header.protocol,
+            received_cmd:   response.smb2_header.command
+          )
         end
         unless response.status_code == WindowsError::NTStatus::STATUS_SUCCESS
           raise RubySMB::Error::UnexpectedStatusCode, response.status_code.name
@@ -132,7 +142,12 @@ module RubySMB
           raw_response = tree.client.send_recv(read_request)
           response     = RubySMB::SMB2::Packet::ReadResponse.read(raw_response)
           unless response.valid?
-            raise RubySMB::Error::InvalidPacket, 'Not a ReadResponse packet'
+            raise RubySMB::Error::InvalidPacket.new(
+              expected_proto: RubySMB::SMB2::SMB2_PROTOCOL_ID,
+              expected_cmd:   RubySMB::SMB2::Packet::ReadResponse::COMMAND,
+              received_proto: response.smb2_header.protocol,
+              received_cmd:   response.smb2_header.command
+            )
           end
           unless response.status_code == WindowsError::NTStatus::STATUS_SUCCESS
             raise RubySMB::Error::UnexpectedStatusCode, response.status_code.name
@@ -161,14 +176,24 @@ module RubySMB
         raw_response = tree.client.send_recv(read_request)
         response = RubySMB::SMB2::Packet::ReadResponse.read(raw_response)
         unless response.valid?
-          raise RubySMB::Error::InvalidPacket, 'Not a ReadResponse packet'
+          raise RubySMB::Error::InvalidPacket.new(
+            expected_proto: RubySMB::SMB2::SMB2_PROTOCOL_ID,
+            expected_cmd:   RubySMB::SMB2::Packet::ReadResponse::COMMAND,
+            received_proto: response.smb2_header.protocol,
+            received_cmd:   response.smb2_header.command
+          )
         end
         if response.status_code == WindowsError::NTStatus::STATUS_PENDING
           sleep 1
           raw_response = tree.client.dispatcher.recv_packet
           response = RubySMB::SMB2::Packet::ReadResponse.read(raw_response)
           unless response.valid?
-            raise RubySMB::Error::InvalidPacket, 'Not a ReadResponse packet'
+            raise RubySMB::Error::InvalidPacket.new(
+              expected_proto: RubySMB::SMB2::SMB2_PROTOCOL_ID,
+              expected_cmd:   RubySMB::SMB2::Packet::ReadResponse::COMMAND,
+              received_proto: response.smb2_header.protocol,
+              received_cmd:   response.smb2_header.command
+            )
           end
         elsif response.status_code != WindowsError::NTStatus::STATUS_SUCCESS
           raise RubySMB::Error::UnexpectedStatusCode, response.status_code.name
@@ -184,7 +209,12 @@ module RubySMB
         raw_response = tree.client.send_recv(delete_packet)
         response = RubySMB::SMB2::Packet::SetInfoResponse.read(raw_response)
         unless response.valid?
-          raise RubySMB::Error::InvalidPacket, 'Not a SetInfoResponse packet'
+          raise RubySMB::Error::InvalidPacket.new(
+            expected_proto: RubySMB::SMB2::SMB2_PROTOCOL_ID,
+            expected_cmd:   RubySMB::SMB2::Packet::SetInfoResponse::COMMAND,
+            received_proto: response.smb2_header.protocol,
+            received_cmd:   response.smb2_header.command
+          )
         end
         response.smb2_header.nt_status.to_nt_status
       end
@@ -229,7 +259,12 @@ module RubySMB
           raw_response  = tree.client.send_recv(write_request)
           response      = RubySMB::SMB2::Packet::WriteResponse.read(raw_response)
           unless response.valid?
-            raise RubySMB::Error::InvalidPacket, 'Not a WriteResponse packet'
+            raise RubySMB::Error::InvalidPacket.new(
+              expected_proto: RubySMB::SMB2::SMB2_PROTOCOL_ID,
+              expected_cmd:   RubySMB::SMB2::Packet::WriteResponse::COMMAND,
+              received_proto: response.smb2_header.protocol,
+              received_cmd:   response.smb2_header.command
+            )
           end
           status        = response.smb2_header.nt_status.to_nt_status
 
@@ -257,14 +292,24 @@ module RubySMB
         raw_response = tree.client.send_recv(pkt)
         response = RubySMB::SMB2::Packet::WriteResponse.read(raw_response)
         unless response.valid?
-          raise RubySMB::Error::InvalidPacket, 'Not a WriteResponse packet'
+          raise RubySMB::Error::InvalidPacket.new(
+            expected_proto: RubySMB::SMB2::SMB2_PROTOCOL_ID,
+            expected_cmd:   RubySMB::SMB2::Packet::WriteResponse::COMMAND,
+            received_proto: response.smb2_header.protocol,
+            received_cmd:   response.smb2_header.command
+          )
         end
         if response.status_code == WindowsError::NTStatus::STATUS_PENDING
           sleep 1
           raw_response = tree.client.dispatcher.recv_packet
           response = RubySMB::SMB2::Packet::WriteResponse.read(raw_response)
           unless response.valid?
-            raise RubySMB::Error::InvalidPacket, 'Not a WriteResponse packet'
+            raise RubySMB::Error::InvalidPacket.new(
+              expected_proto: RubySMB::SMB2::SMB2_PROTOCOL_ID,
+              expected_cmd:   RubySMB::SMB2::Packet::WriteResponse::COMMAND,
+              received_proto: response.smb2_header.protocol,
+              received_cmd:   response.smb2_header.command
+            )
           end
         elsif response.status_code != WindowsError::NTStatus::STATUS_SUCCESS
           raise RubySMB::Error::UnexpectedStatusCode, response.status_code.name
@@ -281,7 +326,12 @@ module RubySMB
         raw_response = tree.client.send_recv(rename_packet(new_file_name))
         response = RubySMB::SMB2::Packet::SetInfoResponse.read(raw_response)
         unless response.valid?
-          raise RubySMB::Error::InvalidPacket, 'Not a SetInfoResponse packet'
+          raise RubySMB::Error::InvalidPacket.new(
+            expected_proto: RubySMB::SMB2::SMB2_PROTOCOL_ID,
+            expected_cmd:   RubySMB::SMB2::Packet::SetInfoResponse::COMMAND,
+            received_proto: response.smb2_header.protocol,
+            received_cmd:   response.smb2_header.command
+          )
         end
         response.smb2_header.nt_status.to_nt_status
       end

--- a/lib/ruby_smb/smb2/packet/close_request.rb
+++ b/lib/ruby_smb/smb2/packet/close_request.rb
@@ -14,10 +14,6 @@ module RubySMB
         uint32                :reserved,              label: 'Reserved Space'
         smb2_fileid           :file_id,               label: 'File ID'
 
-        def initialize_instance
-          super
-          smb2_header.command = COMMAND
-        end
       end
     end
   end

--- a/lib/ruby_smb/smb2/packet/close_request.rb
+++ b/lib/ruby_smb/smb2/packet/close_request.rb
@@ -4,6 +4,8 @@ module RubySMB
       # An SMB2 Close Request Packet as defined in
       # [2.2.15 SMB2 CLOSE Request](https://msdn.microsoft.com/en-us/library/cc246523.aspx)
       class CloseRequest < RubySMB::GenericPacket
+        COMMAND = RubySMB::SMB2::Commands::CLOSE
+
         endian :little
 
         smb2_header           :smb2_header
@@ -14,7 +16,7 @@ module RubySMB
 
         def initialize_instance
           super
-          smb2_header.command = RubySMB::SMB2::Commands::CLOSE
+          smb2_header.command = COMMAND
         end
       end
     end

--- a/lib/ruby_smb/smb2/packet/close_response.rb
+++ b/lib/ruby_smb/smb2/packet/close_response.rb
@@ -22,7 +22,6 @@ module RubySMB
 
         def initialize_instance
           super
-          smb2_header.command     = COMMAND
           smb2_header.flags.reply = 1
         end
       end

--- a/lib/ruby_smb/smb2/packet/close_response.rb
+++ b/lib/ruby_smb/smb2/packet/close_response.rb
@@ -4,6 +4,8 @@ module RubySMB
       # An SMB2 Close Response Packet as defined in
       # [2.2.16 SMB2 CLOSE Response](https://msdn.microsoft.com/en-us/library/cc246524.aspx)
       class CloseResponse < RubySMB::GenericPacket
+        COMMAND = RubySMB::SMB2::Commands::CLOSE
+
         endian :little
 
         smb2_header      :smb2_header
@@ -20,7 +22,7 @@ module RubySMB
 
         def initialize_instance
           super
-          smb2_header.command     = RubySMB::SMB2::Commands::CLOSE
+          smb2_header.command     = COMMAND
           smb2_header.flags.reply = 1
         end
       end

--- a/lib/ruby_smb/smb2/packet/create_request.rb
+++ b/lib/ruby_smb/smb2/packet/create_request.rb
@@ -46,10 +46,6 @@ module RubySMB
 
         array :context, label: 'Contexts', type: :create_context, read_until: :eof
 
-        def initialize_instance
-          super
-          smb2_header.command = COMMAND
-        end
       end
     end
   end

--- a/lib/ruby_smb/smb2/packet/create_request.rb
+++ b/lib/ruby_smb/smb2/packet/create_request.rb
@@ -4,6 +4,8 @@ module RubySMB
       # An SMB2 Create Request Packet as defined in
       # [2.2.13 SMB2 CREATE Request](https://msdn.microsoft.com/en-us/library/cc246502.aspx)
       class CreateRequest < RubySMB::GenericPacket
+        COMMAND = RubySMB::SMB2::Commands::CREATE
+
         require 'ruby_smb/smb1/bit_field/create_options'
 
         endian :little
@@ -46,7 +48,7 @@ module RubySMB
 
         def initialize_instance
           super
-          smb2_header.command = RubySMB::SMB2::Commands::CREATE
+          smb2_header.command = COMMAND
         end
       end
     end

--- a/lib/ruby_smb/smb2/packet/create_response.rb
+++ b/lib/ruby_smb/smb2/packet/create_response.rb
@@ -28,7 +28,6 @@ module RubySMB
 
         def initialize_instance
           super
-          smb2_header.command = COMMAND
           smb2_header.flags.reply = 1
         end
       end

--- a/lib/ruby_smb/smb2/packet/create_response.rb
+++ b/lib/ruby_smb/smb2/packet/create_response.rb
@@ -4,6 +4,8 @@ module RubySMB
       # An SMB2 Create Response Packet as defined in
       # [2.2.14 SMB2 CREATE Response](https://msdn.microsoft.com/en-us/library/cc246512.aspx)
       class CreateResponse < RubySMB::GenericPacket
+        COMMAND = RubySMB::SMB2::Commands::CREATE
+
         endian :little
         smb2_header           :smb2_header
         uint16                :structure_size,       label: 'Structure Size', initial_value: 89
@@ -26,7 +28,7 @@ module RubySMB
 
         def initialize_instance
           super
-          smb2_header.command = RubySMB::SMB2::Commands::CREATE
+          smb2_header.command = COMMAND
           smb2_header.flags.reply = 1
         end
       end

--- a/lib/ruby_smb/smb2/packet/echo_request.rb
+++ b/lib/ruby_smb/smb2/packet/echo_request.rb
@@ -11,10 +11,6 @@ module RubySMB
         uint16       :structure_size, label: 'Structure Size', initial_value: 4
         uint16       :reserved
 
-        def initialize_instance
-          super
-          smb2_header.command = COMMAND
-        end
       end
     end
   end

--- a/lib/ruby_smb/smb2/packet/echo_request.rb
+++ b/lib/ruby_smb/smb2/packet/echo_request.rb
@@ -4,6 +4,8 @@ module RubySMB
       # An SMB2 Echo Request Packet as defined in
       # [2.2.28 SMB2 ECHO Request](https://msdn.microsoft.com/en-us/library/cc246540.aspx)
       class EchoRequest < RubySMB::GenericPacket
+        COMMAND = RubySMB::SMB2::Commands::ECHO
+
         endian       :little
         smb2_header  :smb2_header
         uint16       :structure_size, label: 'Structure Size', initial_value: 4
@@ -11,7 +13,7 @@ module RubySMB
 
         def initialize_instance
           super
-          smb2_header.command = RubySMB::SMB2::Commands::ECHO
+          smb2_header.command = COMMAND
         end
       end
     end

--- a/lib/ruby_smb/smb2/packet/echo_response.rb
+++ b/lib/ruby_smb/smb2/packet/echo_response.rb
@@ -13,7 +13,6 @@ module RubySMB
 
         def initialize_instance
           super
-          smb2_header.command = COMMAND
           smb2_header.flags.reply = 1
         end
       end

--- a/lib/ruby_smb/smb2/packet/echo_response.rb
+++ b/lib/ruby_smb/smb2/packet/echo_response.rb
@@ -4,6 +4,8 @@ module RubySMB
       # An SMB2 Echo response Packet as defined in
       # [2.2.29 SMB2 ECHO Response](https://msdn.microsoft.com/en-us/library/cc246541.aspx)
       class EchoResponse < RubySMB::GenericPacket
+        COMMAND = RubySMB::SMB2::Commands::ECHO
+
         endian       :little
         smb2_header  :smb2_header
         uint16       :structure_size, label: 'Structure Size', initial_value: 4
@@ -11,7 +13,7 @@ module RubySMB
 
         def initialize_instance
           super
-          smb2_header.command = RubySMB::SMB2::Commands::ECHO
+          smb2_header.command = COMMAND
           smb2_header.flags.reply = 1
         end
       end

--- a/lib/ruby_smb/smb2/packet/error_packet.rb
+++ b/lib/ruby_smb/smb2/packet/error_packet.rb
@@ -3,10 +3,17 @@ module RubySMB
     module Packet
       # An SMB2 Error packet for when an incomplete response comes back
       class ErrorPacket < RubySMB::GenericPacket
+        attr_accessor :original_command
+
         endian       :little
         smb2_header  :smb2_header
         uint16       :structure_size, label: 'Structure Size', initial_value: 4
         uint8        :error_data
+
+        def valid?
+          return smb2_header.protocol == RubySMB::SMB2::SMB2_PROTOCOL_ID &&
+            smb2_header.command == @original_command
+        end
       end
     end
   end

--- a/lib/ruby_smb/smb2/packet/ioctl_request.rb
+++ b/lib/ruby_smb/smb2/packet/ioctl_request.rb
@@ -32,11 +32,6 @@ module RubySMB
         uint32  :reserved2, label: 'Reserved Space'
         string  :buffer,    label: 'Input Buffer', read_length: -> { input_count + output_count }
 
-        def initialize_instance
-          super
-          smb2_header.command = COMMAND
-        end
-
         # Calculates the value for the input_offset field.
         # If the input buffer is empty then this should be set to 0,
         # otherwise it should return the absolute offset of the input buffer.

--- a/lib/ruby_smb/smb2/packet/ioctl_request.rb
+++ b/lib/ruby_smb/smb2/packet/ioctl_request.rb
@@ -4,6 +4,8 @@ module RubySMB
       # An SMB2 Ioctl Request Packet as defined in
       # [2.2.31 SMB2 IOCTL Request](https://msdn.microsoft.com/en-us/library/cc246545.aspx)
       class IoctlRequest < RubySMB::GenericPacket
+        COMMAND = RubySMB::SMB2::Commands::IOCTL
+
         endian :little
 
         smb2_header   :smb2_header
@@ -32,7 +34,7 @@ module RubySMB
 
         def initialize_instance
           super
-          smb2_header.command = RubySMB::SMB2::Commands::IOCTL
+          smb2_header.command = COMMAND
         end
 
         # Calculates the value for the input_offset field.

--- a/lib/ruby_smb/smb2/packet/ioctl_response.rb
+++ b/lib/ruby_smb/smb2/packet/ioctl_response.rb
@@ -24,7 +24,6 @@ module RubySMB
         def initialize_instance
           super
           smb2_header.flags.reply = 1
-          smb2_header.command     = COMMAND
         end
 
         def input_data

--- a/lib/ruby_smb/smb2/packet/ioctl_response.rb
+++ b/lib/ruby_smb/smb2/packet/ioctl_response.rb
@@ -4,6 +4,8 @@ module RubySMB
       # An SMB2 Ioctl Response Packet as defined in
       # [2.2.32 SMB2 IOCTL Response](https://msdn.microsoft.com/en-us/library/cc246548.aspx)
       class IoctlResponse < RubySMB::GenericPacket
+        COMMAND = RubySMB::SMB2::Commands::IOCTL
+
         endian :little
 
         smb2_header   :smb2_header
@@ -22,7 +24,7 @@ module RubySMB
         def initialize_instance
           super
           smb2_header.flags.reply = 1
-          smb2_header.command     = RubySMB::SMB2::Commands::IOCTL
+          smb2_header.command     = COMMAND
         end
 
         def input_data

--- a/lib/ruby_smb/smb2/packet/logoff_request.rb
+++ b/lib/ruby_smb/smb2/packet/logoff_request.rb
@@ -4,6 +4,8 @@ module RubySMB
       # An SMB2 LOGOFF Request Packet as defined in
       # [2.2.7 SMB2 LOGOFF Request](https://msdn.microsoft.com/en-us/library/cc246565.aspx)
       class LogoffRequest < RubySMB::GenericPacket
+        COMMAND = RubySMB::SMB2::Commands::LOGOFF
+
         endian       :little
         smb2_header  :smb2_header
         uint16       :structure_size, label: 'Structure Size', initial_value: 4
@@ -11,7 +13,7 @@ module RubySMB
 
         def initialize_instance
           super
-          smb2_header.command = RubySMB::SMB2::Commands::LOGOFF
+          smb2_header.command = COMMAND
         end
       end
     end

--- a/lib/ruby_smb/smb2/packet/logoff_request.rb
+++ b/lib/ruby_smb/smb2/packet/logoff_request.rb
@@ -11,10 +11,6 @@ module RubySMB
         uint16       :structure_size, label: 'Structure Size', initial_value: 4
         uint16       :reserved,       label: 'Reserved Space'
 
-        def initialize_instance
-          super
-          smb2_header.command = COMMAND
-        end
       end
     end
   end

--- a/lib/ruby_smb/smb2/packet/logoff_response.rb
+++ b/lib/ruby_smb/smb2/packet/logoff_response.rb
@@ -13,7 +13,6 @@ module RubySMB
 
         def initialize_instance
           super
-          smb2_header.command = COMMAND
           smb2_header.flags.reply = 1
         end
       end

--- a/lib/ruby_smb/smb2/packet/logoff_response.rb
+++ b/lib/ruby_smb/smb2/packet/logoff_response.rb
@@ -4,6 +4,8 @@ module RubySMB
       # An SMB2 LOGOFF Response Packet as defined in
       # [2.2.8 SMB2 LOGOFF Response](https://msdn.microsoft.com/en-us/library/cc246566.aspx)
       class LogoffResponse < RubySMB::GenericPacket
+        COMMAND = RubySMB::SMB2::Commands::LOGOFF
+
         endian       :little
         smb2_header  :smb2_header
         uint16       :structure_size, label: 'Structure Size', initial_value: 4
@@ -11,7 +13,7 @@ module RubySMB
 
         def initialize_instance
           super
-          smb2_header.command = RubySMB::SMB2::Commands::LOGOFF
+          smb2_header.command = COMMAND
           smb2_header.flags.reply = 1
         end
       end

--- a/lib/ruby_smb/smb2/packet/negotiate_request.rb
+++ b/lib/ruby_smb/smb2/packet/negotiate_request.rb
@@ -17,11 +17,6 @@ module RubySMB
         file_time           :client_start_time,   label: 'Client Start Time',  initial_value: 0
         array               :dialects,            label: 'Dialects',           type: :uint16, read_until: :eof
 
-        def initialize_instance
-          super
-          smb2_header.command = COMMAND
-        end
-
         # Adds a dialect to the Dialects array and increments the dialect count
         #
         # @param [Fixnum] the numeric code for the dialect you wish to add

--- a/lib/ruby_smb/smb2/packet/negotiate_request.rb
+++ b/lib/ruby_smb/smb2/packet/negotiate_request.rb
@@ -4,6 +4,8 @@ module RubySMB
       # An SMB2 NEGOTIATE Request packet as defined by
       # [2.2.3 SMB2 NEGOTIATE Request](https://msdn.microsoft.com/en-us/library/cc246543.aspx)
       class NegotiateRequest < RubySMB::GenericPacket
+        COMMAND = RubySMB::SMB2::Commands::NEGOTIATE
+
         endian              :little
         smb2_header         :smb2_header
         uint16              :structure_size,      label: 'Structure Size', initial_value: 36
@@ -17,7 +19,7 @@ module RubySMB
 
         def initialize_instance
           super
-          smb2_header.command = RubySMB::SMB2::Commands::NEGOTIATE
+          smb2_header.command = COMMAND
         end
 
         # Adds a dialect to the Dialects array and increments the dialect count

--- a/lib/ruby_smb/smb2/packet/negotiate_response.rb
+++ b/lib/ruby_smb/smb2/packet/negotiate_response.rb
@@ -26,7 +26,6 @@ module RubySMB
 
         def initialize_instance
           super
-          smb2_header.command = COMMAND
           smb2_header.flags.reply = 1
         end
       end

--- a/lib/ruby_smb/smb2/packet/negotiate_response.rb
+++ b/lib/ruby_smb/smb2/packet/negotiate_response.rb
@@ -4,6 +4,8 @@ module RubySMB
       # An SMB2 NEGOTIATE Response packet as defined by
       # [2.2.4 SMB2 NEGOTIATE Response](https://msdn.microsoft.com/en-us/library/cc246561.aspx)
       class NegotiateResponse < RubySMB::GenericPacket
+        COMMAND = RubySMB::SMB2::Commands::NEGOTIATE
+
         endian              :little
         smb2_header         :smb2_header
         uint16              :structure_size, label: 'Structure Size', initial_value: 65
@@ -24,7 +26,7 @@ module RubySMB
 
         def initialize_instance
           super
-          smb2_header.command = RubySMB::SMB2::Commands::NEGOTIATE
+          smb2_header.command = COMMAND
           smb2_header.flags.reply = 1
         end
       end

--- a/lib/ruby_smb/smb2/packet/query_directory_request.rb
+++ b/lib/ruby_smb/smb2/packet/query_directory_request.rb
@@ -27,10 +27,6 @@ module RubySMB
         uint32        :output_length, label: 'Output Buffer Length'
         string16      :name,          label: 'Name/Search Pattern'
 
-        def initialize_instance
-          super
-          smb2_header.command = COMMAND
-        end
       end
     end
   end

--- a/lib/ruby_smb/smb2/packet/query_directory_request.rb
+++ b/lib/ruby_smb/smb2/packet/query_directory_request.rb
@@ -4,6 +4,8 @@ module RubySMB
       # An SMB2 Query Directory Request Packet as defined in
       # [2.2.33 SMB2 QUERY_DIRECTORY Request](https://msdn.microsoft.com/en-us/library/cc246551.aspx)
       class QueryDirectoryRequest < RubySMB::GenericPacket
+        COMMAND = RubySMB::SMB2::Commands::QUERY_DIRECTORY
+
         endian       :little
         smb2_header  :smb2_header
         uint16       :structure_size,          label: 'Structure Size', initial_value: 33
@@ -27,7 +29,7 @@ module RubySMB
 
         def initialize_instance
           super
-          smb2_header.command = RubySMB::SMB2::Commands::QUERY_DIRECTORY
+          smb2_header.command = COMMAND
         end
       end
     end

--- a/lib/ruby_smb/smb2/packet/query_directory_response.rb
+++ b/lib/ruby_smb/smb2/packet/query_directory_response.rb
@@ -15,7 +15,6 @@ module RubySMB
 
         def initialize_instance
           super
-          smb2_header.command = COMMAND
           smb2_header.flags.reply = 1
         end
 

--- a/lib/ruby_smb/smb2/packet/read_request.rb
+++ b/lib/ruby_smb/smb2/packet/read_request.rb
@@ -4,6 +4,8 @@ module RubySMB
       # An SMB2 Read Request Packet as defined in
       # [2.2.19 SMB2 READ Request](https://msdn.microsoft.com/en-us/library/cc246527.aspx)
       class ReadRequest < RubySMB::GenericPacket
+        COMMAND = RubySMB::SMB2::Commands::READ
+
         endian :little
 
         smb2_header           :smb2_header
@@ -22,7 +24,7 @@ module RubySMB
 
         def initialize_instance
           super
-          smb2_header.command = RubySMB::SMB2::Commands::READ
+          smb2_header.command = COMMAND
         end
       end
     end

--- a/lib/ruby_smb/smb2/packet/read_request.rb
+++ b/lib/ruby_smb/smb2/packet/read_request.rb
@@ -22,10 +22,6 @@ module RubySMB
         uint16                :channel_length,        label: 'Read Channel Info Length'
         string                :buffer,                label: 'Read Channel info Buffer', initial_value: 0x00
 
-        def initialize_instance
-          super
-          smb2_header.command = COMMAND
-        end
       end
     end
   end

--- a/lib/ruby_smb/smb2/packet/read_response.rb
+++ b/lib/ruby_smb/smb2/packet/read_response.rb
@@ -4,6 +4,8 @@ module RubySMB
       # An SMB2 Read Response Packet as defined in
       # [2.2.20 SMB2 READ Response](https://msdn.microsoft.com/en-us/library/cc246531.aspx)
       class ReadResponse < RubySMB::GenericPacket
+        COMMAND = RubySMB::SMB2::Commands::READ
+
         endian :little
 
         smb2_header   :smb2_header
@@ -17,7 +19,7 @@ module RubySMB
 
         def initialize_instance
           super
-          smb2_header.command     = RubySMB::SMB2::Commands::READ
+          smb2_header.command     = COMMAND
           smb2_header.flags.reply = 1
         end
       end

--- a/lib/ruby_smb/smb2/packet/read_response.rb
+++ b/lib/ruby_smb/smb2/packet/read_response.rb
@@ -19,7 +19,6 @@ module RubySMB
 
         def initialize_instance
           super
-          smb2_header.command     = COMMAND
           smb2_header.flags.reply = 1
         end
       end

--- a/lib/ruby_smb/smb2/packet/session_setup_request.rb
+++ b/lib/ruby_smb/smb2/packet/session_setup_request.rb
@@ -18,11 +18,6 @@ module RubySMB
         uint64                     :previous_session_id,     label: 'Previous Session ID'
         string                     :buffer,                  label: 'Security Buffer', length: -> { security_buffer_length }
 
-        def initialize_instance
-          super
-          smb2_header.command = COMMAND
-        end
-
         # Takes a serialized NTLM Type 1 message and wraps it in the GSS ASN1 encoding
         # and inserts it into the {RubySMB::SMB2::Packet::SessionSetupRequest#buffer}
         # as well as updating the {RubySMB::SMB2::Packet::SessionSetupRequest#security_buffer_length}

--- a/lib/ruby_smb/smb2/packet/session_setup_request.rb
+++ b/lib/ruby_smb/smb2/packet/session_setup_request.rb
@@ -4,6 +4,8 @@ module RubySMB
       # An SMB2 SessionSetupRequest Packet as defined in
       # [2.2.5 SMB2 SESSION_SETUP Request](https://msdn.microsoft.com/en-us/library/cc246563.aspx)
       class SessionSetupRequest < RubySMB::GenericPacket
+        COMMAND = RubySMB::SMB2::Commands::SESSION_SETUP
+
         endian                     :little
         smb2_header                :smb2_header
         uint16                     :structure_size,          label: 'Structure Size',          initial_value: 25
@@ -18,7 +20,7 @@ module RubySMB
 
         def initialize_instance
           super
-          smb2_header.command = RubySMB::SMB2::Commands::SESSION_SETUP
+          smb2_header.command = COMMAND
         end
 
         # Takes a serialized NTLM Type 1 message and wraps it in the GSS ASN1 encoding

--- a/lib/ruby_smb/smb2/packet/session_setup_response.rb
+++ b/lib/ruby_smb/smb2/packet/session_setup_response.rb
@@ -4,6 +4,8 @@ module RubySMB
       # An SMB2 SessionSetupResponse Packet as defined in
       # [2.2.6 SMB2 SESSION_SETUP Response](https://msdn.microsoft.com/en-us/library/cc246564.aspx)
       class SessionSetupResponse < RubySMB::GenericPacket
+        COMMAND = RubySMB::SMB2::Commands::SESSION_SETUP
+
         endian :little
         smb2_header         :smb2_header
         uint16              :structure_size, label: 'Structure Size', initial_value: 9
@@ -14,7 +16,7 @@ module RubySMB
 
         def initialize_instance
           super
-          smb2_header.command = RubySMB::SMB2::Commands::SESSION_SETUP
+          smb2_header.command = COMMAND
           smb2_header.flags.reply = 1
         end
 

--- a/lib/ruby_smb/smb2/packet/session_setup_response.rb
+++ b/lib/ruby_smb/smb2/packet/session_setup_response.rb
@@ -16,7 +16,6 @@ module RubySMB
 
         def initialize_instance
           super
-          smb2_header.command = COMMAND
           smb2_header.flags.reply = 1
         end
 

--- a/lib/ruby_smb/smb2/packet/set_info_request.rb
+++ b/lib/ruby_smb/smb2/packet/set_info_request.rb
@@ -4,6 +4,8 @@ module RubySMB
       # An SMB2 Set Info Request Packet as defined in
       # [2.2.39 SMB2 SET_INFO Request](https://msdn.microsoft.com/en-us/library/cc246560.aspx)
       class SetInfoRequest < RubySMB::GenericPacket
+        COMMAND = RubySMB::SMB2::Commands::SET_INFO
+
         include RubySMB::Fscc::FileInformation
 
         endian :little
@@ -50,7 +52,7 @@ module RubySMB
 
         def initialize_instance
           super
-          smb2_header.command = RubySMB::SMB2::Commands::SET_INFO
+          smb2_header.command = COMMAND
         end
       end
     end

--- a/lib/ruby_smb/smb2/packet/set_info_request.rb
+++ b/lib/ruby_smb/smb2/packet/set_info_request.rb
@@ -50,10 +50,6 @@ module RubySMB
           file_id_full_directory_information FILE_ID_FULL_DIRECTORY_INFORMATION, label: 'File Id Full Directory Information'
         end
 
-        def initialize_instance
-          super
-          smb2_header.command = COMMAND
-        end
       end
     end
   end

--- a/lib/ruby_smb/smb2/packet/set_info_response.rb
+++ b/lib/ruby_smb/smb2/packet/set_info_response.rb
@@ -13,7 +13,6 @@ module RubySMB
 
         def initialize_instance
           super
-          smb2_header.command     = COMMAND
           smb2_header.flags.reply = 1
         end
       end

--- a/lib/ruby_smb/smb2/packet/set_info_response.rb
+++ b/lib/ruby_smb/smb2/packet/set_info_response.rb
@@ -4,6 +4,8 @@ module RubySMB
       # An SMB2 Read Response Packet as defined in
       # [2.2.40 SMB2 SET_INFO Response](https://msdn.microsoft.com/en-us/library/cc246562.aspx)
       class SetInfoResponse < RubySMB::GenericPacket
+        COMMAND = RubySMB::SMB2::Commands::SET_INFO
+
         endian :little
 
         smb2_header   :smb2_header
@@ -11,7 +13,7 @@ module RubySMB
 
         def initialize_instance
           super
-          smb2_header.command     = RubySMB::SMB2::Commands::SET_INFO
+          smb2_header.command     = COMMAND
           smb2_header.flags.reply = 1
         end
       end

--- a/lib/ruby_smb/smb2/packet/tree_connect_request.rb
+++ b/lib/ruby_smb/smb2/packet/tree_connect_request.rb
@@ -4,6 +4,8 @@ module RubySMB
       # An SMB2 TreeConnectRequest Packet as defined in
       # [2.2.9 SMB2 TREE_CONNECT Request](https://msdn.microsoft.com/en-us/library/cc246567.aspx)
       class TreeConnectRequest < RubySMB::GenericPacket
+        COMMAND = RubySMB::SMB2::Commands::TREE_CONNECT
+
         endian       :little
         smb2_header  :smb2_header
         uint16       :structure_size, label: 'Structure Size', initial_value: 9
@@ -14,7 +16,7 @@ module RubySMB
 
         def initialize_instance
           super
-          smb2_header.command = RubySMB::SMB2::Commands::TREE_CONNECT
+          smb2_header.command = COMMAND
         end
 
         def encode_path(path)

--- a/lib/ruby_smb/smb2/packet/tree_connect_request.rb
+++ b/lib/ruby_smb/smb2/packet/tree_connect_request.rb
@@ -14,11 +14,6 @@ module RubySMB
         uint16       :path_length,    label: 'Path Length',    initial_value: -> { path.length }
         string       :path,           label: 'Path Buffer'
 
-        def initialize_instance
-          super
-          smb2_header.command = COMMAND
-        end
-
         def encode_path(path)
           self.path = path.encode('utf-16le')
         end

--- a/lib/ruby_smb/smb2/packet/tree_connect_response.rb
+++ b/lib/ruby_smb/smb2/packet/tree_connect_response.rb
@@ -17,7 +17,6 @@ module RubySMB
 
         def initialize_instance
           super
-          smb2_header.command = COMMAND
           smb2_header.flags.reply = 1
         end
 

--- a/lib/ruby_smb/smb2/packet/tree_connect_response.rb
+++ b/lib/ruby_smb/smb2/packet/tree_connect_response.rb
@@ -4,6 +4,8 @@ module RubySMB
       # An SMB2 TreeConnectResponse Packet as defined in
       # [2.2.10 SMB2 TREE_CONNECT Response](https://msdn.microsoft.com/en-us/library/cc246499.aspx)
       class TreeConnectResponse < RubySMB::GenericPacket
+        COMMAND = RubySMB::SMB2::Commands::TREE_CONNECT
+
         endian :little
         smb2_header           :smb2_header
         uint16                :structure_size, label: 'Structure Size', initial_value: 16
@@ -15,7 +17,7 @@ module RubySMB
 
         def initialize_instance
           super
-          smb2_header.command = RubySMB::SMB2::Commands::TREE_CONNECT
+          smb2_header.command = COMMAND
           smb2_header.flags.reply = 1
         end
 
@@ -25,12 +27,17 @@ module RubySMB
         #
         # @return [RubySMB::SMB2::BitField::DirectoryAccessMask] if a directory was connected to
         # @return [RubySMB::SMB2::BitField::FileAccessMask] if anything else was connected to
+        # @raise [RubySMB::Error::InvalidBitField] if ACCESS_MASK bit field is not valid
         def access_rights
           if is_directory?
             maximal_access
           else
             mask = maximal_access.to_binary_s
-            RubySMB::SMB2::BitField::FileAccessMask.read(mask)
+            begin
+              RubySMB::SMB2::BitField::FileAccessMask.read(mask)
+            rescue IOError
+              raise RubySMB::Error::InvalidBitField, 'Invalid ACCESS_MASK for the Maximal Share Access Rights'
+            end
           end
         end
 

--- a/lib/ruby_smb/smb2/packet/tree_disconnect_request.rb
+++ b/lib/ruby_smb/smb2/packet/tree_disconnect_request.rb
@@ -11,10 +11,6 @@ module RubySMB
         uint16       :structure_size, label: 'Structure Size', initial_value: 4
         uint16       :reserved, label: 'Reserved', initial_value: 0
 
-        def initialize_instance
-          super
-          smb2_header.command = COMMAND
-        end
       end
     end
   end

--- a/lib/ruby_smb/smb2/packet/tree_disconnect_request.rb
+++ b/lib/ruby_smb/smb2/packet/tree_disconnect_request.rb
@@ -4,6 +4,8 @@ module RubySMB
       # An SMB2 TreeDisconnectRequest Packet as defined in
       # [2.2.11 SMB2 TREE_DISCONNECT Request](https://msdn.microsoft.com/en-us/library/cc246500.aspx)
       class TreeDisconnectRequest < RubySMB::GenericPacket
+        COMMAND = RubySMB::SMB2::Commands::TREE_DISCONNECT
+
         endian       :little
         smb2_header  :smb2_header
         uint16       :structure_size, label: 'Structure Size', initial_value: 4
@@ -11,7 +13,7 @@ module RubySMB
 
         def initialize_instance
           super
-          smb2_header.command = RubySMB::SMB2::Commands::TREE_DISCONNECT
+          smb2_header.command = COMMAND
         end
       end
     end

--- a/lib/ruby_smb/smb2/packet/tree_disconnect_response.rb
+++ b/lib/ruby_smb/smb2/packet/tree_disconnect_response.rb
@@ -4,13 +4,15 @@ module RubySMB
       # An SMB2 TreeDisconnectResponse Packet as defined in
       # [2.2.12 SMB2 TREE_DISCONNECT Response](https://msdn.microsoft.com/en-us/library/cc246501.aspx)
       class TreeDisconnectResponse < RubySMB::GenericPacket
+        COMMAND = RubySMB::SMB2::Commands::TREE_DISCONNECT
+
         endian       :little
         smb2_header  :smb2_header
         uint16       :structure_size, label: 'Structure Size', initial_value: 4
 
         def initialize_instance
           super
-          smb2_header.command = RubySMB::SMB2::Commands::TREE_DISCONNECT
+          smb2_header.command = COMMAND
           smb2_header.flags.reply = 1
         end
       end

--- a/lib/ruby_smb/smb2/packet/tree_disconnect_response.rb
+++ b/lib/ruby_smb/smb2/packet/tree_disconnect_response.rb
@@ -12,7 +12,6 @@ module RubySMB
 
         def initialize_instance
           super
-          smb2_header.command = COMMAND
           smb2_header.flags.reply = 1
         end
       end

--- a/lib/ruby_smb/smb2/packet/write_request.rb
+++ b/lib/ruby_smb/smb2/packet/write_request.rb
@@ -21,10 +21,6 @@ module RubySMB
         uint32                :flags,                 label: 'Flags'
         string                :buffer,                label: 'Write Data Buffer'
 
-        def initialize_instance
-          super
-          smb2_header.command = COMMAND
-        end
       end
     end
   end

--- a/lib/ruby_smb/smb2/packet/write_request.rb
+++ b/lib/ruby_smb/smb2/packet/write_request.rb
@@ -4,6 +4,8 @@ module RubySMB
       # An SMB2 Write Request Packet as defined in
       # [2.2.21 SMB2 WRITE Request](https://msdn.microsoft.com/en-us/library/cc246532.aspx)
       class WriteRequest < RubySMB::GenericPacket
+        COMMAND = RubySMB::SMB2::Commands::WRITE
+
         endian :little
 
         smb2_header           :smb2_header
@@ -21,7 +23,7 @@ module RubySMB
 
         def initialize_instance
           super
-          smb2_header.command = RubySMB::SMB2::Commands::WRITE
+          smb2_header.command = COMMAND
         end
       end
     end

--- a/lib/ruby_smb/smb2/packet/write_response.rb
+++ b/lib/ruby_smb/smb2/packet/write_response.rb
@@ -19,7 +19,6 @@ module RubySMB
 
         def initialize_instance
           super
-          smb2_header.command = COMMAND
           smb2_header.flags.reply = 1
         end
       end

--- a/lib/ruby_smb/smb2/packet/write_response.rb
+++ b/lib/ruby_smb/smb2/packet/write_response.rb
@@ -4,6 +4,8 @@ module RubySMB
       # An SMB2 Write Response Packet as defined in
       # [2.2.22 SMB2 WRITE Response](https://msdn.microsoft.com/en-us/library/cc246533.aspx)
       class WriteResponse < RubySMB::GenericPacket
+        COMMAND = RubySMB::SMB2::Commands::WRITE
+
         endian :little
 
         smb2_header           :smb2_header
@@ -17,7 +19,7 @@ module RubySMB
 
         def initialize_instance
           super
-          smb2_header.command = RubySMB::SMB2::Commands::WRITE
+          smb2_header.command = COMMAND
           smb2_header.flags.reply = 1
         end
       end

--- a/lib/ruby_smb/smb2/pipe.rb
+++ b/lib/ruby_smb/smb2/pipe.rb
@@ -26,7 +26,12 @@ module RubySMB
         raw_response = @tree.client.send_recv(packet)
         response = RubySMB::SMB2::Packet::IoctlResponse.read(raw_response)
         unless response.valid?
-          raise RubySMB::Error::InvalidPacket, 'Not an IoctlResponse packet'
+          raise RubySMB::Error::InvalidPacket.new(
+            expected_proto: RubySMB::SMB2::SMB2_PROTOCOL_ID,
+            expected_cmd:   RubySMB::SMB2::Packet::IoctlResponse::COMMAND,
+            received_proto: response.smb2_header.protocol,
+            received_cmd:   response.smb2_header.command
+          )
         end
 
         unless response.status_code == WindowsError::NTStatus::STATUS_BUFFER_OVERFLOW or response.status_code == WindowsError::NTStatus::STATUS_SUCCESS

--- a/lib/ruby_smb/smb2/pipe.rb
+++ b/lib/ruby_smb/smb2/pipe.rb
@@ -14,7 +14,7 @@ module RubySMB
       #
       # @param peek_size [Integer] Amount of data to peek
       # @return [RubySMB::SMB2::Packet::IoctlResponse]
-      # @raise [RubySMB::Error::InvalidPacket] if not a valid FSCTL_PIPE_PEEK response
+      # @raise [RubySMB::Error::InvalidPacket] if not a valid FIoctlResponse response
       # @raise [RubySMB::Error::UnexpectedStatusCode] If status is not STATUS_BUFFER_OVERFLOW or STATUS_SUCCESS
       def peek(peek_size: 0)
         packet = RubySMB::SMB2::Packet::IoctlRequest.new
@@ -24,18 +24,13 @@ module RubySMB
         packet.max_output_response = 16 + peek_size
         packet = set_header_fields(packet)
         raw_response = @tree.client.send_recv(packet)
-        begin
-          response = RubySMB::SMB2::Packet::IoctlResponse.read(raw_response)
-        rescue IOError
-          response = RubySMB::SMB2::Packet::ErrorPacket.read(raw_response)
+        response = RubySMB::SMB2::Packet::IoctlResponse.read(raw_response)
+        unless response.valid?
+          raise RubySMB::Error::InvalidPacket, 'Not an IoctlResponse packet'
         end
 
         unless response.status_code == WindowsError::NTStatus::STATUS_BUFFER_OVERFLOW or response.status_code == WindowsError::NTStatus::STATUS_SUCCESS
           raise RubySMB::Error::UnexpectedStatusCode, response.status_code.name
-        end
-
-        unless response.smb2_header.command == RubySMB::SMB2::Commands::IOCTL
-          raise RubySMB::Error::InvalidPacket, 'Not an IoctlResponse packet'
         end
         response
       end

--- a/lib/ruby_smb/smb2/tree.rb
+++ b/lib/ruby_smb/smb2/tree.rb
@@ -41,7 +41,12 @@ module RubySMB
         raw_response = client.send_recv(request)
         response = RubySMB::SMB2::Packet::TreeDisconnectResponse.read(raw_response)
         unless response.valid?
-          raise RubySMB::Error::InvalidPacket, 'Not a TreeDisconnectResponse packet'
+          raise RubySMB::Error::InvalidPacket.new(
+            expected_proto: RubySMB::SMB2::SMB2_PROTOCOL_ID,
+            expected_cmd:   RubySMB::SMB2::Packet::TreeDisconnectResponse::COMMAND,
+            received_proto: response.smb2_header.protocol,
+            received_cmd:   response.smb2_header.command
+          )
         end
         response.status_code
       end
@@ -94,7 +99,12 @@ module RubySMB
         raw_response  = client.send_recv(create_request)
         response      = RubySMB::SMB2::Packet::CreateResponse.read(raw_response)
         unless response.valid?
-          raise RubySMB::Error::InvalidPacket, 'Not a CreateResponse packet'
+          raise RubySMB::Error::InvalidPacket.new(
+            expected_proto: RubySMB::SMB2::SMB2_PROTOCOL_ID,
+            expected_cmd:   RubySMB::SMB2::Packet::CreateResponse::COMMAND,
+            received_proto: response.smb2_header.protocol,
+            received_cmd:   response.smb2_header.command
+          )
         end
         unless response.status_code == WindowsError::NTStatus::STATUS_SUCCESS
           raise RubySMB::Error::UnexpectedStatusCode, response.status_code.name
@@ -141,7 +151,12 @@ module RubySMB
           response            = client.send_recv(directory_request)
           directory_response  = RubySMB::SMB2::Packet::QueryDirectoryResponse.read(response)
           unless directory_response.valid?
-            raise RubySMB::Error::InvalidPacket, 'Not a QueryDirectoryResponse packet'
+            raise RubySMB::Error::InvalidPacket.new(
+              expected_proto: RubySMB::SMB2::SMB2_PROTOCOL_ID,
+              expected_cmd:   RubySMB::SMB2::Packet::QueryDirectoryResponse::COMMAND,
+              received_proto: directory_response.smb2_header.protocol,
+              received_cmd:   directory_response.smb2_header.command
+            )
           end
 
           status_code         = directory_response.smb2_header.nt_status.to_nt_status
@@ -181,7 +196,12 @@ module RubySMB
         raw_response    = client.send_recv(create_request)
         response = RubySMB::SMB2::Packet::CreateResponse.read(raw_response)
         unless response.valid?
-          raise RubySMB::Error::InvalidPacket, 'Not a CreateResponse packet'
+          raise RubySMB::Error::InvalidPacket.new(
+            expected_proto: RubySMB::SMB2::SMB2_PROTOCOL_ID,
+            expected_cmd:   RubySMB::SMB2::Packet::CreateResponse::COMMAND,
+            received_proto: response.smb2_header.protocol,
+            received_cmd:   response.smb2_header.command
+          )
         end
         unless response.status_code == WindowsError::NTStatus::STATUS_SUCCESS
           raise RubySMB::Error::UnexpectedStatusCode, response.status_code.name

--- a/spec/lib/ruby_smb/client_spec.rb
+++ b/spec/lib/ruby_smb/client_spec.rb
@@ -211,7 +211,7 @@ RSpec.describe RubySMB::Client do
       before :example do
         allow(smb2_client).to receive(:send_recv).and_return(raw_response)
         allow(RubySMB::SMB2::Packet::LogoffResponse).to receive(:read).and_return(logoff_response)
-        allow(smb1_client).to receive(:wipe_state!)
+        allow(smb2_client).to receive(:wipe_state!)
       end
 
       it 'creates a LogoffRequest packet' do

--- a/spec/lib/ruby_smb/client_spec.rb
+++ b/spec/lib/ruby_smb/client_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe RubySMB::Client do
   let(:smb1_client) { described_class.new(dispatcher, smb2: false, username: username, password: password) }
   let(:smb2_client) { described_class.new(dispatcher, smb1: false, username: username, password: password) }
   let(:empty_packet) { RubySMB::SMB1::Packet::EmptyPacket.new }
+  let(:error_packet) { RubySMB::SMB2::Packet::ErrorPacket.new }
 
   describe '#initialize' do
     it 'should raise an ArgumentError without a valid dispatcher' do
@@ -153,6 +154,94 @@ RSpec.describe RubySMB::Client do
     end
   end
 
+  describe '#logoff!' do
+    context 'with SMB1' do
+      let(:raw_response) { double('Raw response') }
+      let(:logoff_response) {
+        RubySMB::SMB1::Packet::LogoffResponse.new(smb_header: {:command => RubySMB::SMB1::Commands::SMB_COM_LOGOFF} )
+      }
+      before :example do
+        allow(smb1_client).to receive(:send_recv).and_return(raw_response)
+        allow(RubySMB::SMB1::Packet::LogoffResponse).to receive(:read).and_return(logoff_response)
+        allow(smb1_client).to receive(:wipe_state!)
+      end
+
+      it 'creates a LogoffRequest packet' do
+        expect(RubySMB::SMB1::Packet::LogoffRequest).to receive(:new).and_call_original
+        smb1_client.logoff!
+      end
+
+      it 'calls #send_recv' do
+        expect(smb1_client).to receive(:send_recv)
+        smb1_client.logoff!
+      end
+
+      it 'reads the raw response as a LogoffResponse packet' do
+        expect(RubySMB::SMB1::Packet::LogoffResponse).to receive(:read).with(raw_response)
+        smb1_client.logoff!
+      end
+
+      it 'raise an InvalidPacket exception when the response is an empty packet' do
+        allow(RubySMB::SMB1::Packet::LogoffResponse).to receive(:read).and_return(RubySMB::SMB1::Packet::EmptyPacket.new)
+        expect {smb1_client.logoff!}.to raise_error(RubySMB::Error::InvalidPacket)
+      end
+
+      it 'raise an InvalidPacket exception when the response is not valid' do
+        allow(logoff_response).to receive(:valid?).and_return(false)
+        expect {smb1_client.logoff!}.to raise_error(RubySMB::Error::InvalidPacket)
+      end
+
+      it 'calls #wipe_state!' do
+        expect(smb1_client).to receive(:wipe_state!)
+        smb1_client.logoff!
+      end
+
+      it 'returns the expected status code' do
+        logoff_response.smb_header.nt_status = WindowsError::NTStatus::STATUS_PENDING.value
+        allow(RubySMB::SMB1::Packet::LogoffResponse).to receive(:read).and_return(logoff_response)
+        expect(smb1_client.logoff!).to eq(WindowsError::NTStatus::STATUS_PENDING)
+      end
+    end
+
+    context 'with SMB2' do
+      let(:raw_response) { double('Raw response') }
+      let(:logoff_response) {
+        RubySMB::SMB2::Packet::LogoffResponse.new(smb_header: {:command => RubySMB::SMB2::Commands::LOGOFF} )
+      }
+      before :example do
+        allow(smb2_client).to receive(:send_recv).and_return(raw_response)
+        allow(RubySMB::SMB2::Packet::LogoffResponse).to receive(:read).and_return(logoff_response)
+        allow(smb1_client).to receive(:wipe_state!)
+      end
+
+      it 'creates a LogoffRequest packet' do
+        expect(RubySMB::SMB2::Packet::LogoffRequest).to receive(:new).and_call_original
+        smb2_client.logoff!
+      end
+
+      it 'calls #send_recv' do
+        expect(smb2_client).to receive(:send_recv)
+        smb2_client.logoff!
+      end
+
+      it 'reads the raw response as a LogoffResponse packet' do
+        expect(RubySMB::SMB2::Packet::LogoffResponse).to receive(:read).with(raw_response)
+        smb2_client.logoff!
+      end
+
+      it 'raise an InvalidPacket exception when the response is an error packet' do
+        allow(RubySMB::SMB2::Packet::LogoffResponse).to receive(:read).and_return(RubySMB::SMB2::Packet::ErrorPacket.new)
+        expect {smb2_client.logoff!}.to raise_error(RubySMB::Error::InvalidPacket)
+      end
+
+      it 'raise an InvalidPacket exception when the response is not a LOGOFF command' do
+        logoff_response.smb2_header.command = RubySMB::SMB2::Commands::ECHO
+        allow(RubySMB::SMB2::Packet::LogoffResponse).to receive(:read).and_return(logoff_response)
+        expect {smb2_client.logoff!}.to raise_error(RubySMB::Error::InvalidPacket)
+      end
+    end
+  end
+
   context 'NetBIOS Session Service' do
     describe '#session_request' do
       let(:session_header)  { RubySMB::Nbss::SessionHeader.new }
@@ -196,6 +285,11 @@ RSpec.describe RubySMB::Client do
         negative_session_response.error_code = 0x80
         allow(dispatcher).to receive(:recv_packet).and_return(negative_session_response.to_binary_s)
         expect { client.session_request }.to raise_error(RubySMB::Error::NetBiosSessionService)
+      end
+
+      it 'raises an InvalidPacket exception when an error occurs while reading' do
+        allow(RubySMB::Nbss::SessionHeader).to receive(:read).and_raise(IOError)
+        expect { client.session_request }.to raise_error(RubySMB::Error::InvalidPacket)
       end
     end
 
@@ -332,8 +426,13 @@ RSpec.describe RubySMB::Client do
           expect(smb1_client.negotiate_response(smb1_extended_response_raw)).to eq smb1_extended_response
         end
 
-        it 'raises an exception if the Response is invalid' do
+        it 'raises an exception if the response is not a SMB packet' do
           expect { smb1_client.negotiate_response(random_junk) }.to raise_error(RubySMB::Error::InvalidPacket)
+        end
+
+        it 'raises an InvalidPacket error if the response is not a valid response' do
+          empty_packet.smb_header.command = RubySMB::SMB2::Commands::NEGOTIATE
+          expect { smb1_client.negotiate_response(empty_packet.to_binary_s) }.to raise_error(RubySMB::Error::InvalidPacket)
         end
 
         it 'considers the response invalid if it is not an actual Negotiate Response' do
@@ -356,6 +455,12 @@ RSpec.describe RubySMB::Client do
 
         it 'raises an exception if the Response is invalid' do
           expect { smb2_client.negotiate_response(random_junk) }.to raise_error(RubySMB::Error::InvalidPacket)
+        end
+
+        it 'considers the response invalid if it is not an actual Negotiate Response' do
+          bogus_response = smb2_response
+          bogus_response.smb2_header.command = RubySMB::SMB2::Commands::ECHO
+          expect { smb2_client.negotiate_response(bogus_response.to_binary_s) }.to raise_error(RubySMB::Error::InvalidPacket)
         end
       end
 
@@ -624,7 +729,7 @@ RSpec.describe RubySMB::Client do
           expect { smb1_client.smb1_ntlmssp_challenge_packet(response.to_binary_s) }.to raise_error(RubySMB::Error::UnexpectedStatusCode)
         end
 
-        it 'raises an InvalidPacket if the Command field is wrong' do
+        it 'raise an InvalidPacket exception when the response is not valid' do
           expect { smb1_client.smb1_ntlmssp_challenge_packet(wrong_command.to_binary_s) }.to raise_error(RubySMB::Error::InvalidPacket)
         end
       end
@@ -645,7 +750,7 @@ RSpec.describe RubySMB::Client do
           expect(smb1_client.smb1_ntlmssp_final_packet(response.to_binary_s)).to eq response
         end
 
-        it 'raises an InvalidPacket if the Command field is wrong' do
+        it 'raise an InvalidPacket exception when the response is not valid' do
           expect { smb1_client.smb1_ntlmssp_final_packet(wrong_command.to_binary_s) }.to raise_error(RubySMB::Error::InvalidPacket)
         end
       end
@@ -717,12 +822,7 @@ RSpec.describe RubySMB::Client do
             expect(smb1_client.smb1_anonymous_auth_response(anonymous_response.to_binary_s)).to eq anonymous_response
           end
 
-          it 'returns an empty packet if the raw data is not a valid response' do
-            empty_packet.smb_header.command = RubySMB::SMB1::Commands::SMB_COM_SESSION_SETUP
-            expect(smb1_client.smb1_anonymous_auth_response(empty_packet.to_binary_s)).to eq empty_packet
-          end
-
-          it 'raises an InvalidPacket error if the command is wrong' do
+          it 'raise an InvalidPacket exception when the response is not valid' do
             anonymous_response.smb_header.command = RubySMB::SMB1::Commands::SMB_COM_NEGOTIATE
             expect { smb1_client.smb1_anonymous_auth_response(anonymous_response.to_binary_s) }.to raise_error(RubySMB::Error::InvalidPacket)
           end
@@ -829,7 +929,7 @@ RSpec.describe RubySMB::Client do
           expect { smb2_client.smb2_ntlmssp_challenge_packet(response.to_binary_s) }.to raise_error(RubySMB::Error::UnexpectedStatusCode)
         end
 
-        it 'raises an InvalidPacket if the Command field is wrong' do
+        it 'raise an InvalidPacket exception when the response is not valid' do
           expect { smb2_client.smb2_ntlmssp_challenge_packet(wrong_command.to_binary_s) }.to raise_error(RubySMB::Error::InvalidPacket)
         end
       end
@@ -888,7 +988,7 @@ RSpec.describe RubySMB::Client do
           expect(smb2_client.smb2_ntlmssp_final_packet(response.to_binary_s)).to eq response
         end
 
-        it 'raises an InvalidPacket if the Command field is wrong' do
+        it 'raise an InvalidPacket exception when the response is not valid' do
           expect { smb2_client.smb2_ntlmssp_final_packet(wrong_command.to_binary_s) }.to raise_error(RubySMB::Error::InvalidPacket)
         end
       end
@@ -1199,6 +1299,12 @@ RSpec.describe RubySMB::Client do
         expect(smb1_client).to receive(:send_recv).and_return(echo_response.to_binary_s)
         expect(smb1_client.echo).to eq WindowsError::NTStatus::STATUS_ABANDONED
       end
+
+      it 'raise an InvalidPacket exception when the response is not valid' do
+        echo_response.smb_header.command = RubySMB::SMB1::Commands::SMB_COM_SESSION_SETUP
+        allow(smb1_client).to receive(:send_recv).and_return(echo_response.to_binary_s)
+        expect { smb1_client.echo }.to raise_error(RubySMB::Error::InvalidPacket)
+      end
     end
 
     context 'with SMB2' do
@@ -1209,6 +1315,12 @@ RSpec.describe RubySMB::Client do
         allow(RubySMB::SMB2::Packet::EchoRequest).to receive(:new).and_return(echo_request)
         expect(smb2_client).to receive(:send_recv).with(echo_request).and_return(echo_response.to_binary_s)
         expect(smb2_client.smb2_echo).to eq echo_response
+      end
+
+      it 'raise an InvalidPacket exception when the response is not valid' do
+        echo_response.smb2_header.command = RubySMB::SMB2::Commands::SESSION_SETUP
+        allow(smb2_client).to receive(:send_recv).and_return(echo_response.to_binary_s)
+        expect { smb2_client.smb2_echo }.to raise_error(RubySMB::Error::InvalidPacket)
       end
     end
   end

--- a/spec/lib/ruby_smb/smb1/file_spec.rb
+++ b/spec/lib/ruby_smb/smb1/file_spec.rb
@@ -513,6 +513,9 @@ RSpec.describe RubySMB::SMB1::File do
 
     it 'raises an InvalidPacket exception if the response is not valid' do
       allow(response).to receive(:valid?).and_return(false)
+      smb_header = double('SMB Header')
+      allow(response).to receive(:smb_header).and_return(smb_header)
+      allow(smb_header).to receive_messages(:protocol => nil, :command => nil)
       expect { file.close }.to raise_error(RubySMB::Error::InvalidPacket)
     end
 

--- a/spec/lib/ruby_smb/smb1/packet/empty_packet_spec.rb
+++ b/spec/lib/ruby_smb/smb1/packet/empty_packet_spec.rb
@@ -34,4 +34,25 @@ RSpec.describe RubySMB::SMB1::Packet::EmptyPacket do
       expect(data_block.to_binary_s).to eq "\x00\x00"
     end
   end
+
+  describe '#valid?' do
+    before :example do
+      packet.original_command = RubySMB::SMB1::Commands::SMB_COM_TREE_CONNECT
+      packet.smb_header.command = RubySMB::SMB1::Commands::SMB_COM_TREE_CONNECT
+    end
+
+    it 'returns true if the packet protocol ID and header command are valid' do
+      expect(packet).to be_valid
+    end
+
+    it 'returns false if the packet protocol ID is wrong' do
+      packet.smb_header.protocol = RubySMB::SMB2::SMB2_PROTOCOL_ID
+      expect(packet).to_not be_valid
+    end
+
+    it 'returns false if the packet header command is wrong' do
+      packet.smb_header.command = RubySMB::SMB1::Commands::SMB_COM_NEGOTIATE
+      expect(packet).to_not be_valid
+    end
+  end
 end

--- a/spec/lib/ruby_smb/smb1/packet/trans2/find_next2_response_spec.rb
+++ b/spec/lib/ruby_smb/smb1/packet/trans2/find_next2_response_spec.rb
@@ -78,6 +78,8 @@ RSpec.describe RubySMB::SMB1::Packet::Trans2::FindNext2Response do
 
     let(:names_blob) { names_array.collect(&:to_binary_s).join('') }
 
+    let(:find_info) { FindFileFullDirectoryInfo.new }
+
     it 'returns an array of parsed FindFileFullDirectoryInfo structs' do
       packet.data_block.trans2_data.buffer = names_blob
       expect(packet.results(FindFileFullDirectoryInfo, unicode: false)).to eq names_array
@@ -85,7 +87,6 @@ RSpec.describe RubySMB::SMB1::Packet::Trans2::FindNext2Response do
 
     it 'sets the FindFileFullDirectoryInfo unicode attribute when unicode argument is true' do
       packet.data_block.trans2_data.buffer = names1.to_binary_s
-      find_info = FindFileFullDirectoryInfo.new
       allow(FindFileFullDirectoryInfo).to receive(:new).and_return find_info
       expect(find_info).to receive(:unicode=).with(true).once
       packet.results(FindFileFullDirectoryInfo, unicode: true)
@@ -93,10 +94,18 @@ RSpec.describe RubySMB::SMB1::Packet::Trans2::FindNext2Response do
 
     it 'does not set the FindFileFullDirectoryInfo unicode attribute when unicode argument is false' do
       packet.data_block.trans2_data.buffer = names1.to_binary_s
-      find_info = FindFileFullDirectoryInfo.new
       allow(FindFileFullDirectoryInfo).to receive(:new).and_return find_info
       expect(find_info).to receive(:unicode=).with(false).once
       packet.results(FindFileFullDirectoryInfo, unicode: false)
+    end
+
+    context 'when the File Information is not a valid' do
+      it 'raises an InvalidPacket exception' do
+        packet.data_block.trans2_data.buffer = names1.to_binary_s
+        allow(FindFileFullDirectoryInfo).to receive(:new).and_return(find_info)
+        allow(find_info).to receive(:read).and_raise(IOError)
+        expect { packet.results(FindFileFullDirectoryInfo, unicode: false) }.to raise_error(RubySMB::Error::InvalidPacket)
+      end
     end
   end
 end

--- a/spec/lib/ruby_smb/smb1/packet/tree_connect_response_spec.rb
+++ b/spec/lib/ruby_smb/smb1/packet/tree_connect_response_spec.rb
@@ -104,4 +104,44 @@ RSpec.describe RubySMB::SMB1::Packet::TreeConnectResponse do
       expect(file_response.guest_access_rights).to be_a RubySMB::SMB1::BitField::FileAccessMask
     end
   end
+
+  describe '#access_rights' do
+    it 'is a DirectoryAccessMask if the Tree is a directory' do
+      allow(packet).to receive(:is_directory?).and_return(true)
+      expect(packet.access_rights).to be_a RubySMB::SMB1::BitField::DirectoryAccessMask
+    end
+
+    it 'is a FileAccessMask if the Tree is not a directory' do
+      allow(packet).to receive(:is_directory?).and_return(false)
+      expect(packet.access_rights).to be_a RubySMB::SMB1::BitField::FileAccessMask
+    end
+
+    context 'when it is not a valid FileAccessMask' do
+      it 'raises an InvalidBitField exception' do
+        allow(packet).to receive(:is_directory?).and_return(false)
+        allow(RubySMB::SMB1::BitField::FileAccessMask).to receive(:read).and_raise(IOError)
+        expect { packet.access_rights }.to raise_error(RubySMB::Error::InvalidBitField)
+      end
+    end
+  end
+
+  describe '#guest_access_rights' do
+    it 'is a DirectoryAccessMask if the Tree is a directory' do
+      allow(packet).to receive(:is_directory?).and_return(true)
+      expect(packet.guest_access_rights).to be_a RubySMB::SMB1::BitField::DirectoryAccessMask
+    end
+
+    it 'is a FileAccessMask if the Tree is not a directory' do
+      allow(packet).to receive(:is_directory?).and_return(false)
+      expect(packet.guest_access_rights).to be_a RubySMB::SMB1::BitField::FileAccessMask
+    end
+
+    context 'when it is not a valid FileAccessMask' do
+      it 'raises an InvalidBitField exception' do
+        allow(packet).to receive(:is_directory?).and_return(false)
+        allow(RubySMB::SMB1::BitField::FileAccessMask).to receive(:read).and_raise(IOError)
+        expect { packet.guest_access_rights }.to raise_error(RubySMB::Error::InvalidBitField)
+      end
+    end
+  end
 end

--- a/spec/lib/ruby_smb/smb1/pipe_spec.rb
+++ b/spec/lib/ruby_smb/smb1/pipe_spec.rb
@@ -83,6 +83,9 @@ RSpec.describe RubySMB::SMB1::Pipe do
 
     it 'raises an InvalidPacket exception if the response is not valid' do
       allow(response).to receive(:valid?).and_return(false)
+      smb_header = double('SMB Header')
+      allow(response).to receive(:smb_header).and_return(smb_header)
+      allow(smb_header).to receive_messages(:protocol => nil, :command => nil)
       expect { pipe.peek }.to raise_error(RubySMB::Error::InvalidPacket)
     end
 

--- a/spec/lib/ruby_smb/smb1/pipe_spec.rb
+++ b/spec/lib/ruby_smb/smb1/pipe_spec.rb
@@ -37,6 +37,65 @@ RSpec.describe RubySMB::SMB1::Pipe do
     described_class.new(tree: tree, response: nt_create_andx_response, name: filename)
   }
 
+  describe '#peek' do
+    let(:request) { RubySMB::SMB1::Packet::Trans::PeekNmpipeRequest.new }
+    let(:raw_response) { double('Raw response') }
+    let(:response) { double('Response') }
+
+    before :example do
+      allow(RubySMB::SMB1::Packet::Trans::PeekNmpipeRequest).to receive(:new).and_return(request)
+      allow(client).to receive(:send_recv).and_return(raw_response)
+      allow(RubySMB::SMB1::Packet::Trans::PeekNmpipeResponse).to receive(:read).and_return(response)
+      allow(response).to receive(:valid?).and_return(true)
+      allow(response).to receive(:status_code).and_return(WindowsError::NTStatus::STATUS_SUCCESS)
+    end
+
+    it 'creates a PeekNmpipeRequest'do
+      expect(RubySMB::SMB1::Packet::Trans::PeekNmpipeRequest).to receive(:new)
+      pipe.peek
+    end
+
+    it 'sets the request #fid field' do
+      expect(request).to receive(:fid=).with(pipe.fid)
+      pipe.peek
+    end
+
+    it 'sets the request #max_data_count fieldto the peek_size argument' do
+      peek_size = 5
+      pipe.peek(peek_size: peek_size)
+      expect(request.parameter_block.max_data_count).to eq(peek_size)
+    end
+
+    it 'calls Tree #set_header_fields' do
+      expect(tree).to receive(:set_header_fields).with(request)
+      pipe.peek
+    end
+
+    it 'calls Client #send_recv' do
+      expect(client).to receive(:send_recv).with(request)
+      pipe.peek
+    end
+
+    it 'parses the response as a SMB1 PeekNmpipeResponse packet' do
+      expect(RubySMB::SMB1::Packet::Trans::PeekNmpipeResponse).to receive(:read).with(raw_response)
+      pipe.peek
+    end
+
+    it 'raises an InvalidPacket exception if the response is not valid' do
+      allow(response).to receive(:valid?).and_return(false)
+      expect { pipe.peek }.to raise_error(RubySMB::Error::InvalidPacket)
+    end
+
+    it 'raises an UnexpectedStatusCode exception if the response status code is not STATUS_SUCCESS or STATUS_BUFFER_OVERFLOW' do
+      allow(response).to receive(:status_code).and_return(WindowsError::NTStatus::STATUS_OBJECT_NAME_NOT_FOUND)
+      expect { pipe.peek }.to raise_error(RubySMB::Error::UnexpectedStatusCode)
+    end
+
+    it 'returns the expected response' do
+      expect(pipe.peek).to eq(response)
+    end
+  end
+
   describe '#peek_available' do
     it 'reads the correct number of bytes available' do
       allow(pipe).to receive(:peek) { peek_nmpipe_response }
@@ -227,8 +286,7 @@ RSpec.describe RubySMB::SMB1::Pipe do
       end
 
       it 'raises the expected exception when it is not a Trans packet' do
-        response = RubySMB::SMB1::Packet::Trans2::Response.new
-        allow(RubySMB::SMB1::Packet::Trans::TransactNmpipeResponse).to receive(:read).and_return(response)
+        nmpipe_response.smb_header.command = RubySMB::SMB1::Commands::SMB_COM_TRANSACTION2
         expect { pipe.request(opnum, options) }.to raise_error(RubySMB::Error::InvalidPacket)
       end
 

--- a/spec/lib/ruby_smb/smb1/tree_spec.rb
+++ b/spec/lib/ruby_smb/smb1/tree_spec.rb
@@ -438,7 +438,7 @@ RSpec.describe RubySMB::SMB1::Tree do
         expect(tree.list).to eq([file_info1, file_info2])
       end
 
-      context 'when the response is not a valid Trans2 FindFirst2Response' do
+      context 'when the response is not a valid Trans2 FindNext2Response' do
         it 'raises an InvalidPacket exception' do
           find_next2_res.smb_header.command = RubySMB::SMB1::Commands::SMB_COM_ECHO
           expect { tree.list }.to raise_error(RubySMB::Error::InvalidPacket)

--- a/spec/lib/ruby_smb/smb2/file_spec.rb
+++ b/spec/lib/ruby_smb/smb2/file_spec.rb
@@ -341,6 +341,9 @@ RSpec.describe RubySMB::SMB2::File do
 
     it 'raises an InvalidPacket exception if the response is not valid' do
       allow(response).to receive(:valid?).and_return(false)
+      smb2_header = double('SMB2 Header')
+      allow(response).to receive(:smb2_header).and_return(smb2_header)
+      allow(smb2_header).to receive_messages(:protocol => nil, :command => nil)
       expect { file.close }.to raise_error(RubySMB::Error::InvalidPacket)
     end
 

--- a/spec/lib/ruby_smb/smb2/packet/error_packet_spec.rb
+++ b/spec/lib/ruby_smb/smb2/packet/error_packet_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+RSpec.describe RubySMB::SMB2::Packet::ErrorPacket do
+  subject(:packet) { described_class.new }
+
+  it { is_expected.to respond_to :smb2_header }
+  it { is_expected.to respond_to :structure_size }
+  it { is_expected.to respond_to :error_data }
+
+  describe '#smb2_header' do
+    subject(:header) { packet.smb2_header }
+
+    it 'is a standard SMB2 Header' do
+      expect(header).to be_a RubySMB::SMB2::SMB2Header
+    end
+  end
+
+  describe '#structure_size' do
+    it 'should be a 16-bit unsigned integer' do
+      expect(packet.structure_size).to be_a BinData::Uint16le
+    end
+  end
+
+  describe '#error_data' do
+    it 'should be a 8-bit unsigned integer' do
+      expect(packet.error_data).to be_a BinData::Uint8
+    end
+  end
+
+  describe '#valid?' do
+    before :example do
+      packet.original_command = RubySMB::SMB2::Commands::LOGOFF
+      packet.smb2_header.command = RubySMB::SMB2::Commands::LOGOFF
+    end
+
+    it 'returns true if the packet protocol ID and header command are valid' do
+      expect(packet).to be_valid
+    end
+
+    it 'returns false if the packet protocol ID is wrong' do
+      packet.smb2_header.protocol = RubySMB::SMB1::SMB_PROTOCOL_ID
+      expect(packet).to_not be_valid
+    end
+
+    it 'returns false if the packet header command is wrong' do
+      packet.smb2_header.command = RubySMB::SMB2::Commands::NEGOTIATE
+      expect(packet).to_not be_valid
+    end
+  end
+end
+

--- a/spec/lib/ruby_smb/smb2/packet/query_directory_response_spec.rb
+++ b/spec/lib/ruby_smb/smb2/packet/query_directory_response_spec.rb
@@ -60,5 +60,13 @@ RSpec.describe RubySMB::SMB2::Packet::QueryDirectoryResponse do
       packet.buffer = names_blob
       expect(packet.results(RubySMB::Fscc::FileInformation::FileNamesInformation)).to eq names_array
     end
+
+    context 'when the File Information is not a valid' do
+      it 'raises an InvalidPacket exception' do
+        packet.buffer = names_blob
+        allow(RubySMB::Fscc::FileInformation::FileNamesInformation).to receive(:read).and_raise(IOError)
+        expect { packet.results(RubySMB::Fscc::FileInformation::FileNamesInformation) }.to raise_error(RubySMB::Error::InvalidPacket)
+      end
+    end
   end
 end

--- a/spec/lib/ruby_smb/smb2/packet/tree_connect_response_spec.rb
+++ b/spec/lib/ruby_smb/smb2/packet/tree_connect_response_spec.rb
@@ -52,5 +52,13 @@ RSpec.describe RubySMB::SMB2::Packet::TreeConnectResponse do
       allow(packet).to receive(:is_directory?).and_return(false)
       expect(packet.access_rights).to be_a RubySMB::SMB2::BitField::FileAccessMask
     end
+
+    context 'when it is not a valid FileAccessMask' do
+      it 'raises an InvalidBitField exception' do
+        allow(packet).to receive(:is_directory?).and_return(false)
+        allow(RubySMB::SMB2::BitField::FileAccessMask).to receive(:read).and_raise(IOError)
+        expect { packet.access_rights }.to raise_error(RubySMB::Error::InvalidBitField)
+      end
+    end
   end
 end

--- a/spec/lib/ruby_smb/smb2/pipe_spec.rb
+++ b/spec/lib/ruby_smb/smb2/pipe_spec.rb
@@ -86,6 +86,9 @@ RSpec.describe RubySMB::SMB2::Pipe do
 
     it 'raises an InvalidPacket exception if the response is not valid' do
       allow(response).to receive(:valid?).and_return(false)
+      smb2_header = double('SMB2 Header')
+      allow(response).to receive(:smb2_header).and_return(smb2_header)
+      allow(smb2_header).to receive_messages(:protocol => nil, :command => nil)
       expect { pipe.peek }.to raise_error(RubySMB::Error::InvalidPacket)
     end
 

--- a/spec/lib/ruby_smb/smb2/pipe_spec.rb
+++ b/spec/lib/ruby_smb/smb2/pipe_spec.rb
@@ -36,6 +36,69 @@ RSpec.describe RubySMB::SMB2::Pipe do
 
   subject(:pipe) { described_class.new(name: 'msf-pipe', response: create_response, tree: tree) }
 
+  describe '#peek' do
+    let(:request) { RubySMB::SMB2::Packet::IoctlRequest.new }
+    let(:raw_response) { double('Raw response') }
+    let(:response) { double('Response') }
+
+    before :example do
+      allow(RubySMB::SMB2::Packet::IoctlRequest).to receive(:new).and_return(request)
+      allow(client).to receive(:send_recv).and_return(raw_response)
+      allow(RubySMB::SMB2::Packet::IoctlResponse).to receive(:read).and_return(response)
+      allow(response).to receive(:valid?).and_return(true)
+      allow(response).to receive(:status_code).and_return(WindowsError::NTStatus::STATUS_SUCCESS)
+    end
+
+    it 'creates a IoctlRequest'do
+      expect(RubySMB::SMB2::Packet::IoctlRequest).to receive(:new)
+      pipe.peek
+    end
+
+    it 'sets the request #ctl_code field' do
+      expect(request).to receive(:ctl_code=).with(RubySMB::Fscc::ControlCodes::FSCTL_PIPE_PEEK)
+      pipe.peek
+    end
+
+    it 'sets the request #is_fsctl flag to true' do
+      pipe.peek
+      expect(request.flags.is_fsctl).to eq 1
+    end
+
+    it 'sets the request #max_output_response field to the expected value' do
+      pipe.peek(peek_size: 10)
+      expect(request.max_output_response).to eq(16 + 10)
+    end
+
+    it 'calls #set_header_fields' do
+      expect(pipe).to receive(:set_header_fields).with(request)
+      pipe.peek
+    end
+
+    it 'calls Client #send_recv' do
+      expect(client).to receive(:send_recv).with(request)
+      pipe.peek
+    end
+
+    it 'parses the response as a SMB2 IoctlResponse packet' do
+      expect(RubySMB::SMB2::Packet::IoctlResponse).to receive(:read).with(raw_response)
+      pipe.peek
+    end
+
+    it 'raises an InvalidPacket exception if the response is not valid' do
+      allow(response).to receive(:valid?).and_return(false)
+      expect { pipe.peek }.to raise_error(RubySMB::Error::InvalidPacket)
+    end
+
+    it 'raises an UnexpectedStatusCode exception if the response status code is not STATUS_SUCCESS or STATUS_BUFFER_OVERFLOW' do
+      allow(response).to receive(:status_code).and_return(WindowsError::NTStatus::STATUS_OBJECT_NAME_NOT_FOUND)
+      expect { pipe.peek }.to raise_error(RubySMB::Error::UnexpectedStatusCode)
+    end
+
+    it 'returns the expected response' do
+      expect(pipe.peek).to eq(response)
+    end
+  end
+
   describe '#peek_available' do
     it 'reads the correct number of bytes available' do
       allow(pipe).to receive(:peek) { ioctl_response }
@@ -244,9 +307,9 @@ RSpec.describe RubySMB::SMB2::Pipe do
         pipe.ioctl_send_recv(action, options)
       end
 
-      it 'raises the expected exception when it is not a IoctlResponse packet' do
-        response = RubySMB::SMB2::Packet::LogoffResponse.new
-        allow(RubySMB::SMB2::Packet::IoctlResponse).to receive(:read).and_return(response)
+      it 'raises the expected exception when it is not a valid packet' do
+        ioctl_response.smb2_header.command = RubySMB::SMB2::Commands::LOGOFF
+        allow(RubySMB::SMB2::Packet::IoctlResponse).to receive(:read).and_return(ioctl_response)
         expect { pipe.ioctl_send_recv(action, options) }.to raise_error(RubySMB::Error::InvalidPacket)
       end
 


### PR DESCRIPTION
This fixes #128

This PR updates the error handling logic by adding validation for packet structures.

## Changes
- Add valid? method to GenericPacket, ErrorPacket and EmptyPacket.
- Add packet validation for SMB1 and SMB2 packets.
- Update specs.
- Add some missing specs.
## Verification Steps
- [x] `bundle install`
- [x] Run all the examples in examples/ directory and verify errors are properly handled.
## `rake spec`
- [x] `rake spec`
- [x] VERIFY no failures