### PR TITLE
Multiple fixes and query_service_status example script

### DIFF
--- a/examples/query_service_status.rb
+++ b/examples/query_service_status.rb
@@ -1,0 +1,64 @@
+#!/usr/bin/ruby
+
+# This example script is used for testing remote service status and start type query.
+# It will attempt to connect to a host and query the status and start type of the provided service.
+# Example usage: ruby query_service_status.rb 192.168.172.138 msfadmin msfadmin "RemoteRegistry"
+# This will try to connect to \\192.168.172.138 with the msfadmin:msfadmin credentialas and get the status and start type of the "RemoteRegistry" service.
+
+require 'bundler/setup'
+require 'ruby_smb'
+
+address      = ARGV[0]
+username     = ARGV[1]
+password     = ARGV[2]
+service      = ARGV[3]
+smb_versions = ARGV[4]&.split(',') || ['1','2','3']
+
+sock = TCPSocket.new address, 445
+dispatcher = RubySMB::Dispatcher::Socket.new(sock, read_timeout: 60)
+
+client = RubySMB::Client.new(dispatcher, smb1: smb_versions.include?('1'), smb2: smb_versions.include?('2'), smb3: smb_versions.include?('3'), username: username, password: password)
+protocol = client.negotiate
+status = client.authenticate
+
+puts "#{protocol} : #{status}"
+
+tree = client.tree_connect("\\\\#{address}\\IPC$")
+svcctl = tree.open_file(filename: 'svcctl', write: true, read: true)
+
+puts('Binding to \\svcctl...')
+svcctl.bind(endpoint: RubySMB::Dcerpc::Svcctl)
+puts('Bound to \\svcctl')
+
+puts('Opening Service Control Manager')
+scm_handle = svcctl.open_sc_manager_w(address)
+
+svc_handle = svcctl.open_service_w(scm_handle, service)
+svc_status = svcctl.query_service_status(svc_handle)
+
+case svc_status.dw_current_state
+when RubySMB::Dcerpc::Svcctl::SERVICE_RUNNING
+  puts("Service #{service} is running")
+when RubySMB::Dcerpc::Svcctl::SERVICE_STOPPED
+  puts("Service #{service} is in stopped state")
+end
+
+svc_config = svcctl.query_service_config(svc_handle)
+case svc_config.dw_start_type
+when RubySMB::Dcerpc::Svcctl::SERVICE_DISABLED
+  puts("Service #{service} is disabled")
+when RubySMB::Dcerpc::Svcctl::SERVICE_BOOT_START, RubySMB::Dcerpc::Svcctl::SERVICE_SYSTEM_START
+  puts("Service #{service} starts when the system boots up (driver)")
+when RubySMB::Dcerpc::Svcctl::SERVICE_AUTO_START
+  puts("Service #{service} starts automatically during system startup")
+when RubySMB::Dcerpc::Svcctl::SERVICE_DEMAND_START
+  puts("Service #{service} starts manually")
+end
+
+if svcctl
+  svcctl.close_service_handle(svc_handle) if svc_handle
+  svcctl.close_service_handle(scm_handle) if scm_handle
+  svcctl.close
+end
+client.disconnect!
+

--- a/lib/ruby_smb/client.rb
+++ b/lib/ruby_smb/client.rb
@@ -514,7 +514,8 @@ module RubySMB
 
     # Encrypt (if required) and send a packet.
     #
-    # @param encrypt [Boolean] true if the packet is encrypted, false otherwise
+    # @param encrypt [Boolean] true if the packet should be encrypted, false
+    #   otherwise
     def send_packet(packet, encrypt: false)
       if encrypt
         begin

--- a/lib/ruby_smb/client.rb
+++ b/lib/ruby_smb/client.rb
@@ -160,8 +160,15 @@ module RubySMB
 
     # The UID set in SMB1
     # @!attribute [rw] user_id
-    #   @return [String]
+    #   @return [Integer]
     attr_accessor :user_id
+
+    # The Process ID set in SMB1
+    # It is randomly generated during the client initialization, but can
+    # be modified using the accessor.
+    # @!attribute [rw] pid
+    #   @return [Integer]
+    attr_accessor :pid
 
     # The maximum size SMB message that the Client accepts (in bytes)
     # The default value is equal to {MAX_BUFFER_SIZE}.
@@ -258,6 +265,14 @@ module RubySMB
     #   @return [Integer] the negotiated SMB version
     attr_accessor :negotiated_smb_version
 
+    # Whether or not the server supports multi-credit operations. It is
+    # reported by the LARGE_MTU capabiliy as part of the negotiation process
+    # (SMB 2.x and 3.x).
+    # @!attribute [rw] server_supports_multi_credit
+    #   @return [Boolean] true if the server supports multi-credit operations,
+    #   false otherwise
+    attr_accessor :server_supports_multi_credit
+
     # @param dispatcher [RubySMB::Dispatcher::Socket] the packet dispatcher to use
     # @param smb1 [Boolean] whether or not to enable SMB1 support
     # @param smb2 [Boolean] whether or not to enable SMB2 support
@@ -268,6 +283,7 @@ module RubySMB
         raise ArgumentError, 'You must enable at least one Protocol'
       end
       @dispatcher        = dispatcher
+      @pid               = rand(0xFFFF)
       @domain            = domain
       @local_workstation = local_workstation
       @password          = password.encode('utf-8') || ''.encode('utf-8')
@@ -285,6 +301,7 @@ module RubySMB
       @server_max_read_size   = RubySMB::SMB2::File::MAX_PACKET_SIZE
       @server_max_write_size  = RubySMB::SMB2::File::MAX_PACKET_SIZE
       @server_max_transact_size = RubySMB::SMB2::File::MAX_PACKET_SIZE
+      @server_supports_multi_credit = false
 
       # SMB 3.x options
       @session_encrypt_data = always_encrypt
@@ -344,7 +361,7 @@ module RubySMB
     # @param packet [RubySMB::GenericPacket] the packet to set the message id for
     # @return [RubySMB::GenericPacket] the modified packet
     def increment_smb_message_id(packet)
-      packet.smb2_header.message_id = smb2_message_id
+      packet.smb2_header.message_id = self.smb2_message_id
       self.smb2_message_id += 1
       packet
     end
@@ -427,7 +444,8 @@ module RubySMB
       version = packet.packet_smb_version
       case version
       when 'SMB1'
-        packet.smb_header.uid = user_id if user_id
+        packet.smb_header.uid = self.user_id if self.user_id
+        packet.smb_header.pid_low = self.pid if self.pid
         packet = smb1_sign(packet)
       when 'SMB2'
         packet = increment_smb_message_id(packet)
@@ -443,35 +461,32 @@ module RubySMB
         packet = packet
       end
 
+      encrypt_data = false
       if can_be_encrypted?(packet) && encryption_supported? && (@session_encrypt_data || encrypt)
-        send_encrypt(packet)
-        raw_response = recv_encrypt
-        loop do
-          break unless is_status_pending?(raw_response)
-          sleep 1
-          raw_response = recv_encrypt
-        end
-      else
-        dispatcher.send_packet(packet)
-        raw_response = dispatcher.recv_packet
-        loop do
-          break unless is_status_pending?(raw_response)
-          sleep 1
-          raw_response = dispatcher.recv_packet
-        end unless version == 'SMB1'
+        encrypt_data = true
       end
