### PR TITLE
Update EmptyPacket and ErrorPacket Validation

### DIFF
--- a/lib/ruby_smb/smb1/packet/empty_packet.rb
+++ b/lib/ruby_smb/smb1/packet/empty_packet.rb
@@ -1,7 +1,7 @@
 module RubySMB
   module SMB1
     module Packet
-      # This packet represent an SMB1 Response Packet when the parameter and
+      # This packet represent an SMB1 Error Response Packet when the parameter and
       # data blocks will be empty.
       class EmptyPacket < RubySMB::GenericPacket
         attr_accessor :original_command
@@ -12,7 +12,9 @@ module RubySMB
 
         def valid?
           return smb_header.protocol == RubySMB::SMB1::SMB_PROTOCOL_ID &&
-            smb_header.command == @original_command
+                 smb_header.command == @original_command &&
+                 parameter_block.word_count == 0 &&
+                 data_block.byte_count == 0
         end
       end
     end

--- a/lib/ruby_smb/smb2/packet/error_packet.rb
+++ b/lib/ruby_smb/smb2/packet/error_packet.rb
@@ -1,18 +1,25 @@
 module RubySMB
   module SMB2
     module Packet
-      # An SMB2 Error packet for when an incomplete response comes back
+      # This class represents an SMB2 Error Response Packet as defined in
+      # [2.2.2 SMB2 ERROR Response](https://msdn.microsoft.com/en-us/library/cc246530.aspx)
       class ErrorPacket < RubySMB::GenericPacket
         attr_accessor :original_command
 
         endian       :little
         smb2_header  :smb2_header
-        uint16       :structure_size, label: 'Structure Size', initial_value: 4
-        uint8        :error_data
+        uint16       :structure_size,      label: 'Structure Size', initial_value: 9
+        uint8        :error_context_count, label: 'ErrorContextCount'
+        uint8        :reserved
+        uint32       :byte_count,          label: 'Byte Count of ErrorData',
+                                           initial_value: -> { error_data.num_bytes == 1 ? 0 : error_data.num_bytes }
+        string       :error_data,          label: 'Error Data', initial_value: "\x00",
+                                           read_length: -> { byte_count == 0 ? 1 : byte_count }
 
         def valid?
           return smb2_header.protocol == RubySMB::SMB2::SMB2_PROTOCOL_ID &&
-            smb2_header.command == @original_command
+                 smb2_header.command == @original_command &&
+                 structure_size == 9
         end
       end
     end

--- a/spec/lib/ruby_smb/smb1/packet/empty_packet_spec.rb
+++ b/spec/lib/ruby_smb/smb1/packet/empty_packet_spec.rb
@@ -54,5 +54,15 @@ RSpec.describe RubySMB::SMB1::Packet::EmptyPacket do
       packet.smb_header.command = RubySMB::SMB1::Commands::SMB_COM_NEGOTIATE
       expect(packet).to_not be_valid
     end
+
+    it 'returns false if the packet parameter block size is not 0' do
+      packet.parameter_block.word_count = 10
+      expect(packet).to_not be_valid
+    end
+
+    it 'returns false if the packet data block size is not 0' do
+      packet.data_block.byte_count = 10
+      expect(packet).to_not be_valid
+    end
   end
 end

--- a/spec/lib/ruby_smb/smb2/packet/error_packet_spec.rb
+++ b/spec/lib/ruby_smb/smb2/packet/error_packet_spec.rb
@@ -19,11 +19,54 @@ RSpec.describe RubySMB::SMB2::Packet::ErrorPacket do
     it 'should be a 16-bit unsigned integer' do
       expect(packet.structure_size).to be_a BinData::Uint16le
     end
+
+    it 'should be 9 by default' do
+      expect(packet.structure_size).to eq 9
+    end
+  end
+
+  describe '#error_context_count' do
+    it 'should be a 8-bit unsigned integer' do
+      expect(packet.error_context_count).to be_a BinData::Uint8
+    end
+  end
+
+  describe '#byte_count' do
+    it 'should be a 32-bit unsigned integer' do
+      expect(packet.byte_count).to be_a BinData::Uint32le
+    end
+
+    it 'should be the number of bytes in #error_data' do
+      str = 'testing'
+      packet.error_data = str
+      expect(packet.byte_count).to eq str.size
+    end
+
+    it 'should be 0 when #error_data is 1-byte long' do
+      packet.error_data = "\x00"
+      expect(packet.byte_count).to eq 0
+    end
   end
 
   describe '#error_data' do
-    it 'should be a 8-bit unsigned integer' do
-      expect(packet.error_data).to be_a BinData::Uint8
+    it 'should be a String' do
+      expect(packet.error_data).to be_a BinData::String
+    end
+
+    it 'should be \x00 by default' do
+      expect(packet.error_data).to eq "\x00"
+    end
+
+    it 'should read 1 byte when #byte_count is 0' do
+      packet.error_data = 'test'
+      packet.byte_count = 0
+      expect(described_class.read(packet.to_binary_s).error_data.size).to eq 1
+    end
+
+    it 'should read #byte_count bytes when #byte_count is not 0' do
+      packet.error_data = 'test'
+      packet.byte_count = 4
+      expect(described_class.read(packet.to_binary_s).error_data.size).to eq 4
     end
   end
 
@@ -44,6 +87,11 @@ RSpec.describe RubySMB::SMB2::Packet::ErrorPacket do
 
     it 'returns false if the packet header command is wrong' do
       packet.smb2_header.command = RubySMB::SMB2::Commands::NEGOTIATE
+      expect(packet).to_not be_valid
+    end
+
+    it 'returns false if the packet #structure_size is wrong' do
+      packet.structure_size = 10
       expect(packet).to_not be_valid
     end
   end


### PR DESCRIPTION
This PR adds some specific checks in the `valid?` method for `EmptyPacket` and `ErrorPacket`. It also updates the fields of SMB2 `ErrorPacket` to follow the protocol . This will ensure the validation to fail if the error packet is malformed.

Before these changes, when the response was not the expected packet but the protocol ID and the command ID were correct, it was being converted to a **valid** `EmptyPacket` or `ErrorPacket`, even if it was not an error packet at all.

I came across this corner case when I was probing an Echo service. The SMB request was returned verbatim as a response, which, as a result, included the correct protocol ID and command ID. Since it was not the expected packet structure, the parsing was failing and the response was converted to an error packet, but `valid?` was returning true (protocol ID and command ID were correct). Now, `valid?` will return false in this situation, since the extra checks will fail.