### PR TITLE
Store server time values and GUID

### DIFF
--- a/lib/ruby_smb/client.rb
+++ b/lib/ruby_smb/client.rb
@@ -233,6 +233,11 @@ module RubySMB
     #     (constants defined in RubySMB::SMB2::CompressionCapabilities)
     attr_accessor :server_compression_algorithms
 
+    # The GUID of the server (SMB 2.x and 3.x).
+    # @!attribute [rw] server_guid
+    #   @return [String]
+    attr_accessor :server_guid
+
     # The server's start time if it is reported as part of the negotiation
     # process (SMB 2.x and 3.x). This value is nil if the server does not report
     # it (reports a value of 0).

--- a/lib/ruby_smb/client.rb
+++ b/lib/ruby_smb/client.rb
@@ -233,6 +233,20 @@ module RubySMB
     #     (constants defined in RubySMB::SMB2::CompressionCapabilities)
     attr_accessor :server_compression_algorithms
 
+    # The server's start time if it is reported as part of the negotiation
+    # process (SMB 2.x and 3.x). This value is nil if the server does not report
+    # it (reports a value of 0).
+    # @!attribute [rw] server_start_time
+    #   @return [Time] the time that the server reports that it was started at
+    attr_accessor :server_start_time
+
+    # The server's current time if it is reported as part of the negotiation
+    # process (SMB 2.x and 3.x). This value is nil if the server does not report
+    # it (reports a value of 0).
+    # @!attribute [rw] server_system_time
+    #   @return [Time] the time that the server reports as current
+    attr_accessor :server_system_time
+
     # The SMB version that has been successfully negotiated. This value is only
     # set after the NEGOTIATE handshake has been performed.
     # @!attribute [rw] negotiated_smb_version

--- a/lib/ruby_smb/client/negotiation.rb
+++ b/lib/ruby_smb/client/negotiation.rb
@@ -25,7 +25,7 @@ module RubySMB
           parse_smb3_encryption_data(request_packet, response_packet)
         end
 
-        if %w{0x0202 0x0210 0x0300 0x0302 0x0311 0x02ff}.include? @dialect
+        if response_packet && %w{0x0202 0x0210 0x0300 0x0302 0x0311 0x02ff}.include?(@dialect)
           if response_packet.server_start_time != 0
             @server_start_time = response_packet.server_start_time.to_time
           end

--- a/lib/ruby_smb/client/negotiation.rb
+++ b/lib/ruby_smb/client/negotiation.rb
@@ -26,6 +26,7 @@ module RubySMB
         end
 
         if response_packet && %w{0x0202 0x0210 0x0300 0x0302 0x0311 0x02ff}.include?(@dialect)
+          @server_guid = response_packet.server_guid
           if response_packet.server_start_time != 0
             @server_start_time = response_packet.server_start_time.to_time
           end

--- a/lib/ruby_smb/client/negotiation.rb
+++ b/lib/ruby_smb/client/negotiation.rb
@@ -25,16 +25,6 @@ module RubySMB
           parse_smb3_encryption_data(request_packet, response_packet)
         end
 
-        if response_packet && %w{0x0202 0x0210 0x0300 0x0302 0x0311 0x02ff}.include?(@dialect)
-          @server_guid = response_packet.server_guid
-          if response_packet.server_start_time != 0
-            @server_start_time = response_packet.server_start_time.to_time
-          end
-          if response_packet.system_time != 0
-            @server_system_time = response_packet.system_time.to_time
-          end
-        end
-
         # If the response contains the SMB2 wildcard revision number dialect;
         # it indicates that the server implements SMB 2.1 or future dialect
         # revisions and expects the client to send a subsequent SMB2 Negotiate
@@ -148,6 +138,9 @@ module RubySMB
           # This value is used in SMB1 only but calculate a valid value anyway
           self.server_max_buffer_size = [self.server_max_read_size, self.server_max_write_size, self.server_max_transact_size].min
           self.negotiated_smb_version = self.smb2 ? 2 : 3
+          self.server_guid = packet.server_guid
+          self.server_start_time = packet.server_start_time.to_time if packet.server_start_time != 0
+          self.server_system_time = packet.system_time.to_time if packet.system_time != 0
           return "SMB#{self.negotiated_smb_version}"
         else
           error = 'Unable to negotiate with remote host'

--- a/lib/ruby_smb/client/negotiation.rb
+++ b/lib/ruby_smb/client/negotiation.rb
@@ -24,6 +24,16 @@ module RubySMB
         when '0x0311'
           parse_smb3_encryption_data(request_packet, response_packet)
         end
+
+        if %w{0x0202 0x0210 0x0300 0x0302 0x0311 0x02ff}.include? @dialect
+          if response_packet.server_start_time != 0
+            @server_start_time = response_packet.server_start_time.to_time
+          end
+          if response_packet.system_time != 0
+            @server_system_time = response_packet.system_time.to_time
+          end
+        end
+
         # If the response contains the SMB2 wildcard revision number dialect;
         # it indicates that the server implements SMB 2.1 or future dialect
         # revisions and expects the client to send a subsequent SMB2 Negotiate

--- a/lib/ruby_smb/smb2/packet/negotiate_response.rb
+++ b/lib/ruby_smb/smb2/packet/negotiate_response.rb
@@ -15,7 +15,7 @@ module RubySMB
         uint16              :dialect_revision,          label: 'Dialect Revision'
         uint16              :negotiate_context_count,   label: 'Negotiate Context Count', initial_value: -> { negotiate_context_list.size }, onlyif: -> { has_negotiate_context? }
         uint16              :reserved1,                 label: 'Reserved', initial_value: 0, onlyif: -> { !has_negotiate_context? }
-        string              :server_guid,               label: 'Server GUID',                  length: 16
+        string              :server_guid,               label: 'Server GUID', length: 16
         smb2_capabilities   :capabilities
         uint32              :max_transact_size,         label: 'Max Transaction Size'
         uint32              :max_read_size,             label: 'Max Read Size'


### PR DESCRIPTION
This stores the server start and system times in the client object. This will be necessary for upcoming changes to Metasploit's `smb_version` module which will consolidate the `auxilary/scanner/smb/smb2` module. The `smb2` scanner module currently reports the amount of time the remote system has been booted, so to not lose this we'll need it in RubySMB.

For testing you can inspect the object manually, or check out the [`smb_version` WIP](https://github.com/zeroSteiner/metasploit-framework/blob/36ba47398a263de0943fef5a0312b7dd3628ffe7/modules/auxiliary/scanner/smb/smb_version.rb). If you choose to go with the later, `uptime` should be reported for any server that reports *both* the system and start times.