+      send_packet(packet, encrypt: encrypt_data)
+      raw_response = recv_packet(encrypt: encrypt_data)
+      smb2_header = nil
+      loop do
+        smb2_header = RubySMB::SMB2::SMB2Header.read(raw_response)
+        break unless is_status_pending?(smb2_header)
+        sleep 1
+        raw_response = recv_packet(encrypt: encrypt_data)
+      end unless version == 'SMB1'
 
       self.sequence_counter += 1 if signing_required && !session_key.empty?
+      # update the SMB2 message ID according to the received Credit Charged
+      self.smb2_message_id += smb2_header.credit_charge - 1 if smb2_header && self.dialect != '0x0202'
       raw_response
     end
 
     # Check if the response is an asynchronous operation with STATUS_PENDING
     # status code.
     #
-    # @param raw_response [String] the raw response packet
+    # @param smb2_header [String] the response packet SMB2 header
     # @return [Boolean] true if it is a status pending operation, false otherwise
-    def is_status_pending?(raw_response)
-      smb2_header = RubySMB::SMB2::SMB2Header.read(raw_response)
+    def is_status_pending?(smb2_header)
       value = smb2_header.nt_status.value
       status_code = WindowsError::NTStatus.find_by_retval(value).first
       status_code == WindowsError::NTStatus::STATUS_PENDING &&
@@ -497,37 +512,49 @@ module RubySMB
       ['0x0300', '0x0302', '0x0311'].include?(@dialect)
     end
 
-    # Encrypt and send a packet
-    def send_encrypt(packet)
-      begin
-        transform_request = smb3_encrypt(packet.to_binary_s)
-      rescue RubySMB::Error::RubySMBError => e
-        raise RubySMB::Error::EncryptionError, "Error while encrypting #{packet.class.name} packet (SMB #{@dialect}): #{e}"
+    # Encrypt (if required) and send a packet.
+    #
+    # @param encrypt [Boolean] true if the packet is encrypted, false otherwise
+    def send_packet(packet, encrypt: false)
+      if encrypt
+        begin
+          packet = smb3_encrypt(packet.to_binary_s)
+        rescue RubySMB::Error::RubySMBError => e
+          raise RubySMB::Error::EncryptionError, "Error while encrypting #{packet.class.name} packet (SMB #{@dialect}): #{e}"
+        end
       end
-      dispatcher.send_packet(transform_request)
+      dispatcher.send_packet(packet)
     end
 
-    # Receives the raw response through the Dispatcher and decrypt the packet.
+    # Receives the raw response through the Dispatcher and decrypt the packet (if required).
     #
+    # @param encrypt [Boolean] true if the packet is encrypted, false otherwise
     # @return [String] the raw unencrypted packet
-    def recv_encrypt
+    def recv_packet(encrypt: false)
       begin
         raw_response = dispatcher.recv_packet
       rescue RubySMB::Error::CommunicationError => e
-        raise RubySMB::Error::EncryptionError, "Communication error with the "\
-          "remote host: #{e.message}. The server supports encryption but was "\
-          "not able to handle the encrypted request."
+        if encrypt
+          raise RubySMB::Error::EncryptionError, "Communication error with the "\
+            "remote host: #{e.message}. The server supports encryption but was "\
+            "not able to handle the encrypted request."
+        else
+          raise e
+        end
       end
-      begin
-        transform_response = RubySMB::SMB2::Packet::TransformHeader.read(raw_response)
-      rescue IOError
-        raise RubySMB::Error::InvalidPacket, 'Not a SMB2 TransformHeader packet'
+      if encrypt
+        begin
+          transform_response = RubySMB::SMB2::Packet::TransformHeader.read(raw_response)
+        rescue IOError
+          raise RubySMB::Error::InvalidPacket, 'Not a SMB2 TransformHeader packet'
+        end
+        begin
+          raw_response = smb3_decrypt(transform_response)
+        rescue RubySMB::Error::RubySMBError => e
+          raise RubySMB::Error::EncryptionError, "Error while decrypting #{transform_response.class.name} packet (SMB #@dialect}): #{e}"
+        end
       end
-      begin
-        smb3_decrypt(transform_response)
-      rescue RubySMB::Error::RubySMBError => e
-        raise RubySMB::Error::EncryptionError, "Error while decrypting #{transform_response.class.name} packet (SMB #@dialect}): #{e}"
-      end
+      raw_response
     end
 
     # Connects to the supplied share
@@ -568,6 +595,7 @@ module RubySMB
       self.smb2_message_id  = 0
       self.client_encryption_key = nil
       self.server_encryption_key = nil
+      self.server_supports_multi_credit = false
     end
 
     # Requests a NetBIOS Session Service using the provided name.
@@ -605,7 +633,7 @@ module RubySMB
       session_request.session_header.session_packet_type = RubySMB::Nbss::SESSION_REQUEST
       session_request.called_name  = called_name
       session_request.calling_name = calling_name
-      session_request.session_header.packet_length =
+      session_request.session_header.stream_protocol_length =
         session_request.num_bytes - session_request.session_header.num_bytes
       session_request
     end

--- a/lib/ruby_smb/client/negotiation.rb
+++ b/lib/ruby_smb/client/negotiation.rb
@@ -140,7 +140,7 @@ module RubySMB
           self.server_guid = packet.server_guid
           self.server_start_time = packet.server_start_time.to_time if packet.server_start_time != 0
           self.server_system_time = packet.system_time.to_time if packet.system_time != 0
-          self.server_supports_multi_credit = packet&.capabilities&.large_mtu == 1
+          self.server_supports_multi_credit = self.dialect != '0x0202' && packet&.capabilities&.large_mtu == 1
           case self.dialect
           when '0x02ff'
           when '0x0300', '0x0302'

--- a/lib/ruby_smb/client/negotiation.rb
+++ b/lib/ruby_smb/client/negotiation.rb
@@ -140,6 +140,7 @@ module RubySMB
           self.server_guid = packet.server_guid
           self.server_start_time = packet.server_start_time.to_time if packet.server_start_time != 0
           self.server_system_time = packet.system_time.to_time if packet.system_time != 0
+          self.server_supports_multi_credit = packet&.capabilities&.large_mtu == 1
           case self.dialect
           when '0x02ff'
           when '0x0300', '0x0302'

--- a/lib/ruby_smb/dispatcher/base.rb
+++ b/lib/ruby_smb/dispatcher/base.rb
@@ -9,7 +9,7 @@ module RubySMB
       def nbss(packet)
         nbss = RubySMB::Nbss::SessionHeader.new
         nbss.session_packet_type = RubySMB::Nbss::SESSION_MESSAGE
-        nbss.packet_length       = packet.do_num_bytes
+        nbss.stream_protocol_length = packet.do_num_bytes
         nbss.to_binary_s
       end
 

--- a/lib/ruby_smb/dispatcher/socket.rb
+++ b/lib/ruby_smb/dispatcher/socket.rb
@@ -74,7 +74,7 @@ module RubySMB
           raise ::RubySMB::Error::NetBiosSessionService, 'NBSS Header is missing'
         end
 
