### PR TITLE
Fixes and improvements from MSF code review

### DIFF
--- a/lib/ruby_smb/client.rb
+++ b/lib/ruby_smb/client.rb
@@ -292,7 +292,8 @@ module RubySMB
       negotiate_version_flag = 0x02000000
       flags = Net::NTLM::Client::DEFAULT_FLAGS |
         Net::NTLM::FLAGS[:TARGET_INFO] |
-        negotiate_version_flag
+        negotiate_version_flag ^
+        Net::NTLM::FLAGS[:OEM]
 
       @ntlm_client = Net::NTLM::Client.new(
         @username,
@@ -366,7 +367,8 @@ module RubySMB
       negotiate_version_flag = 0x02000000
       flags = Net::NTLM::Client::DEFAULT_FLAGS |
         Net::NTLM::FLAGS[:TARGET_INFO] |
-        negotiate_version_flag
+        negotiate_version_flag ^
+        Net::NTLM::FLAGS[:OEM]
 
       @ntlm_client = Net::NTLM::Client.new(
           @username,

--- a/lib/ruby_smb/client/authentication.rb
+++ b/lib/ruby_smb/client/authentication.rb
@@ -216,8 +216,8 @@ module RubySMB
         raw = smb2_ntlmssp_authenticate(type3_message, @session_id)
         response = smb2_ntlmssp_final_packet(raw)
 
-        if @smb3 && !@encryption_required && response.session_flags.encrypt_data == 1
-          @encryption_required = true
+        if @smb3 && !@session_encrypt_data && response.session_flags.encrypt_data == 1
+          @session_encrypt_data = true
         end
         ######
         # DEBUG

--- a/lib/ruby_smb/client/negotiation.rb
+++ b/lib/ruby_smb/client/negotiation.rb
@@ -129,6 +129,8 @@ module RubySMB
           unless packet.dialect_revision.to_i == 0x02ff
             self.smb2 = packet.dialect_revision.to_i >= 0x0200 && packet.dialect_revision.to_i < 0x0300
             self.smb3 = packet.dialect_revision.to_i >= 0x0300 && packet.dialect_revision.to_i < 0x0400
+            # Only enable session encryption if the server supports it
+            @session_encrypt_data = self.smb3 && @session_encrypt_data && packet.capabilities.encryption == 1
           end
           self.signing_required = packet.security_mode.signing_required == 1 if self.smb2 || self.smb3
           self.dialect = "0x%04x" % packet.dialect_revision

--- a/lib/ruby_smb/client/negotiation.rb
+++ b/lib/ruby_smb/client/negotiation.rb
@@ -202,6 +202,12 @@ module RubySMB
         # while being guaranteed to work with any modern Windows system. We can get more sophisticated
         # with switching this on and off at a later date if the need arises.
         packet.smb_header.flags2.extended_security = 1
+        # Recent Mac OS X requires the unicode flag to be set on the Negotiate
+        # SMB Header request, even if this packet does not contain string fields
+        # (see Flags2 SMB_FLAGS2_UNICODE definition in "2.2.3.1 The SMB Header"
+        # documentation:
+        # https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/69a29f73-de0c-45a6-a1aa-8ceeea42217f
+        packet.smb_header.flags2.unicode = 1
         # There is no real good reason to ever send an SMB1 Negotiate packet
         # to Negotiate strictly SMB2, but the protocol WILL support it
         packet.add_dialect(SMB1_DIALECT_SMB1_DEFAULT) if smb1

--- a/lib/ruby_smb/dispatcher/socket.rb
+++ b/lib/ruby_smb/dispatcher/socket.rb
@@ -61,13 +61,14 @@ module RubySMB
       #   which are assumed to be the NetBiosSessionService header.
       # @raise [RubySMB::Error::CommunicationError] if the read timeout expires or an error occurs when reading the socket
       def recv_packet(full_response: false)
+        raise RubySMB::Error::CommunicationError, 'Connection has already been closed' if @tcp_socket.closed?
         if IO.select([@tcp_socket], nil, nil, @read_timeout).nil?
           raise RubySMB::Error::CommunicationError, "Read timeout expired when reading from the Socket (timeout=#{@read_timeout})"
         end
 
         begin
           nbss_data = @tcp_socket.read(4)
-          raise IOError if nbss_data.nil?
+          raise RubySMB::Error::CommunicationError, 'Socket read returned nil' if nbss_data.nil?
           nbss_header = RubySMB::Nbss::SessionHeader.read(nbss_data)
         rescue IOError
           raise ::RubySMB::Error::NetBiosSessionService, 'NBSS Header is missing'

--- a/lib/ruby_smb/smb1/tree.rb
+++ b/lib/ruby_smb/smb1/tree.rb
@@ -123,6 +123,15 @@ module RubySMB
         raw_response = @client.send_recv(nt_create_andx_request)
         response = RubySMB::SMB1::Packet::NtCreateAndxResponse.read(raw_response)
         unless response.valid?
+          if response.is_a?(RubySMB::SMB1::Packet::EmptyPacket) &&
+               response.smb_header.protocol == RubySMB::SMB1::SMB_PROTOCOL_ID &&
+               response.smb_header.command == response.original_command
+            raise RubySMB::Error::InvalidPacket.new(
+              'The response seems to be an SMB1 NtCreateAndxResponse but an '\
+              'error occurs while parsing it. It is probably missing the '\
+              'required extended information.'
+            )
+          end
           raise RubySMB::Error::InvalidPacket.new(
             expected_proto: RubySMB::SMB1::SMB_PROTOCOL_ID,
             expected_cmd:   RubySMB::SMB1::Packet::NtCreateAndxResponse::COMMAND,

--- a/lib/ruby_smb/smb2/file.rb
+++ b/lib/ruby_smb/smb2/file.rb
@@ -52,10 +52,10 @@ module RubySMB
       #   @return [RubySMB::SMB2::Tree]
       attr_accessor :tree
 
-      # Whether or not encryption is required (SMB 3.x)
-      # @!attribute [rw] encryption_required
+      # Whether or not the share associated with this tree connect needs to be encrypted (SMB 3.x)
+      # @!attribute [rw] tree_connect_encrypt_data
       #   @return [Boolean]
-      attr_accessor :encryption_required
+      attr_accessor :tree_connect_encrypt_data
 
       def initialize(tree:, response:, name:, encrypt: false)
         raise ArgumentError, 'No Tree Provided' if tree.nil?
@@ -71,7 +71,7 @@ module RubySMB
         @last_write   = response.last_write.to_datetime
         @size         = response.end_of_file
         @size_on_disk = response.allocation_size
-        @encryption_required = encrypt
+        @tree_connect_encrypt_data = encrypt
       end
 
       # Appends the supplied data to the end of the file.
@@ -89,7 +89,7 @@ module RubySMB
       # @raise [RubySMB::Error::UnexpectedStatusCode] if the response NTStatus is not STATUS_SUCCESS
       def close
         close_request = set_header_fields(RubySMB::SMB2::Packet::CloseRequest.new)
-        raw_response  = tree.client.send_recv(close_request, encrypt: @encryption_required)
+        raw_response  = tree.client.send_recv(close_request, encrypt: @tree_connect_encrypt_data)
         response = RubySMB::SMB2::Packet::CloseResponse.read(raw_response)
         unless response.valid?
           raise RubySMB::Error::InvalidPacket.new(
@@ -122,7 +122,7 @@ module RubySMB
                            end
 
         read_request = read_packet(read_length: atomic_read_size, offset: offset)
-        raw_response = tree.client.send_recv(read_request, encrypt: @encryption_required)
+        raw_response = tree.client.send_recv(read_request, encrypt: @tree_connect_encrypt_data)
         response     = RubySMB::SMB2::Packet::ReadResponse.read(raw_response)
         unless response.valid?
           raise RubySMB::Error::InvalidPacket.new(
@@ -145,7 +145,7 @@ module RubySMB
           atomic_read_size = remaining_bytes if remaining_bytes < tree.client.server_max_read_size
 
           read_request = read_packet(read_length: atomic_read_size, offset: offset)
-          raw_response = tree.client.send_recv(read_request, encrypt: @encryption_required)
+          raw_response = tree.client.send_recv(read_request, encrypt: @tree_connect_encrypt_data)
           response     = RubySMB::SMB2::Packet::ReadResponse.read(raw_response)
           unless response.valid?
             raise RubySMB::Error::InvalidPacket.new(
@@ -179,7 +179,7 @@ module RubySMB
 
       def send_recv_read(read_length: 0, offset: 0)
         read_request = read_packet(read_length: read_length, offset: offset)
-        raw_response = tree.client.send_recv(read_request, encrypt: @encryption_required)
+        raw_response = tree.client.send_recv(read_request, encrypt: @tree_connect_encrypt_data)
         response = RubySMB::SMB2::Packet::ReadResponse.read(raw_response)
         unless response.valid?
           raise RubySMB::Error::InvalidPacket.new(
@@ -200,7 +200,7 @@ module RubySMB
       # @return [WindowsError::ErrorCode] the NTStatus Response code
       # @raise [RubySMB::Error::InvalidPacket] if the response is not a SetInfoResponse packet
       def delete
-        raw_response = tree.client.send_recv(delete_packet, encrypt: @encryption_required)
+        raw_response = tree.client.send_recv(delete_packet, encrypt: @tree_connect_encrypt_data)
         response = RubySMB::SMB2::Packet::SetInfoResponse.read(raw_response)
         unless response.valid?
           raise RubySMB::Error::InvalidPacket.new(
@@ -250,7 +250,7 @@ module RubySMB
 
         while buffer.length > 0 do
           write_request = write_packet(data: buffer.slice!(0,atomic_write_size), offset: offset)
-          raw_response  = tree.client.send_recv(write_request, encrypt: @encryption_required)
+          raw_response  = tree.client.send_recv(write_request, encrypt: @tree_connect_encrypt_data)
           response      = RubySMB::SMB2::Packet::WriteResponse.read(raw_response)
           unless response.valid?
             raise RubySMB::Error::InvalidPacket.new(
@@ -283,7 +283,7 @@ module RubySMB
 
       def send_recv_write(data:'', offset: 0)
         pkt = write_packet(data: data, offset: offset)
-        raw_response = tree.client.send_recv(pkt, encrypt: @encryption_required)
+        raw_response = tree.client.send_recv(pkt, encrypt: @tree_connect_encrypt_data)
         response = RubySMB::SMB2::Packet::WriteResponse.read(raw_response)
         unless response.valid?
           raise RubySMB::Error::InvalidPacket.new(
@@ -305,7 +305,7 @@ module RubySMB
       # @return [WindowsError::ErrorCode] the NTStatus Response code
       # @raise [RubySMB::Error::InvalidPacket] if the response is not a SetInfoResponse packet
       def rename(new_file_name)
-        raw_response = tree.client.send_recv(rename_packet(new_file_name), encrypt: @encryption_required)
+        raw_response = tree.client.send_recv(rename_packet(new_file_name), encrypt: @tree_connect_encrypt_data)
         response = RubySMB::SMB2::Packet::SetInfoResponse.read(raw_response)
         unless response.valid?
           raise RubySMB::Error::InvalidPacket.new(

--- a/spec/lib/ruby_smb/client_spec.rb
+++ b/spec/lib/ruby_smb/client_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe RubySMB::Client do
         expect(opt[:workstation]).to eq(local_workstation)
         expect(opt[:domain]).to eq(domain)
         flags = Net::NTLM::Client::DEFAULT_FLAGS |
-          Net::NTLM::FLAGS[:TARGET_INFO] | 0x02000000
+          Net::NTLM::FLAGS[:TARGET_INFO] | 0x02000000 ^ Net::NTLM::FLAGS[:OEM]
         expect(opt[:flags]).to eq(flags)
       end
 

--- a/spec/lib/ruby_smb/client_spec.rb
+++ b/spec/lib/ruby_smb/client_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe RubySMB::Client do
   it { is_expected.to respond_to :encryption_algorithm }
   it { is_expected.to respond_to :client_encryption_key }
   it { is_expected.to respond_to :server_encryption_key }
-  it { is_expected.to respond_to :encryption_required }
+  it { is_expected.to respond_to :session_encrypt_data }
   it { is_expected.to respond_to :server_encryption_algorithms }
   it { is_expected.to respond_to :server_compression_algorithms }
   it { is_expected.to respond_to :negotiated_smb_version }
@@ -106,9 +106,9 @@ RSpec.describe RubySMB::Client do
       expect(client.password).to eq password
     end
 
-    it 'sets the encryption_required attribute' do
+    it 'sets the session_encrypt_data attribute' do
       client =  described_class.new(dispatcher, username: username, password: password, always_encrypt: true)
-      expect(client.encryption_required).to eq true
+      expect(client.session_encrypt_data).to eq true
     end
 
     it 'creates an NTLM client' do
@@ -189,11 +189,6 @@ RSpec.describe RubySMB::Client do
       allow(client).to receive(:is_status_pending?).and_return(false)
       allow(dispatcher).to receive(:send_packet).and_return(nil)
       allow(dispatcher).to receive(:recv_packet).and_return('A')
-    end
-
-    it 'checks the packet version' do
-      expect(smb1_request).to receive(:packet_smb_version).and_call_original
-      client.send_recv(smb1_request)
     end
 
     context 'when signing' do
@@ -322,6 +317,11 @@ RSpec.describe RubySMB::Client do
       expect(client.can_be_encrypted?(packet)).to be true
     end
 
+    it 'returns false if it is an SMB1 packet' do
+      packet = RubySMB::SMB1::Packet::LogoffRequest.new
+      expect(client.can_be_encrypted?(packet)).to be false
+    end
+
     [RubySMB::SMB2::Packet::SessionSetupRequest, RubySMB::SMB2::Packet::NegotiateRequest].each do |klass|
       it "returns false if the packet is a #{klass}" do
         packet = klass.new
@@ -385,6 +385,15 @@ RSpec.describe RubySMB::Client do
       expect(dispatcher).to have_received(:recv_packet)
     end
 
+    it 'raises an EncryptionError exception if an error occurs while receiving the response' do
+      allow(dispatcher).to receive(:recv_packet).and_raise(RubySMB::Error::CommunicationError)
+      expect { client.recv_encrypt }.to raise_error(
+        RubySMB::Error::EncryptionError,
+        'Communication error with the remote host: RubySMB::Error::CommunicationError. '\
+        'The server supports encryption but was not able to handle the encrypted request.'
+      )
+    end
+
     it 'parses the response as a Transform response packet' do
       expect(RubySMB::SMB2::Packet::TransformHeader).to receive(:read).with(packet.to_binary_s)
       client.recv_encrypt
@@ -392,7 +401,7 @@ RSpec.describe RubySMB::Client do
 
     it 'raises an InvalidPacket exception if an error occurs while parsing the response' do
       allow(RubySMB::SMB2::Packet::TransformHeader).to receive(:read).and_raise(IOError)
-      expect { client.recv_encrypt}.to raise_error(RubySMB::Error::InvalidPacket, 'Not a SMB2 TransformHeader packet')
+      expect { client.recv_encrypt }.to raise_error(RubySMB::Error::InvalidPacket, 'Not a SMB2 TransformHeader packet')
     end
 
     it 'decrypts the Transform response packet' do
@@ -403,10 +412,10 @@ RSpec.describe RubySMB::Client do
     end
 
     it 'raises an EncryptionError exception if an error occurs while decrypting' do
-      allow(client).to receive(:smb3_decrypt).and_raise(RubySMB::Error::RubySMBError )
-      expect { client.recv_encrypt}.to raise_error(
+      allow(client).to receive(:smb3_decrypt).and_raise(RubySMB::Error::RubySMBError)
+      expect { client.recv_encrypt }.to raise_error(
         RubySMB::Error::EncryptionError,
-        "Error while decrypting RubySMB::SMB2::Packet::TransformHeader packet (SMB 0x0300}): RubySMB::Error::RubySMBError"
+        'Error while decrypting RubySMB::SMB2::Packet::TransformHeader packet (SMB 0x0300}): RubySMB::Error::RubySMBError'
       )
     end
   end
@@ -1049,6 +1058,42 @@ RSpec.describe RubySMB::Client do
 
         it 'returns the string \'SMB2\'' do
           expect(client.parse_negotiate_response(smb3_response)).to eq ('SMB3')
+        end
+
+        context 'when the server supports encryption' do
+          before :example do
+            smb3_response.capabilities.encryption = 1
+          end
+
+          it 'keeps session encryption enabled if it was already' do
+            client.session_encrypt_data = true
+            client.parse_negotiate_response(smb3_response)
+            expect(client.session_encrypt_data).to be true
+          end
+
+          it 'keeps session encryption disabled if it was already' do
+            client.session_encrypt_data = false
+            client.parse_negotiate_response(smb3_response)
+            expect(client.session_encrypt_data).to be false
+          end
+        end
+
+        context 'when the server does not support encryption' do
+          before :example do
+            smb3_response.capabilities.encryption = 0
+          end
+
+          it 'disables session encryption if it was already enabled' do
+            client.session_encrypt_data = true
+            client.parse_negotiate_response(smb3_response)
+            expect(client.session_encrypt_data).to be false
+          end
+
+          it 'keeps session encryption disabled if it was already' do
+            client.session_encrypt_data = false
+            client.parse_negotiate_response(smb3_response)
+            expect(client.session_encrypt_data).to be false
+          end
         end
       end
 
@@ -1710,22 +1755,22 @@ RSpec.describe RubySMB::Client do
           smb2_client.smb2_authenticate
         end
 
-        context 'when setting the encryption_required parameter' do
+        context 'when setting the session_encrypt_data parameter' do
           before :example do
             smb2_client.smb3 = true
-            smb2_client.encryption_required = false
+            smb2_client.session_encrypt_data = false
           end
 
-          it 'sets the encryption_required parameter to true if the server requires encryption' do
+          it 'sets the session_encrypt_data parameter to true if the server requires encryption' do
             final_response_packet.session_flags.encrypt_data = 1
             smb2_client.smb2_authenticate
-            expect(smb2_client.encryption_required).to be true
+            expect(smb2_client.session_encrypt_data).to be true
           end
 
-          it 'does not set the encryption_required parameter if the server does not require encryption' do
+          it 'does not set the session_encrypt_data parameter if the server does not require encryption' do
             final_response_packet.session_flags.encrypt_data = 0
             smb2_client.smb2_authenticate
-            expect(smb2_client.encryption_required).to be false
+            expect(smb2_client.session_encrypt_data).to be false
           end
         end
       end

--- a/spec/lib/ruby_smb/dispatcher/socket_spec.rb
+++ b/spec/lib/ruby_smb/dispatcher/socket_spec.rb
@@ -51,9 +51,9 @@ RSpec.describe RubySMB::Dispatcher::Socket do
     let(:session_header)  { RubySMB::Nbss::SessionHeader.new }
 
     context 'when reading from the socket results in a nil value' do
-      it 'should raise Error::NetBiosSessionService' do
+      it 'should raise Error::CommunicationError' do
         smb_socket.tcp_socket = blank_socket
-        expect { smb_socket.recv_packet }.to raise_error(::RubySMB::Error::NetBiosSessionService)
+        expect { smb_socket.recv_packet }.to raise_error(::RubySMB::Error::CommunicationError)
       end
     end
 

--- a/spec/lib/ruby_smb/smb2/file_spec.rb
+++ b/spec/lib/ruby_smb/smb2/file_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe RubySMB::SMB2::File do
   it { is_expected.to respond_to :size }
   it { is_expected.to respond_to :size_on_disk }
   it { is_expected.to respond_to :tree }
-  it { is_expected.to respond_to :encryption_required }
+  it { is_expected.to respond_to :tree_connect_encrypt_data }
 
   it 'pulls the attributes from the response packet' do
     expect(file.attributes).to eq create_response.file_attributes
@@ -73,8 +73,8 @@ RSpec.describe RubySMB::SMB2::File do
     expect(file.size_on_disk).to eq create_response.allocation_size
   end
 
-  it 'sets the encryption_required flag to false by default' do
-    expect(file.encryption_required).to be false
+  it 'sets the tree_connect_encrypt_data flag to false by default' do
+    expect(file.tree_connect_encrypt_data).to be false
   end
 
   describe '#set_header_fields' do
@@ -132,7 +132,7 @@ RSpec.describe RubySMB::SMB2::File do
       end
 
       it 'calls Client #send_recv with encryption set if required' do
-        file.encryption_required = true
+        file.tree_connect_encrypt_data = true
         expect(client).to receive(:send_recv).with(small_read, encrypt: true)
         file.read
       end
@@ -177,7 +177,7 @@ RSpec.describe RubySMB::SMB2::File do
       it 'calls Client #send_recv with encryption set if required' do
         read_request = double('Read Request')
         allow(file).to receive(:read_packet).and_return(read_request)
-        file.encryption_required = true
+        file.tree_connect_encrypt_data = true
         expect(client).to receive(:send_recv).twice.with(read_request, encrypt: true)
         file.read(bytes: (described_class::MAX_PACKET_SIZE * 2))
       end
@@ -235,7 +235,7 @@ RSpec.describe RubySMB::SMB2::File do
       it 'calls Client #send_recv with encryption set if required' do
         write_request = double('Write Request')
         allow(file).to receive(:write_packet).and_return(write_request)
-        file.encryption_required = true
+        file.tree_connect_encrypt_data = true
         expect(client).to receive(:send_recv).once.with(write_request, encrypt: true).and_return(write_response.to_binary_s)
         file.write(data: 'test')
       end
@@ -250,7 +250,7 @@ RSpec.describe RubySMB::SMB2::File do
       it 'calls Client #send_recv with encryption set if required' do
         write_request = double('Write Request')
         allow(file).to receive(:write_packet).and_return(write_request)
-        file.encryption_required = true
+        file.tree_connect_encrypt_data = true
         expect(client).to receive(:send_recv).twice.with(write_request, encrypt: true).and_return(write_response.to_binary_s)
         file.write(data: SecureRandom.random_bytes(described_class::MAX_PACKET_SIZE + 1))
       end
@@ -307,7 +307,7 @@ RSpec.describe RubySMB::SMB2::File do
       it 'calls Client #send_recv with encryption set if required' do
         allow(file).to receive(:delete_packet)
         allow(RubySMB::SMB2::Packet::SetInfoResponse).to receive(:read).and_return(small_response)
-        file.encryption_required = true
+        file.tree_connect_encrypt_data = true
         expect(client).to receive(:send_recv).with(small_delete, encrypt: true)
         file.delete
       end
@@ -349,7 +349,7 @@ RSpec.describe RubySMB::SMB2::File do
 
       it 'calls Client #send_recv with encryption set if required' do
         allow(RubySMB::SMB2::Packet::SetInfoResponse).to receive(:read).and_return(small_response)
-        file.encryption_required = true
+        file.tree_connect_encrypt_data = true
         expect(client).to receive(:send_recv).with(small_rename, encrypt: true)
         file.rename('new_file.txt')
       end
@@ -393,7 +393,7 @@ RSpec.describe RubySMB::SMB2::File do
     end
 
     it 'calls Client #send_recv with encryption set if required' do
-      file.encryption_required = true
+      file.tree_connect_encrypt_data = true
       expect(client).to receive(:send_recv).with(request, encrypt: true)
       file.close
     end
@@ -465,7 +465,7 @@ RSpec.describe RubySMB::SMB2::File do
     it 'calls Client #send_recv with encryption set if required' do
       request = double('Request')
       allow(file).to receive(:read_packet).and_return(request)
-      file.encryption_required = true
+      file.tree_connect_encrypt_data = true
       expect(client).to receive(:send_recv).with(request, encrypt: true)
       file.send_recv_read
     end
@@ -528,7 +528,7 @@ RSpec.describe RubySMB::SMB2::File do
     end
 
     it 'calls Client #send_recv with encryption set if required' do
-      file.encryption_required = true
+      file.tree_connect_encrypt_data = true
       expect(client).to receive(:send_recv).with(request, encrypt: true)
       file.send_recv_write
     end

--- a/spec/lib/ruby_smb/smb2/tree_spec.rb
+++ b/spec/lib/ruby_smb/smb2/tree_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe RubySMB::SMB2::Tree do
   it { is_expected.to respond_to :permissions }
   it { is_expected.to respond_to :share }
   it { is_expected.to respond_to :id }
-  it { is_expected.to respond_to :encryption_required }
+  it { is_expected.to respond_to :tree_connect_encrypt_data }
 
   it 'inherits the client that spawned it' do
     expect(tree.client).to eq client
@@ -51,7 +51,7 @@ RSpec.describe RubySMB::SMB2::Tree do
 
     it 'calls Client #send_recv with encryption set if required' do
       allow(tree).to receive(:set_header_fields).and_return(disco_req)
-      tree.encryption_required = true
+      tree.tree_connect_encrypt_data = true
       expect(client).to receive(:send_recv).with(disco_req, encrypt: true).and_return(disco_resp.to_binary_s)
       tree.disconnect!
     end
@@ -147,7 +147,7 @@ RSpec.describe RubySMB::SMB2::Tree do
 
     it 'calls Client #send_recv with encryption set if required' do
       allow(tree).to receive(:open_directory_packet).and_return(create_req)
-      tree.encryption_required = true
+      tree.tree_connect_encrypt_data = true
       expect(client).to receive(:send_recv).with(create_req, encrypt: true).and_return(create_response.to_binary_s)
       tree.open_directory
     end
@@ -229,7 +229,7 @@ RSpec.describe RubySMB::SMB2::Tree do
 
     it 'calls Client #send_recv with encryption set if required' do
       allow(tree).to receive(:set_header_fields).and_return(query_dir_req)
-      tree.encryption_required = true
+      tree.tree_connect_encrypt_data = true
       expect(client).to receive(:send_recv).with(query_dir_req, encrypt: true)
       tree.list
     end
@@ -437,7 +437,7 @@ RSpec.describe RubySMB::SMB2::Tree do
     end
 
     it 'calls Client #send_recv with encryption set if required' do
-      tree.encryption_required = true
+      tree.tree_connect_encrypt_data = true
       expect(client).to receive(:send_recv).with(create_request, encrypt: true).and_return(create_response.to_binary_s)
       tree.open_file(filename: filename)
     end
@@ -459,7 +459,7 @@ RSpec.describe RubySMB::SMB2::Tree do
         context 'when encryption is required' do
           it 'returns the expected RubySMB::SMB2::File object' do
             file_obj = RubySMB::SMB2::File.new(name: filename, tree: tree, response: create_response, encrypt: true)
-            tree.encryption_required = true
+            tree.tree_connect_encrypt_data = true
             expect(RubySMB::SMB2::File).to receive(:new).with(name: filename, tree: tree, response: create_response, encrypt: true).and_return(file_obj)
             expect(tree.open_file(filename: filename)).to eq(file_obj)
           end


### PR DESCRIPTION
This is related to the comments left in https://github.com/rapid7/metasploit-framework/pull/13417:

- Fix issues with Mac OS X SMB server
  - Set the unicode flag on the Negotiate SMB Header request
  - Check if the Socket is closed before calling IO.select
  - Improve `Socket#recv_packet` exception handling
- Improvements related to the Windows 8 errors:
  - Change `:encryption_required` parameter name to a more meaningful name according
  to the context: `:session_encrypt_data` and `:tree_connect_encrypt_data`.
  - `#can_be_encrypted?` now returns false with SMB1 packet.
  - Improve exception handling in `recv_encrypt` in case an encryption
    error occurs on the server (this will help in detecting the unpatched Win8 bug).
  - Only enable session encryption if the server supports it. This only applies
    if `session_encrypt_data` was originally set (forced). If it is not set, session
    encryption will stay disabled even if the server supports encryption.

## Verification Steps
Follow the instructions in https://github.com/rapid7/metasploit-framework/pull/13417 to setup the targets.

On Mac OS X, you can enable file sharing in `System Preferences` > `Sharing` > `File Sharing`.

### Mac OS X testing with MSF
These changes are needed: https://github.com/rapid7/metasploit-framework/pull/13417
I set up a local share and a new test account for smb file sharing.
```
set RHOSTS 127.0.0.1
set SMBUser smbtest
set SMBPass 123456
set SMB::ProtocolVersion 1,2,3
```
```
msf5 auxiliary(scanner/smb/smb_enumshares) > run

[-] 127.0.0.1:139         - Error: '127.0.0.1' 'Rex::ConnectionRefused' 'The connection was refused by the remote host (127.0.0.1:139).'
[!] 127.0.0.1:445         - peer_native_os is only available with SMB1 (current version: SMB2)
[!] 127.0.0.1:445         - peer_native_lm is only available with SMB1 (current version: SMB2)
[+] 127.0.0.1:445         - Administrators Public Folder - (DISK)
[+] 127.0.0.1:445         - IPC$ - (IPC)
[+] 127.0.0.1:445         - smbtests Public Folder - (DISK)
[+] 127.0.0.1:445         - tmp - (DISK)
[+] 127.0.0.1:445         - smbtest - (DISK)
[*] 127.0.0.1:            - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

### Windows 8 testing with MSF
These changes are needed: https://github.com/rapid7/metasploit-framework/pull/13417
I set up a local share and a new test account for smb file sharing on a remote unpatched Windows 8 (fresh installation).
```
set RHOSTS 172.16.60.131
set SMBUser smbtest
set SMBPass 123456
set SMB::ProtocolVersion 1,2,3
set SMB::AlwaysEncrypt true
```
```
msf5 auxiliary(scanner/smb/smb_enumshares) > run

[-] 172.16.60.131:139     - Login Failed: Unable to negotiate SMB1 with the remote host: Not a valid SMB packet
[-] 172.16.60.131:445     - Error: '172.16.60.131' 'RubySMB::Error::EncryptionError' 'Communication error with the remote host: An error occurred reading from the Socket Connection reset by peer. The server supports encryption but was not able to handle the encrypted request.'
[*] 172.16.60.131:        - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```
Make sure the error message is this one:
```
'RubySMB::Error::EncryptionError' 'Communication error with the remote host: An error occurred reading from the Socket Connection reset by peer. The server supports encryption but was not able to handle the encrypted request.
```