### PR TITLE
style consistency fixes, some grammar and spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,12 @@
 [![Code Climate](https://codeclimate.com/github/rapid7/ruby_smb.png)](https://codeclimate.com/github/rapid7/ruby_smb)
 [![Coverage Status](https://coveralls.io/repos/github/rapid7/ruby_smb/badge.svg?branch=master)](https://coveralls.io/github/rapid7/ruby_smb?branch=master)
 
-A native Ruby implementation of the SMB Protocol Family. It currently supports
+This is a native Ruby implementation of the SMB Protocol Family. It currently supports:
+
  1. [[MS-SMB]](https://msdn.microsoft.com/en-us/library/cc246231.aspx)
  1. [[MS-SMB2]](http://msdn.microsoft.com/en-us/library/cc246482.aspx)
 
-This library currently include both a client level, and packet level support. A user can parse and manipulate raw SMB packets, or use the simple client to perform SMB operations.
+The RubySMB library provides client-level and packet-level support for the protocol. A user can parse and manipulate raw SMB packets, or use the client to perform higher-level SMB operations.
 
 See the Wiki for more information on this project's long-term goals, style guide, and developer tips.
 
@@ -32,22 +33,17 @@ Or install it yourself as:
 
 ### Defining a packet
 
-All packets are implemented in a declarative style with BinData. Nested data
-structures are used where appropriate to give users an easy method of adjusting
-data.
+All packets are implemented in a declarative style with BinData. Nested data structures are used where appropriate to give users an easy method of manipulating individual fields inside of a packet.
 
 #### SMB1
-SMB1 Packets are made up of three basic components:
- 1. **The SMB Header** - This is a standard SMB Header. All SMB1 packets use the same SMB header.
- 1. **The Parameter Block** - This is where function parameters are passed across the wire in the packet. Parameter Blocks will always
- have a 'Word Count' field that gives the size of the Parameter Block in words(2-bytes)
- 1. **The Data Block** - This is the data section of the packet. the Data Block will always have a 'byte count' field that gives the size of
- the Data block in bytes.
 
-The SMB Header can always just be declared as a field in the BinData DSL for the packet class, because its structure never changes.
-For the ParameterBlock and DataBlocks, we always define subclasses for this particular packet. They inherit the 'Word Count' and
-'Byte Count' fields, along with the auto-calculation routines for those fields, from their ancestors. Any other fields are then
-defined in our subclass before we start the DSL declarations for the packet.
+SMB1 Packets are made up of three basic components:
+
+ 1. **The SMB Header** - This is a standard SMB Header. All SMB1 packets use the same SMB header.
+ 1. **The Parameter Block** - This is where function parameters are passed across the wire in the packet. Parameter blocks will always have a 'Word Count' field that gives the size of the parameter block in words (2-bytes)
+ 1. **The Data Block** - This is the data section of the packet. The data block will always have a 'byte count' field that gives the size of the Data block in bytes.
+
+The SMB Header can always just be declared as a field in the BinData DSL for the packet class, because its structure never changes. For the Parameter block and data blocks, we always define subclasses for this particular packet. They inherit the 'Word Count' and 'Byte Count' fields, along with the auto-calculation routines for those fields, from their ancestors. Any other fields are then defined in our subclass before we start the DSL declarations for the packet.
 
 Example:
 
@@ -90,8 +86,7 @@ end
 
 #### SMB2
 
-SMB2 Packets are far simpler than their older SMB1 counterparts. We still abstract out the SMB2 header since it is the same
-structure used for every packet. Beyond that, the SMB2 packet is relatively flat in comparison to SMB1.
+SMB2 Packets are far simpler than their older SMB1 counterparts. We still abstract out the SMB2 header since it is the same structure used for every packet. Beyond that, the SMB2 packet is relatively flat in comparison to SMB1.
 
 Example:
 ```ruby
@@ -127,8 +122,7 @@ end
 ### Using a Packet class
 
 #### Manually
-You can instantiate an instance of a particular packet class, and then reach into the data structure to set or read explicit
-values in a fairly straightforward manner.
+You can create an instance of any particular packet class, and then reach into the data structure to set or read explicit values in a fairly straightforward manner.
 
 Example:
 ```ruby
@@ -152,8 +146,7 @@ Example:
 2.3.3 :009 >
 ```
 
-You can also pass field/value pairs into the packet constructor as arguments, prefilling out certain fields
-if you wish.
+You can also pass field/value pairs into the packet constructor as arguments, defaulting individual fields as desired.
 
 Example:
 ```ruby
@@ -165,9 +158,7 @@ Example:
 
 #### Reading from a Binary Blob
 
-Sometimes you need to read a binary blob and apply one of the packet structures to it.
-For example, when you are reading a response packet off of the wire, you will need to read the raw response
-string into an actual packet class. This is done using the #read class method.
+Sometimes you need to read a binary data and apply one of the packet structures to it.  For example, when you are reading a response packet, you will need to read the raw response string into an actual packet class. This is done using the #read class method.
 
 ```ruby
 2.3.3 :014 > blob = "\xFFSMB+\x00\x00\x00\x00\x98\x01`\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00"
@@ -178,8 +169,7 @@ string into an actual packet class. This is done using the #read class method.
 ```
 
 #### Outputting to a Binary Blob
-Any structure or packet in rubySMB can also be output back into a binary blob using
-BinData's #to_binary_s method.
+Any structure or packet in RubySMB can also be converted back into a binary blob using BinData's #to_binary_s method.
 
 Example:
 ```ruby
@@ -190,38 +180,35 @@ Example:
 ```
 ### Using the Client
 
-Sitting on top of the packet layer in RubySMB is the RubySMB::Client. This is the level msot users will interact with.
-It provides fairly simple conveience methods for performing SMB actions. It handles the creation, sending and receiving of packets
-for the user, relying on reasonable defaults in many cases.
+Sitting on top of the packet layer in RubySMB is the RubySMB::Client class. This is the abstraction that most users of RubySMB will interact with. It provides simple conveience methods for performing SMB actions. It handles the creation, sending and receiving of packets for the user, providing reasonable defaults in many cases.
 
 #### Negotiation
 
-The RubySMB Client is capabale of multi-protocol negotiation. The user simply specifies whether SMB1 and/or SMB2 should be supported, and
-the client will negotiate the propper protocol and dialect behind the scenes.
+The RubySMB client is capable of multi-protocol negotiation. The user simply specifies whether SMB1 and/or SMB2 should be supported, and the client negotiates the protocol and dialect behind the scenes.
 
-In the below example, we tell the client that both SMB1 and SMB2 should be supported. The Client will then Negotiate with the
-server on which version should be used. The user does not have to ever worry about which version was negotiated.
-Example:
+In the following example, we tell the client that both SMB1 and SMB2 should be supported. The client will then negotiate with the server which version should be used.
+
+Negotiation Example:
 ```ruby
   sock = TCPSocket.new address, 445
   dispatcher = RubySMB::Dispatcher::Socket.new(sock)
 
-  client = RubySMB::Client.new(dispatcher, smb1: true, smb2: false, username: 'msfadmin', password: 'msfadmin')
+  client = RubySMB::Client.new(dispatcher, username: 'msfadmin', password: 'msfadmin')
   client.negotiate
 ```
 
 #### Authentication
 
-Authentication is achieved via the [ruby ntlm gem](https://rubygems.org/gems/rubyntlm). While the client
-will not currently attempt older basic authentication on its own, it will attempt an anonymous login, if no
-user credentials are supplied:
+RubySMB uses the [Ruby NTLM gem](https://rubygems.org/gems/rubyntlm) for authentication. While the client
+will not currently attempt older basic authentication on its own, it will attempt an anonymous login if no
+user credentials are supplied.
 
 Authenticated Example:
 ```ruby
   sock = TCPSocket.new address, 445
   dispatcher = RubySMB::Dispatcher::Socket.new(sock)
 
-  client = RubySMB::Client.new(dispatcher, smb1: true, smb2: false, username: 'msfadmin', password: 'msfadmin')
+  client = RubySMB::Client.new(dispatcher, username: 'msfadmin', password: 'msfadmin')
   client.negotiate
   client.authenticate
 ```
@@ -231,24 +218,23 @@ Anonymous Example:
       sock = TCPSocket.new address, 445
       dispatcher = RubySMB::Dispatcher::Socket.new(sock)
 
-      client = RubySMB::Client.new(dispatcher, smb1: true, smb2: false, username: '', password: '')
+      client = RubySMB::Client.new(dispatcher, username: '', password: '')
       client.negotiate
       client.authenticate
 ```
 
 #### Connecting to a Tree
 
-While there is one Client, that has branching code-paths for SMB1 and SMB2, once you connect to a
-Tree you will be given a protocol specific Tree object. This Tree object will be responsible for all file operations
-that are to be conducted on that Tree.
+While there is one RubySMB::Client object that supports both SMB1 and SMB2, once the library connects to an SMB tree, it returns a protocol-specific RubySMB::Tree object. This Tree object executes all subsequent file operations on the tree.
 
-In the below example we see a simple script to connect to a remote Tree, and list all files in a given sub-directory.
+In the below example we see a simple script to connect to a remote tree, and list all files in a given sub-directory.
+
 Example:
 ```ruby
       sock = TCPSocket.new address, 445
       dispatcher = RubySMB::Dispatcher::Socket.new(sock)
 
-      client = RubySMB::Client.new(dispatcher, smb1: true, smb2: false, username: 'msfadmin', password: 'msfadmin')
+      client = RubySMB::Client.new(dispatcher, username: 'msfadmin', password: 'msfadmin')
       client.negotiate
       client.authenticate
 
@@ -273,27 +259,29 @@ Example:
 
 
 ## Developer tips
-You'll want to have Wireshark and perhaps a tool like Impacket (which provides a small SMB client in one of its examples) installed to help with your work:
+
+It is useful to have Wireshark and a reference SMB client, such as Impacket's installed to help debug and compare output:
 
 ### Wireshark
+
+Configure Wireshark in Debian-based systems to be able to capture traffic without root user privileges:
+
 - `sudo apt-get install wireshark`
 - `sudo dpkg-reconfigure wireshark-common`
 - `sudo addgroup wireshark`
 - `sudo usermod -a -G wireshark <USERNAME>`
 
 ### Impacket
+
 - `sudo apt-get install python-setuptools`
 - `sudo easy_install pyasn1 pycrypto`
 - Download from GitHub (https://github.com/coresecurity/impacket)
 - `sudo python setup.py install`
 - `cd examples && python smbclient.py <USER>:<PASS>@<WINDOWS HOST IP>`
 
-
-
 ## License
 
 `ruby_smb` is released under a 3-clause BSD license. See [LICENSE.txt](LICENSE.txt) for full text.
-
 
 ## Contributing
 


### PR DESCRIPTION
This also changes all of the example code to use the defaults for smb1/smb2 rather than disabling smb2 everywhere, which seems to better match the explanations about how the user does not have to care what version to support since it is automatic.