-        length = nbss_header.packet_length
+        length = nbss_header.stream_protocol_length
         data = full_response ? nbss_header.to_binary_s : ''
         if length > 0
           if IO.select([@tcp_socket], nil, nil, @read_timeout).nil?

--- a/lib/ruby_smb/nbss/session_header.rb
+++ b/lib/ruby_smb/nbss/session_header.rb
@@ -1,13 +1,13 @@
 module RubySMB
   module Nbss
     # Representation of the NetBIOS Session Service Header as defined in
-    # [4.3.1 GENERAL FORMAT OF SESSION PACKETS](https://tools.ietf.org/html/rfc1002)
+    # SMB: [2.1 Transport](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-smb/f906c680-330c-43ae-9a71-f854e24aeee6)
+    # SMB2: [2.1 Transport](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/1dfacde4-b5c7-4494-8a14-a09d3ab4cc83)
     class SessionHeader < BinData::Record
       endian :big
 
-      uint8 :session_packet_type,  label: 'Session Packet Type'
-      bit7  :flags,                label: 'Flags',              initial_value: 0
-      bit17 :packet_length,        label: 'Packet Length'
+      uint8  :session_packet_type,    label: 'Session Packet Type', initial_value: 0
+      uint24 :stream_protocol_length, label: 'Stream Protocol Length'
     end
   end
 end

--- a/lib/ruby_smb/smb1/file.rb
+++ b/lib/ruby_smb/smb1/file.rb
@@ -106,11 +106,7 @@ module RubySMB
       # @raise [RubySMB::Error::InvalidPacket] if the response packet is not valid
       # @raise [RubySMB::Error::UnexpectedStatusCode] if the response NTStatus is not STATUS_SUCCESS
       def read(bytes: @size, offset: 0)
-        atomic_read_size = if bytes > @tree.client.max_buffer_size
-                             @tree.client.max_buffer_size
-                           else
-                             bytes
-                           end
+        atomic_read_size = [bytes, @tree.client.max_buffer_size].min
         remaining_bytes = bytes
         data = ''
 
@@ -227,11 +223,7 @@ module RubySMB
         total_bytes_written = 0
 
         loop do
-          atomic_write_size = if bytes > @tree.client.max_buffer_size
-                               @tree.client.max_buffer_size
-                              else
-                                bytes
-                              end
+          atomic_write_size = [bytes, @tree.client.max_buffer_size].min
           write_request = write_packet(data: buffer.slice!(0, atomic_write_size), offset: offset)
           raw_response = @tree.client.send_recv(write_request)
           response = RubySMB::SMB1::Packet::WriteAndxResponse.read(raw_response)

--- a/lib/ruby_smb/smb2/pipe.rb
+++ b/lib/ruby_smb/smb2/pipe.rb
@@ -91,6 +91,7 @@ module RubySMB
         request = set_header_fields(RubySMB::SMB2::Packet::IoctlRequest.new(options))
         request.ctl_code = 0x0011C017
         request.flags.is_fsctl = 0x00000001
+        # TODO: handle fragmentation when the request size > MAX_XMIT_FRAG
         request.buffer = action.to_binary_s
 
         ioctl_raw_response = @tree.client.send_recv(request)

--- a/lib/ruby_smb/smb2/tree.rb
+++ b/lib/ruby_smb/smb2/tree.rb
@@ -147,12 +147,21 @@ module RubySMB
         directory_request.file_information_class  = type::CLASS_LEVEL
         directory_request.file_id                 = file_id
         directory_request.name                    = pattern
-        directory_request.output_length           = 65_535
+
+        max_read = client.server_max_read_size
+        if client.dialect == '0x0202' || !client.server_supports_multi_credit
+          max_read = 65536
+        end
+        credit_charge = 0
+        if client.dialect != '0x0202' && client.server_supports_multi_credit
+          credit_charge = (max_read - 1) / 65536 + 1
+        end
+        directory_request.output_length = max_read
+        directory_request.smb2_header.credit_charge = credit_charge
 
         directory_request = set_header_fields(directory_request)
 
         files = []
-
         loop do
           response            = client.send_recv(directory_request, encrypt: @tree_connect_encrypt_data)
           directory_response  = RubySMB::SMB2::Packet::QueryDirectoryResponse.read(response)
@@ -256,7 +265,6 @@ module RubySMB
       # @return [RubySMB::SMB2::Packet] the modified packet.
       def set_header_fields(request)
         request.smb2_header.tree_id = id
-        request.smb2_header.credit_charge = 1
         request.smb2_header.credits = 256
         request
       end

--- a/lib/ruby_smb/smb2/tree.rb
+++ b/lib/ruby_smb/smb2/tree.rb
@@ -149,11 +149,9 @@ module RubySMB
         directory_request.name                    = pattern
 
         max_read = client.server_max_read_size
-        if client.dialect == '0x0202' || !client.server_supports_multi_credit
-          max_read = 65536
-        end
+        max_read = 65536 unless client.server_supports_multi_credit
         credit_charge = 0
-        if client.dialect != '0x0202' && client.server_supports_multi_credit
+        if client.server_supports_multi_credit
           credit_charge = (max_read - 1) / 65536 + 1
         end
         directory_request.output_length = max_read

--- a/spec/lib/ruby_smb/client_spec.rb
+++ b/spec/lib/ruby_smb/client_spec.rb
@@ -1124,6 +1124,13 @@ RSpec.describe RubySMB::Client do
           client.parse_negotiate_response(smb2_response)
           expect(client.server_supports_multi_credit).to be true
         end
+
+        it 'sets #server_supports_multi_credit to false when the dialect is 0x0202' do
+          smb2_response.dialect_revision = 0x0202
+          smb2_response.capabilities.large_mtu = 1 # just to make sure it won't affect the result
+          client.parse_negotiate_response(smb2_response)
+          expect(client.server_supports_multi_credit).to be false
+        end
       end
 
       context 'when SMB3 was negotiated' do

--- a/spec/lib/ruby_smb/client_spec.rb
+++ b/spec/lib/ruby_smb/client_spec.rb
@@ -65,6 +65,8 @@ RSpec.describe RubySMB::Client do
   it { is_expected.to respond_to :verify_signature }
   it { is_expected.to respond_to :auth_user }
   it { is_expected.to respond_to :last_file_id }
+  it { is_expected.to respond_to :pid }
+  it { is_expected.to respond_to :server_supports_multi_credit }
 
   describe '#initialize' do
     it 'should raise an ArgumentError without a valid dispatcher' do
@@ -141,6 +143,18 @@ RSpec.describe RubySMB::Client do
     it 'sets the max_buffer_size to MAX_BUFFER_SIZE' do
       expect(client.max_buffer_size).to eq RubySMB::Client::MAX_BUFFER_SIZE
     end
+
+    it 'sets the server_supports_multi_credit to false' do
+      expect(client.server_supports_multi_credit).to be false
+    end
+
+    it 'sets the pid to a random value' do
+      100.times do
+        previous_pid = client.pid
+        client = described_class.new(dispatcher, username: username, password: password)
+        expect(client.pid).to_not eq(previous_pid)
+      end
+    end
   end
 
   describe '#echo' do
