### PR TITLE
Fix client pipe example script

### DIFF
--- a/examples/pipes.rb
+++ b/examples/pipes.rb
@@ -33,7 +33,8 @@ end
 
 client.authenticate
 client.tree_connect("\\\\#{address}\\IPC$")
-pipe = client.create_pipe(pipename)
+client.create_pipe(pipename)
+pipe = client.last_file
 
 puts "Available:       #{pipe.peek_available}"
 puts "PipeState:       #{pipe.peek_state}" # 3 == OK

--- a/examples/pipes.rb
+++ b/examples/pipes.rb
@@ -33,7 +33,7 @@ end
 
 client.authenticate
 client.tree_connect("\\\\#{address}\\IPC$")
-pipe = client.create_pipe(pipename, nil)
+pipe = client.create_pipe(pipename)
 
 puts "Available:       #{pipe.peek_available}"
 puts "PipeState:       #{pipe.peek_state}" # 3 == OK

--- a/lib/ruby_smb/client/utils.rb
+++ b/lib/ruby_smb/client/utils.rb
@@ -32,6 +32,7 @@ module RubySMB
            file.fid.to_binary_s
          end
          @open_files[@last_file_id] = file
+         @last_file_id
       end
 
       def create_pipe(path, disposition=RubySMB::Dispositions::FILE_OPEN_IF)

--- a/lib/ruby_smb/client/utils.rb
+++ b/lib/ruby_smb/client/utils.rb
@@ -32,7 +32,6 @@ module RubySMB
            file.fid.to_binary_s
          end
          @open_files[@last_file_id] = file
-         @last_file_id
       end
 
       def create_pipe(path, disposition=RubySMB::Dispositions::FILE_OPEN_IF)


### PR DESCRIPTION
While testing the Winreg PR I discovered the `examples/pipes.rb` was failing due to previous changes.

- Revert return value from `#open`. It had [previously changed](https://github.com/rapid7/ruby_smb/commit/9a391ea44781ed803924c7e43629e8b7aecefa65#diff-f36d39255face0869afcae76098ec44dR35) for msf compatibility (so a solution will be needed for this on the msf side)
- Update `pipes.rb` to remove `nil` argument since a [previous commit](https://github.com/rapid7/ruby_smb/commit/dd463fcda4ee7ffc199f382fb414e826b4c47ec2#diff-f36d39255face0869afcae76098ec44dL38) removed an unused parameter from `#create_pipe`

### Testing

`ruby examples/pipes.rb <ip> '\netlogon' <username> <password> <smbversion>`