@@ -184,11 +198,13 @@ RSpec.describe RubySMB::Client do
   describe '#send_recv' do
     let(:smb1_request) { RubySMB::SMB1::Packet::TreeConnectRequest.new }
     let(:smb2_request) { RubySMB::SMB2::Packet::TreeConnectRequest.new }
+    let(:smb2_header)  { RubySMB::SMB2::SMB2Header.new }
 
     before(:each) do
       allow(client).to receive(:is_status_pending?).and_return(false)
       allow(dispatcher).to receive(:send_packet).and_return(nil)
       allow(dispatcher).to receive(:recv_packet).and_return('A')
+      allow(RubySMB::SMB2::SMB2Header).to receive(:read).and_return(smb2_header)
     end
 
     context 'when signing' do
@@ -199,9 +215,10 @@ RSpec.describe RubySMB::Client do
 
       context 'with an SMB2 packet' do
         it 'does not sign a SessionSetupRequest packet' do
+          allow(smb2_client).to receive(:is_status_pending?).and_return(false)
           expect(smb2_client).to_not receive(:smb2_sign)
           expect(smb2_client).to_not receive(:smb3_sign)
-          client.send_recv(RubySMB::SMB2::Packet::SessionSetupRequest.new)
+          smb2_client.send_recv(RubySMB::SMB2::Packet::SessionSetupRequest.new)
         end
 
         it 'calls #smb2_sign if it is an SMB2 client' do
@@ -229,6 +246,29 @@ RSpec.describe RubySMB::Client do
         expect(smb1_client).to_not receive(:is_status_pending?)
         smb1_client.send_recv(smb1_request)
       end
+
+      it 'set the #uid SMB header when #user_id is defined' do
+        smb1_client.user_id = 333
+        smb1_client.send_recv(smb1_request)
+        expect(smb1_request.smb_header.uid).to eq(333)
+      end
+
+      it 'does not set the #uid SMB header when #user_id is not defined' do
+        smb1_client.send_recv(smb1_request)
+        expect(smb1_request.smb_header.uid).to eq(0)
+      end
+
+      it 'set the #pid SMB header when #pid is defined' do
+        smb1_client.pid = 333
+        smb1_client.send_recv(smb1_request)
+        expect(smb1_request.smb_header.pid_low).to eq(333)
+      end
+
+      it 'does not set the #pid SMB header when #pid is not defined' do
+        smb1_client.pid = nil
+        smb1_client.send_recv(smb1_request)
+        expect(smb1_request.smb_header.pid_low).to eq(0)
+      end
     end
 
     context 'with SMB2' do
@@ -251,10 +291,8 @@ RSpec.describe RubySMB::Client do
       context 'with a SessionSetupRequest' do
         it 'does not encrypt/decrypt' do
           request = RubySMB::SMB2::Packet::SessionSetupRequest.new
-          expect(smb3_client).to_not receive(:send_encrypt).with(request)
-          expect(smb3_client).to_not receive(:recv_encrypt)
-          expect(dispatcher).to receive(:send_packet).with(request)
-          expect(dispatcher).to receive(:recv_packet)
+          expect(smb3_client).to receive(:send_packet).with(request, encrypt: false)
+          expect(smb3_client).to receive(:recv_packet).with(encrypt: false)
           smb3_client.send_recv(request)
         end
       end
@@ -262,17 +300,15 @@ RSpec.describe RubySMB::Client do
       context 'with a NegotiateRequest' do
         it 'does not encrypt/decrypt' do
           request = RubySMB::SMB2::Packet::NegotiateRequest.new
-          expect(smb3_client).to_not receive(:send_encrypt).with(request)
-          expect(smb3_client).to_not receive(:recv_encrypt)
-          expect(dispatcher).to receive(:send_packet).with(request)
-          expect(dispatcher).to receive(:recv_packet)
+          expect(smb3_client).to receive(:send_packet).with(request, encrypt: false)
+          expect(smb3_client).to receive(:recv_packet).with(encrypt: false)
           smb3_client.send_recv(request)
         end
       end
 
       it 'encrypts and decrypts' do
-        expect(smb3_client).to receive(:send_encrypt).with(smb2_request)
-        expect(smb3_client).to receive(:recv_encrypt)
+        expect(smb3_client).to receive(:send_packet).with(smb2_request, encrypt: true)
+        expect(smb3_client).to receive(:recv_packet).with(encrypt: true)
         smb3_client.send_recv(smb2_request)
       end
 
@@ -280,11 +316,38 @@ RSpec.describe RubySMB::Client do
         it 'waits 1 second and reads/decrypts again' do
           allow(smb3_client).to receive(:is_status_pending?).and_return(true, false)
           expect(smb3_client).to receive(:sleep).with(1)
-          expect(smb3_client).to receive(:send_encrypt).with(smb2_request)
-          expect(smb3_client).to receive(:recv_encrypt).twice
+          expect(smb3_client).to receive(:send_packet).with(smb2_request, encrypt: true)
+          expect(smb3_client).to receive(:recv_packet).with(encrypt: true).twice
           smb3_client.send_recv(smb2_request)
         end
       end
+    end
+
+    it 'increments the sequence counter if signing is required and the session key exist' do
+      allow(smb2_client).to receive(:is_status_pending?).and_return(false)
+      smb2_client.signing_required = true
+      smb2_client.session_key = 'key'
+      smb2_client.sequence_counter = 0
+      smb2_client.send_recv(smb2_request)
+      expect(smb2_client.sequence_counter).to eq(1)
+    end
+
+    it 'updates #msb2_message_id with SMB2 header #credit_charge if the dialect is not 0x0202' do
+      allow(smb2_client).to receive(:is_status_pending?).and_return(false)
+      smb2_client.smb2_message_id = 0
+      smb2_client.dialect = '0x0210'
+      smb2_header.credit_charge = 5
+      smb2_client.send_recv(smb2_request)
+      expect(smb2_client.smb2_message_id).to eq(5)
+    end
+
+    it 'does not update #msb2_message_id with SMB2 header #credit_charge if the dialect is 0x0202' do
+      allow(smb2_client).to receive(:is_status_pending?).and_return(false)
+      smb2_client.smb2_message_id = 0
+      smb2_client.dialect = '0x0202'
+      smb2_header.credit_charge = 5
+      smb2_client.send_recv(smb2_request)
+      expect(smb2_client.smb2_message_id).to eq(1)
     end
   end
 
@@ -297,17 +360,17 @@ RSpec.describe RubySMB::Client do
     }
 
     it 'returns true when the response has a STATUS_PENDING status code and the async_command flag set' do
-      expect(client.is_status_pending?(response.to_binary_s)).to be true
+      expect(client.is_status_pending?(response.smb2_header)).to be true
     end
 
     it 'returns false when the response has a STATUS_PENDING status code and the async_command flag not set' do
       response.smb2_header.flags.async_command = 0
-      expect(client.is_status_pending?(response.to_binary_s)).to be false
+      expect(client.is_status_pending?(response.smb2_header)).to be false
     end
 
     it 'returns false when the response has no STATUS_PENDING status code but the async_command flag set' do
       response.smb2_header.nt_status= WindowsError::NTStatus::STATUS_SUCCESS.value
-      expect(client.is_status_pending?(response.to_binary_s)).to be false
+      expect(client.is_status_pending?(response.smb2_header)).to be false
     end
   end
 
@@ -344,35 +407,47 @@ RSpec.describe RubySMB::Client do
     end
   end
 
-  describe '#send_encrypt' do
+  describe '#send_packet' do
     let(:packet) { RubySMB::SMB2::Packet::SessionSetupRequest.new }
     before :example do
       allow(dispatcher).to receive(:send_packet)
       client.dialect = '0x0300'
     end
 
-    it 'creates a Transform request' do
-      expect(client).to receive(:smb3_encrypt).with(packet.to_binary_s)
-      client.send_encrypt(packet)
+    it 'does not encrypt the packet' do
+      expect(client).to_not receive(:smb3_encrypt)
+      client.send_packet(packet)
     end
 
-    it 'raises an EncryptionError exception if an error occurs while encrypting' do
-      allow(client).to receive(:smb3_encrypt).and_raise(RubySMB::Error::RubySMBError.new('Error'))
-      expect { client.send_encrypt(packet) }.to raise_error(
-        RubySMB::Error::EncryptionError,
-        "Error while encrypting #{packet.class.name} packet (SMB 0x0300): Error"
-      )
+    it 'sends the packet through the dispatcher' do
+      client.send_packet(packet)
+      expect(dispatcher).to have_received(:send_packet).with(packet)
     end
 
-    it 'sends the encrypted packet' do
-      encrypted_packet = double('Encrypted packet')
-      allow(client).to receive(:smb3_encrypt).and_return(encrypted_packet)
-      client.send_encrypt(packet)
-      expect(dispatcher).to have_received(:send_packet).with(encrypted_packet)
+    context 'with encryption' do
+      it 'creates a Transform request' do
+        expect(client).to receive(:smb3_encrypt).with(packet.to_binary_s)
+        client.send_packet(packet, encrypt: true)
+      end
+
+      it 'raises an EncryptionError exception if an error occurs while encrypting' do
+        allow(client).to receive(:smb3_encrypt).and_raise(RubySMB::Error::RubySMBError.new('Error'))
+        expect { client.send_packet(packet, encrypt: true) }.to raise_error(
+          RubySMB::Error::EncryptionError,
+          "Error while encrypting #{packet.class.name} packet (SMB 0x0300): Error"
+        )
+      end
+
+      it 'sends the encrypted packet' do
+        encrypted_packet = double('Encrypted packet')
+        allow(client).to receive(:smb3_encrypt).and_return(encrypted_packet)
+        client.send_packet(packet, encrypt: true)
+        expect(dispatcher).to have_received(:send_packet).with(encrypted_packet)
+      end
     end
   end
 
-  describe '#recv_encrypt' do
+  describe '#recv_packet' do
     let(:packet) { RubySMB::SMB2::Packet::SessionSetupRequest.new }
     before :example do
       allow(dispatcher).to receive(:recv_packet).and_return(packet.to_binary_s)
@@ -381,42 +456,49 @@ RSpec.describe RubySMB::Client do
     end
 
     it 'reads the response packet' do
-      client.recv_encrypt
+      client.recv_packet
       expect(dispatcher).to have_received(:recv_packet)
     end
 
-    it 'raises an EncryptionError exception if an error occurs while receiving the response' do
+    it 'raises an CommunicationError exception if an error occurs while receiving the response' do
       allow(dispatcher).to receive(:recv_packet).and_raise(RubySMB::Error::CommunicationError)
-      expect { client.recv_encrypt }.to raise_error(
-        RubySMB::Error::EncryptionError,
-        'Communication error with the remote host: RubySMB::Error::CommunicationError. '\
-        'The server supports encryption but was not able to handle the encrypted request.'
-      )
+      expect { client.recv_packet }.to raise_error(RubySMB::Error::CommunicationError)
     end
 
-    it 'parses the response as a Transform response packet' do
-      expect(RubySMB::SMB2::Packet::TransformHeader).to receive(:read).with(packet.to_binary_s)
-      client.recv_encrypt
-    end
+    context 'with encryption' do
+      it 'raises an EncryptionError exception if an error occurs while receiving the response' do
+        allow(dispatcher).to receive(:recv_packet).and_raise(RubySMB::Error::CommunicationError)
+        expect { client.recv_packet(encrypt: true) }.to raise_error(
+          RubySMB::Error::EncryptionError,
+          'Communication error with the remote host: RubySMB::Error::CommunicationError. '\
+          'The server supports encryption but was not able to handle the encrypted request.'
+        )
+      end
 
-    it 'raises an InvalidPacket exception if an error occurs while parsing the response' do
-      allow(RubySMB::SMB2::Packet::TransformHeader).to receive(:read).and_raise(IOError)
-      expect { client.recv_encrypt }.to raise_error(RubySMB::Error::InvalidPacket, 'Not a SMB2 TransformHeader packet')
-    end
+      it 'parses the response as a Transform response packet' do
+        expect(RubySMB::SMB2::Packet::TransformHeader).to receive(:read).with(packet.to_binary_s)
+        client.recv_packet(encrypt: true)
+      end
 
-    it 'decrypts the Transform response packet' do
-      transform = double('Transform header packet')
-      allow(RubySMB::SMB2::Packet::TransformHeader).to receive(:read).and_return(transform)
-      client.recv_encrypt
-      expect(client).to have_received(:smb3_decrypt).with(transform)
-    end
+      it 'raises an InvalidPacket exception if an error occurs while parsing the response' do
+        allow(RubySMB::SMB2::Packet::TransformHeader).to receive(:read).and_raise(IOError)
+        expect { client.recv_packet(encrypt: true) }.to raise_error(RubySMB::Error::InvalidPacket, 'Not a SMB2 TransformHeader packet')
+      end
 
-    it 'raises an EncryptionError exception if an error occurs while decrypting' do
-      allow(client).to receive(:smb3_decrypt).and_raise(RubySMB::Error::RubySMBError)
-      expect { client.recv_encrypt }.to raise_error(
-        RubySMB::Error::EncryptionError,
-        'Error while decrypting RubySMB::SMB2::Packet::TransformHeader packet (SMB 0x0300}): RubySMB::Error::RubySMBError'
-      )
+      it 'decrypts the Transform response packet' do
+        transform = double('Transform header packet')
+        allow(RubySMB::SMB2::Packet::TransformHeader).to receive(:read).and_return(transform)
+        client.recv_packet(encrypt: true)
+        expect(client).to have_received(:smb3_decrypt).with(transform)
+      end
+
+      it 'raises an EncryptionError exception if an error occurs while decrypting' do
+        allow(client).to receive(:smb3_decrypt).and_raise(RubySMB::Error::RubySMBError)
+        expect { client.recv_packet(encrypt: true) }.to raise_error(
+          RubySMB::Error::EncryptionError,
+          'Error while decrypting RubySMB::SMB2::Packet::TransformHeader packet (SMB 0x0300}): RubySMB::Error::RubySMBError'
+        )
+      end
     end
   end
 
@@ -667,7 +749,7 @@ RSpec.describe RubySMB::Client do
         expect(session_packet.session_header.session_packet_type).to eq RubySMB::Nbss::SESSION_REQUEST
         expect(session_packet.called_name).to eq called_name
         expect(session_packet.calling_name).to eq calling_name
-        expect(session_packet.session_header.packet_length).to eq(
+        expect(session_packet.session_header.stream_protocol_length).to eq(
           session_packet.called_name.to_binary_s.size + session_packet.calling_name.to_binary_s.size
         )
       end
@@ -1036,6 +1118,12 @@ RSpec.describe RubySMB::Client do
         it 'returns the string \'SMB2\'' do
           expect(client.parse_negotiate_response(smb2_response)).to eq ('SMB2')
         end
+
+        it 'sets #server_supports_multi_credit to true when the response has #large_mtu capability set' do
+          smb2_response.capabilities.large_mtu = 1
+          client.parse_negotiate_response(smb2_response)
+          expect(client.server_supports_multi_credit).to be true
+        end
       end
 
       context 'when SMB3 was negotiated' do
@@ -1058,6 +1146,12 @@ RSpec.describe RubySMB::Client do
 
         it 'returns the string \'SMB2\'' do
           expect(client.parse_negotiate_response(smb3_response)).to eq ('SMB3')
+        end
+
+        it 'sets #server_supports_multi_credit to true when the response has #large_mtu capability set' do
+          smb3_response.capabilities.large_mtu = 1
+          client.parse_negotiate_response(smb3_response)
+          expect(client.server_supports_multi_credit).to be true
         end
 
         context 'when the server supports encryption' do

--- a/spec/lib/ruby_smb/dispatcher/socket_spec.rb
+++ b/spec/lib/ruby_smb/dispatcher/socket_spec.rb
@@ -102,26 +102,26 @@ RSpec.describe RubySMB::Dispatcher::Socket do
       end
 
       it 'reads the number of bytes specified in the nbss header' do
-        packet_length = 10
-        session_header.packet_length = packet_length
+        stream_protocol_length = 10
+        session_header.stream_protocol_length = stream_protocol_length
         allow(RubySMB::Nbss::SessionHeader).to receive(:read).and_return(session_header)
         expect(response_socket).to receive(:read).with(4).and_return(session_header)
-        expect(response_socket).to receive(:read).with(packet_length).and_return('A' * packet_length)
+        expect(response_socket).to receive(:read).with(stream_protocol_length).and_return('A' * stream_protocol_length)
         smb_socket.recv_packet
       end
 
       context 'when the socket does not return everything the first time' do
         it 'calls #read several times until everything is returned' do
-          packet_length = 67
+          stream_protocol_length = 67
           returned_length = 10
-          session_header.packet_length = packet_length
+          session_header.stream_protocol_length = stream_protocol_length
           allow(RubySMB::Nbss::SessionHeader).to receive(:read).and_return(session_header)
 
           expect(response_socket).to receive(:read).with(4).and_return(session_header)
           loop do
-            expect(response_socket).to receive(:read).with(packet_length).and_return('A' * returned_length).once
-            packet_length -= returned_length
-            break if packet_length <= 0
+            expect(response_socket).to receive(:read).with(stream_protocol_length).and_return('A' * returned_length).once
+            stream_protocol_length -= returned_length
+            break if stream_protocol_length <= 0
           end
           smb_socket.recv_packet
         end
@@ -134,7 +134,7 @@ RSpec.describe RubySMB::Dispatcher::Socket do
 
         context 'when the SMB packet is empty' do
           it 'returns the nbss header only' do
-            session_header.packet_length = 0
+            session_header.stream_protocol_length = 0
             allow(RubySMB::Nbss::SessionHeader).to receive(:read).and_return(session_header)
             expect(smb_socket.recv_packet(full_response: true)).to eq(session_header.to_binary_s)
           end
@@ -148,7 +148,7 @@ RSpec.describe RubySMB::Dispatcher::Socket do
 
         context 'when the SMB packet is empty' do
           it 'returns an empty string' do
-            session_header.packet_length = 0
+            session_header.stream_protocol_length = 0
             allow(RubySMB::Nbss::SessionHeader).to receive(:read).and_return(session_header)
             expect(smb_socket.recv_packet(full_response: false)).to eq('')
           end

--- a/spec/lib/ruby_smb/nbss/session_header_spec.rb
+++ b/spec/lib/ruby_smb/nbss/session_header_spec.rb
@@ -2,8 +2,7 @@ RSpec.describe RubySMB::Nbss::SessionHeader do
   subject(:session_header) { described_class.new }
 
   it { is_expected.to respond_to :session_packet_type }
-  it { is_expected.to respond_to :flags }
-  it { is_expected.to respond_to :packet_length }
+  it { is_expected.to respond_to :stream_protocol_length }
 
   it 'is big endian' do
     expect(described_class.fields.instance_variable_get(:@hints)[:endian]).to eq :big
@@ -15,15 +14,9 @@ RSpec.describe RubySMB::Nbss::SessionHeader do
     end
   end
 
-  describe '#flags' do
-    it 'is a 7-bit Unsigned Integer' do
-      expect(session_header.flags).to be_a BinData::Bit7
-    end
-  end
-
-  describe '#packet_length' do
-    it 'is a 17-bit Unsigned Integer' do
-      expect(session_header.packet_length).to be_a BinData::Bit17
+  describe '#stream_protocol_length' do
+    it 'is a 24-bit Unsigned Integer' do
+      expect(session_header.stream_protocol_length).to be_a BinData::Uint24be
     end
   end
 end

--- a/spec/lib/ruby_smb/smb2/file_spec.rb
+++ b/spec/lib/ruby_smb/smb2/file_spec.rb
@@ -205,15 +205,6 @@ RSpec.describe RubySMB::SMB2::File do
         end
       end
 
-      context 'when the dialect is 0x0202' do
-        it 'reads 65536 bytes at a time with no credit charge' do
-          client.dialect = '0x0202'
-          expect(file).to receive(:read_packet).once.with(read_length: 65536, offset: 0, credit_charge: 0).and_return(big_read)
-          expect(file).to receive(:read_packet).once.with(read_length: 65536, offset: 65536, credit_charge: 0).and_return(big_read)
-          file.read(bytes: (described_class::MAX_PACKET_SIZE * 4))
-        end
-      end
-
       context 'when the server does not support multi credits' do
         it 'reads 65536 bytes at a time with no credit charge' do
           client.server_supports_multi_credit = false
@@ -223,7 +214,7 @@ RSpec.describe RubySMB::SMB2::File do
         end
       end
 
-      context 'when the dialect is not 0x0202 and the server supports multi credits' do
+      context 'when the server supports multi credits' do
         it 'reads a number of bytes equal to #server_max_read_size, with the expected credit charge' do
           credit_charge = (90000 - 1) / 65536 + 1
           client.server_max_read_size = 90000
@@ -297,16 +288,6 @@ RSpec.describe RubySMB::SMB2::File do
         file.write(data: SecureRandom.random_bytes(described_class::MAX_PACKET_SIZE + 1))
       end
 
-      context 'when the dialect is 0x0202' do
-        it 'writes 65536 bytes at a time with no credit charge' do
-          client.dialect = '0x0202'
-          data = SecureRandom.random_bytes(65536 * 2)
-          expect(file).to receive(:write_packet).once.with(data: data[0, 65536], offset: 0, credit_charge: 0)
-          expect(file).to receive(:write_packet).once.with(data: data[65536, (data.size - 65536)], offset: 65536, credit_charge: 0)
-          file.write(data: data)
-        end
-      end
-
       context 'when the server does not support multi credits' do
         it 'writes 65536 bytes at a time with no credit charge' do
           client.server_supports_multi_credit = false
@@ -317,7 +298,7 @@ RSpec.describe RubySMB::SMB2::File do
         end
       end
 
-      context 'when the dialect is not 0x0202 and the server supports multi credits' do
+      context 'when the server supports multi credits' do
         it 'reads a number of bytes equal to #server_max_write_size, with the expected credit charge' do
           data = SecureRandom.random_bytes(90000 * 2)
           credit_charge = (90000 - 1) / 65536 + 1

--- a/spec/lib/ruby_smb/smb2/file_spec.rb
+++ b/spec/lib/ruby_smb/smb2/file_spec.rb
@@ -107,6 +107,10 @@ RSpec.describe RubySMB::SMB2::File do
     it 'sets the offset of the packet' do
       expect(file.read_packet(offset: 55).offset).to eq 55
     end
+
+    it 'sets the credit_charge of the packet' do
+      expect(file.read_packet(credit_charge: 3).smb2_header.credit_charge).to eq 3
+    end
   end
 
   describe '#read' do
@@ -125,7 +129,7 @@ RSpec.describe RubySMB::SMB2::File do
       end
 
       it 'uses a single packet to read the entire file' do
-        expect(file).to receive(:read_packet).with(read_length: 108, offset: 0).and_return(small_read)
+        expect(file).to receive(:read_packet).with(read_length: 108, offset: 0, credit_charge: 0).and_return(small_read)
         expect(client).to receive(:send_recv).with(small_read, encrypt: false).and_return 'fake data'
         expect(RubySMB::SMB2::Packet::ReadResponse).to receive(:read).with('fake data').and_return(small_response)
         expect(file.read).to eq 'fake data'
@@ -161,14 +165,15 @@ RSpec.describe RubySMB::SMB2::File do
       }
 
       before :example do
+        client.server_supports_multi_credit = 1
         allow(file).to receive(:read_packet)
         allow(client).to receive(:send_recv)
         allow(RubySMB::SMB2::Packet::ReadResponse).to receive(:read).and_return(big_response)
       end
 
-      it 'uses a multiple packet to read the file in chunks' do
-        expect(file).to receive(:read_packet).once.with(read_length: described_class::MAX_PACKET_SIZE, offset: 0).and_return(big_read)
-        expect(file).to receive(:read_packet).once.with(read_length: described_class::MAX_PACKET_SIZE, offset: described_class::MAX_PACKET_SIZE).and_return(big_read)
+      it 'uses multiple packets to read the file in chunks' do
+        expect(file).to receive(:read_packet).once.with(read_length: described_class::MAX_PACKET_SIZE, offset: 0, credit_charge: 1).and_return(big_read)
+        expect(file).to receive(:read_packet).once.with(read_length: described_class::MAX_PACKET_SIZE, offset: described_class::MAX_PACKET_SIZE, credit_charge: 1).and_return(big_read)
         expect(client).to receive(:send_recv).twice.and_return 'fake data'
         expect(RubySMB::SMB2::Packet::ReadResponse).to receive(:read).twice.with('fake data').and_return(big_response)
         file.read(bytes: (described_class::MAX_PACKET_SIZE * 2))
@@ -184,7 +189,7 @@ RSpec.describe RubySMB::SMB2::File do
 
       context 'when the second response is not valid' do
         it 'raise an InvalidPacket exception' do
-          allow(file).to receive(:read_packet).with(read_length: described_class::MAX_PACKET_SIZE, offset: described_class::MAX_PACKET_SIZE) do
+          allow(file).to receive(:read_packet).with(read_length: described_class::MAX_PACKET_SIZE, offset: described_class::MAX_PACKET_SIZE, credit_charge: 1) do
             big_response.smb2_header.command = RubySMB::SMB2::Commands::LOGOFF
           end
           expect { file.read(bytes: (described_class::MAX_PACKET_SIZE * 2)) }.to raise_error(RubySMB::Error::InvalidPacket)
@@ -193,10 +198,38 @@ RSpec.describe RubySMB::SMB2::File do
 
       context 'when the second response status code is not STATUS_SUCCESS' do
         it 'raise an UnexpectedStatusCode exception' do
-          allow(file).to receive(:read_packet).with(read_length: described_class::MAX_PACKET_SIZE, offset: described_class::MAX_PACKET_SIZE) do
+          allow(file).to receive(:read_packet).with(read_length: described_class::MAX_PACKET_SIZE, offset: described_class::MAX_PACKET_SIZE, credit_charge: 1) do
             big_response.smb2_header.nt_status = WindowsError::NTStatus::STATUS_INVALID_HANDLE.value
           end
           expect { file.read(bytes: (described_class::MAX_PACKET_SIZE * 2)) }.to raise_error(RubySMB::Error::UnexpectedStatusCode)
+        end
+      end
+
+      context 'when the dialect is 0x0202' do
+        it 'reads 65536 bytes at a time with no credit charge' do
+          client.dialect = '0x0202'
+          expect(file).to receive(:read_packet).once.with(read_length: 65536, offset: 0, credit_charge: 0).and_return(big_read)
+          expect(file).to receive(:read_packet).once.with(read_length: 65536, offset: 65536, credit_charge: 0).and_return(big_read)
+          file.read(bytes: (described_class::MAX_PACKET_SIZE * 4))
+        end
+      end
+
+      context 'when the server does not support multi credits' do
+        it 'reads 65536 bytes at a time with no credit charge' do
+          client.server_supports_multi_credit = false
+          expect(file).to receive(:read_packet).once.with(read_length: 65536, offset: 0, credit_charge: 0).and_return(big_read)
+          expect(file).to receive(:read_packet).once.with(read_length: 65536, offset: 65536, credit_charge: 0).and_return(big_read)
+          file.read(bytes: (described_class::MAX_PACKET_SIZE * 4))
+        end
+      end
+
+      context 'when the dialect is not 0x0202 and the server supports multi credits' do
+        it 'reads a number of bytes equal to #server_max_read_size, with the expected credit charge' do
+          credit_charge = (90000 - 1) / 65536 + 1
+          client.server_max_read_size = 90000
+          expect(file).to receive(:read_packet).once.with(read_length: 90000, offset: 0, credit_charge: credit_charge).and_return(big_read)
+          expect(file).to receive(:read_packet).once.with(read_length: (described_class::MAX_PACKET_SIZE * 4 - 90000), offset: 90000, credit_charge: credit_charge).and_return(big_read)
+          file.read(bytes: (described_class::MAX_PACKET_SIZE * 4))
         end
       end
     end
@@ -222,6 +255,10 @@ RSpec.describe RubySMB::SMB2::File do
     it 'sets the buffer on the packet' do
       expect(file.write_packet(data:'hello').buffer).to eq 'hello'
     end
+
+    it 'sets the credit_charge on the packet header' do
+      expect(file.write_packet(credit_charge: 5).smb2_header.credit_charge).to eq 5
+    end
   end
 
   describe '#write' do
@@ -242,6 +279,11 @@ RSpec.describe RubySMB::SMB2::File do
     end
 
     context 'for a large write' do
+      before :example do
+        allow(client).to receive(:send_recv).and_return(write_response.to_binary_s)
+        client.server_supports_multi_credit = 1
+      end
+
       it 'sends multiple packets' do
         expect(client).to receive(:send_recv).twice.and_return(write_response.to_binary_s)
         file.write(data: SecureRandom.random_bytes(described_class::MAX_PACKET_SIZE + 1))
@@ -253,6 +295,37 @@ RSpec.describe RubySMB::SMB2::File do
         file.tree_connect_encrypt_data = true
         expect(client).to receive(:send_recv).twice.with(write_request, encrypt: true).and_return(write_response.to_binary_s)
         file.write(data: SecureRandom.random_bytes(described_class::MAX_PACKET_SIZE + 1))
+      end
+
+      context 'when the dialect is 0x0202' do
+        it 'writes 65536 bytes at a time with no credit charge' do
+          client.dialect = '0x0202'
+          data = SecureRandom.random_bytes(65536 * 2)
+          expect(file).to receive(:write_packet).once.with(data: data[0, 65536], offset: 0, credit_charge: 0)
+          expect(file).to receive(:write_packet).once.with(data: data[65536, (data.size - 65536)], offset: 65536, credit_charge: 0)
+          file.write(data: data)
+        end
+      end
+
+      context 'when the server does not support multi credits' do
+        it 'writes 65536 bytes at a time with no credit charge' do
+          client.server_supports_multi_credit = false
+          data = SecureRandom.random_bytes(65536 * 2)
+          expect(file).to receive(:write_packet).once.with(data: data[0, 65536], offset: 0, credit_charge: 0)
+          expect(file).to receive(:write_packet).once.with(data: data[65536, (data.size - 65536)], offset: 65536, credit_charge: 0)
+          file.write(data: data)
+        end
+      end
+
+      context 'when the dialect is not 0x0202 and the server supports multi credits' do
+        it 'reads a number of bytes equal to #server_max_write_size, with the expected credit charge' do
+          data = SecureRandom.random_bytes(90000 * 2)
+          credit_charge = (90000 - 1) / 65536 + 1
+          client.server_max_write_size = 90000
+          expect(file).to receive(:write_packet).once.with(data: data[0, 90000], offset: 0, credit_charge: credit_charge)
+          expect(file).to receive(:write_packet).once.with(data: data[90000, (data.size - 90000)], offset: 90000, credit_charge: credit_charge)
+          file.write(data: data)
+        end
       end
     end
 


### PR DESCRIPTION
This PR add the following fixes and improvements:
- Add the missing Credit Charge logic to SMB2
- Fix NBSS header
- Add missing SMB1 Process ID
- Refactor `send_recv` to avoid code duplication

It also updates the specs accordingly.

## Verification
- [x] Try to read a file bigger than 64KB with: `ruby examples/read_file.rb <host ip> <username> <password> <share> <file name>`
- [x] **Verify** the file is read without error
- [x] Run the query service example script against Windows XP: `ruby examples/query_service_status.rb <host ip> <username> <password> RemoteRegistry`
- [x] **Verify** there is no error and the service status is returned

## Scenarios
### Credit Charge fix
First, check the file size:
```
$ ruby examples/list_directory.rb 192.168.3.22 msfuser mypasswd ADMIN$ test 2
SMB2 : (0x00000000) STATUS_SUCCESS: The operation completed successfully.
Connected to \\192.168.3.22\ADMIN$ successfully!
FILE: .
	SIZE(BYTES):0
	SIZE_ON_DISK(BYTES):0
	CREATED:2020-08-13T18:12:05+02:00
	ACCESSED:2020-08-13T18:12:26+02:00
	CHANGED:2020-08-13T18:12:26+02:00

FILE: ..
	SIZE(BYTES):0
	SIZE_ON_DISK(BYTES):0
	CREATED:2020-08-13T18:12:05+02:00
	ACCESSED:2020-08-13T18:12:26+02:00
	CHANGED:2020-08-13T18:12:26+02:00

FILE: 1lzbtVcI.tmp
	SIZE(BYTES):258048
	SIZE_ON_DISK(BYTES):258048
	CREATED:2020-08-10T20:56:00+02:00
	ACCESSED:2020-08-13T18:09:33+02:00
	CHANGED:2020-08-13T18:12:26+02:00
```
`1lzbtVcI.tmp` size is 258048 bytes (>64KB).

Then try to read it:
- Before this fix
```
$ ruby examples/read_file.rb 192.168.3.22 msfuser mypasswd ADMIN$ test\\1lzbtVcI.tmp
SMB2 : (0x00000000) STATUS_SUCCESS: The operation completed successfully.
Connected to \\192.168.3.22\ADMIN$ successfully!
Traceback (most recent call last):
	1: from examples/read_file.rb:39:in `<main>'
/opt/ruby_smb/lib/ruby_smb/smb2/file.rb:136:in `read': The server responded with an unexpected status code: STATUS_INVALID_PARAMETER (RubySMB::Error::UnexpectedStatusCode)
```
The read returns an `STATUS_INVALID_PARAMETER ` status. this is due to a wrong Credit Charge value in the request.

- After this fix
```
$ ruby examples/read_file.rb 192.168.3.22 msfuser mypasswd ADMIN$ test\\1lzbtVcI.tmp
SMB2 : (0x00000000) STATUS_SUCCESS: The operation completed successfully.
Connected to \\192.168.3.22\ADMIN$ successfully!
...[file content]...
```

### Missing SMB1 Process ID fix
Tested against Windows XP and the example script provided in this PR (`examples/query_service_status.rb`)
- Before this fix
```
$ ruby examples/query_service_status.rb 192.168.3.25 Administrator mypasswd RemoteRegistry
SMB1 : (0x00000000) STATUS_SUCCESS: The operation completed successfully.
Binding to \svcctl...
Bound to \svcctl
Opening Service Control Manager
Traceback (most recent call last):
	1: from examples/query_service_status.rb:34:in `<main>'
/opt/ruby_smb/lib/ruby_smb/dcerpc/svcctl.rb:285:in `open_sc_manager_w': Error returned when opening Service Control Manager (SCM): (0x000006e4) RPC_S_CANNOT_SUPPORT: The requested operation is not supported. (RubySMB::Dcerpc::Error::SvcctlError)
```

- After this fix
```
$ ruby examples/query_service_status.rb 192.168.3.25 Administrator mypasswd RemoteRegistry
SMB1 : (0x00000000) STATUS_SUCCESS: The operation completed successfully.
Binding to \svcctl...
Bound to \svcctl
Opening Service Control Manager
Service RemoteRegistry is running
Service RemoteRegistry starts automatically during system startup
```
