### PR TITLE
Fix for old samba compatibility

### DIFF
--- a/lib/ruby_smb/client.rb
+++ b/lib/ruby_smb/client.rb
@@ -411,8 +411,7 @@ module RubySMB
           raise RubySMB::Error::InvalidPacket.new(
             expected_proto: RubySMB::SMB2::SMB2_PROTOCOL_ID,
             expected_cmd:   RubySMB::SMB2::Packet::LogoffResponse::COMMAND,
-            received_proto: response.smb2_header.protocol,
-            received_cmd:   response.smb2_header.command
+            packet:         response
           )
         end
       else
@@ -423,8 +422,7 @@ module RubySMB
           raise RubySMB::Error::InvalidPacket.new(
             expected_proto: RubySMB::SMB1::SMB_PROTOCOL_ID,
             expected_cmd:   RubySMB::SMB1::Packet::LogoffResponse::COMMAND,
-            received_proto: response.smb_header.protocol,
-            received_cmd:   response.smb_header.command
+            packet:         response
           )
         end
       end

--- a/lib/ruby_smb/client.rb
+++ b/lib/ruby_smb/client.rb
@@ -473,11 +473,17 @@ module RubySMB
         break unless is_status_pending?(smb2_header)
         sleep 1
         raw_response = recv_packet(encrypt: encrypt_data)
+      rescue IOError
+        # We're expecting an SMB2 packet, but the server sent an SMB1 packet
+        # instead. This behavior has been observed with older versions of Samba
+        # when something goes wrong on the server side. So, we just ignore it
+        # and expect the caller to handle this wrong response packet.
+        break
       end unless version == 'SMB1'
 
       self.sequence_counter += 1 if signing_required && !session_key.empty?
       # update the SMB2 message ID according to the received Credit Charged
-      self.smb2_message_id += smb2_header.credit_charge - 1 if smb2_header && self.dialect != '0x0202'
+      self.smb2_message_id += smb2_header.credit_charge - 1 if smb2_header && self.server_supports_multi_credit
       raw_response
     end
 

--- a/lib/ruby_smb/client.rb
+++ b/lib/ruby_smb/client.rb
@@ -585,7 +585,7 @@ module RubySMB
     # @param [String] host
     def net_share_enum_all(host)
       tree = tree_connect("\\\\#{host}\\IPC$")
-      named_pipe = tree.open_file(filename: "srvsvc", write: true, read: true)
+      named_pipe = tree.open_pipe(filename: "srvsvc", write: true, read: true)
       named_pipe.net_share_enum_all(host)
     end
 

--- a/lib/ruby_smb/client/authentication.rb
+++ b/lib/ruby_smb/client/authentication.rb
@@ -60,8 +60,7 @@ module RubySMB
           raise RubySMB::Error::InvalidPacket.new(
             expected_proto: RubySMB::SMB1::SMB_PROTOCOL_ID,
             expected_cmd:   RubySMB::SMB1::Packet::SessionSetupLegacyResponse::COMMAND,
-            received_proto: packet.smb_header.protocol,
-            received_cmd:   packet.smb_header.command
+            packet:         packet
           )
         end
         packet
@@ -154,8 +153,7 @@ module RubySMB
           raise RubySMB::Error::InvalidPacket.new(
             expected_proto: RubySMB::SMB1::SMB_PROTOCOL_ID,
             expected_cmd:   RubySMB::SMB1::Packet::SessionSetupResponse::COMMAND,
-            received_proto: packet.smb_header.protocol,
-            received_cmd:   packet.smb_header.command
+            packet:         packet
           )
         end
         packet
@@ -168,8 +166,7 @@ module RubySMB
           raise RubySMB::Error::InvalidPacket.new(
             expected_proto: RubySMB::SMB1::SMB_PROTOCOL_ID,
             expected_cmd:   RubySMB::SMB1::Packet::SessionSetupResponse::COMMAND,
-            received_proto: packet.smb_header.protocol,
-            received_cmd:   packet.smb_header.command
+            packet:         packet
           )
         end
 
@@ -236,8 +233,7 @@ module RubySMB
           raise RubySMB::Error::InvalidPacket.new(
             expected_proto: RubySMB::SMB2::SMB2_PROTOCOL_ID,
             expected_cmd:   RubySMB::SMB2::Packet::SessionSetupResponse::COMMAND,
-            received_proto: packet.smb2_header.protocol,
-            received_cmd:   packet.smb2_header.command
+            packet:         packet
           )
         end
 
@@ -251,8 +247,7 @@ module RubySMB
           raise RubySMB::Error::InvalidPacket.new(
             expected_proto: RubySMB::SMB2::SMB2_PROTOCOL_ID,
             expected_cmd:   RubySMB::SMB2::Packet::SessionSetupResponse::COMMAND,
-            received_proto: packet.smb2_header.protocol,
-            received_cmd:   packet.smb2_header.command
+            packet:         packet
           )
         end
 

--- a/lib/ruby_smb/client/echo.rb
+++ b/lib/ruby_smb/client/echo.rb
@@ -21,8 +21,7 @@ module RubySMB
           raise RubySMB::Error::InvalidPacket.new(
             expected_proto: RubySMB::SMB1::SMB_PROTOCOL_ID,
             expected_cmd:   RubySMB::SMB1::Packet::EchoResponse::COMMAND,
-            received_proto: response.smb_header.protocol,
-            received_cmd:   response.smb_header.command
+            packet:         response
           )
         end
         response
@@ -40,8 +39,7 @@ module RubySMB
           raise RubySMB::Error::InvalidPacket.new(
             expected_proto: RubySMB::SMB2::SMB2_PROTOCOL_ID,
             expected_cmd:   RubySMB::SMB2::Packet::EchoResponse::COMMAND,
-            received_proto: response.smb2_header.protocol,
-            received_cmd:   response.smb2_header.command
+            packet:         response
           )
         end
         response

--- a/lib/ruby_smb/client/negotiation.rb
+++ b/lib/ruby_smb/client/negotiation.rb
@@ -83,16 +83,14 @@ module RubySMB
               expected_proto:  RubySMB::SMB1::SMB_PROTOCOL_ID,
               expected_cmd:    RubySMB::SMB1::Packet::NegotiateResponseExtended::COMMAND,
               expected_custom: "extended_security=1",
-              received_proto:  packet.smb_header.protocol,
-              received_cmd:    packet.smb_header.command,
+              packet:          packet,
               received_custom: "extended_security=#{extended_security}"
             )
           elsif packet.packet_smb_version == 'SMB2'
             raise RubySMB::Error::InvalidPacket.new(
               expected_proto:  RubySMB::SMB2::SMB2_PROTOCOL_ID,
               expected_cmd:    RubySMB::SMB2::Packet::NegotiateResponse::COMMAND,
-              received_proto:  packet.smb2_header.protocol,
-              received_cmd:    packet.smb2_header.command
+              packet:          packet
             )
           else
             raise RubySMB::Error::InvalidPacket, 'Unknown SMB protocol version'

--- a/lib/ruby_smb/client/tree_connect.rb
+++ b/lib/ruby_smb/client/tree_connect.rb
@@ -33,8 +33,7 @@ module RubySMB
           raise RubySMB::Error::InvalidPacket.new(
             expected_proto: RubySMB::SMB1::SMB_PROTOCOL_ID,
             expected_cmd:   RubySMB::SMB1::Packet::TreeConnectResponse::COMMAND,
-            received_proto: response.smb_header.protocol,
-            received_cmd:   response.smb_header.command
+            packet:         response
           )
         end
         unless response.status_code == WindowsError::NTStatus::STATUS_SUCCESS
@@ -73,8 +72,7 @@ module RubySMB
           raise RubySMB::Error::InvalidPacket.new(
             expected_proto: RubySMB::SMB2::SMB2_PROTOCOL_ID,
             expected_cmd:   RubySMB::SMB2::Packet::TreeConnectResponse::COMMAND,
-            received_proto: response.smb2_header.protocol,
-            received_cmd:   response.smb2_header.command
+            packet:         response
           )
         end
         unless response.status_code == WindowsError::NTStatus::STATUS_SUCCESS

--- a/lib/ruby_smb/client/utils.rb
+++ b/lib/ruby_smb/client/utils.rb
@@ -24,19 +24,23 @@ module RubySMB
         last_tree.id
       end
 
-      def open(path, disposition=RubySMB::Dispositions::FILE_OPEN, write: false, read: true)
-         file = last_tree.open_file(filename: path.sub(/^\\/, ''), write: write, read: read, disposition: disposition)
-         @last_file_id = if file.respond_to?(:guid)
-           file.guid.to_binary_s
-         elsif file.respond_to?(:fid)
-           file.fid.to_binary_s
-         end
-         @open_files[@last_file_id] = file
-         @last_file_id
+      def open(path, disposition=RubySMB::Dispositions::FILE_OPEN, write: false, read: true, pipe: false)
+        if pipe
+         file = last_tree.open_pipe(filename: path, write: write, read: read, disposition: disposition)
+        else
+         file = last_tree.open_file(filename: path, write: write, read: read, disposition: disposition)
+        end
+        @last_file_id = if file.respond_to?(:guid)
+          file.guid.to_binary_s
+        elsif file.respond_to?(:fid)
+          file.fid.to_binary_s
+        end
+        @open_files[@last_file_id] = file
+        @last_file_id
       end
 
       def create_pipe(path, disposition=RubySMB::Dispositions::FILE_OPEN_IF)
-        open(path.gsub(/\\/, ''), disposition, write: true, read: true)
+        open(path, disposition, write: true, read: true, pipe: true)
       end
 
       #Writes data to an open file handle

--- a/lib/ruby_smb/client/utils.rb
+++ b/lib/ruby_smb/client/utils.rb
@@ -31,8 +31,10 @@ module RubySMB
          file = last_tree.open_file(filename: path, write: write, read: read, disposition: disposition)
         end
         @last_file_id = if file.respond_to?(:guid)
+          # SMB2 uses guid
           file.guid.to_binary_s
         elsif file.respond_to?(:fid)
+          # SMB1 uses fid
           file.fid.to_binary_s
         end
         @open_files[@last_file_id] = file

--- a/lib/ruby_smb/client/winreg.rb
+++ b/lib/ruby_smb/client/winreg.rb
@@ -6,7 +6,7 @@ module RubySMB
         share = "\\\\#{host}\\IPC$"
         tree = @tree_connects.find {|tree| tree.share == share}
         tree = tree_connect(share) unless tree
-        named_pipe = tree.open_file(filename: "winreg", write: true, read: true)
+        named_pipe = tree.open_pipe(filename: "winreg", write: true, read: true)
         if block_given?
           res = yield named_pipe
           named_pipe.close

--- a/lib/ruby_smb/dcerpc/winreg.rb
+++ b/lib/ruby_smb/dcerpc/winreg.rb
@@ -387,7 +387,7 @@ module RubySMB
         enum_result
       ensure
         close_key(subkey_handle) if subkey_handle
-        close_key(root_key_handle) if root_key_handle
+        close_key(root_key_handle) if root_key_handle && root_key_handle != subkey_handle
       end
 
       # Enumerate the values for the specified registry key.
@@ -413,7 +413,7 @@ module RubySMB
         enum_result
       ensure
         close_key(subkey_handle) if subkey_handle
-        close_key(root_key_handle) if root_key_handle
+        close_key(root_key_handle) if root_key_handle && root_key_handle != subkey_handle
       end
 
     end

--- a/lib/ruby_smb/error.rb
+++ b/lib/ruby_smb/error.rb
@@ -23,7 +23,7 @@ module RubySMB
         elsif args.is_a? String
           super(args)
         elsif args.is_a? Hash
-          expected_proto = args[:expected_proto] ? translate_protocol(args[:expected_proto]) : "???"
+          expected_proto = args[:expected_proto] ? translate_protocol(args[:expected_proto]) : '???'
           expected_cmd = args[:expected_cmd] || '???'
           received_proto = args[:packet]&.packet_smb_version || '???'
           received_cmd = get_cmd(args[:packet]) || '???'

--- a/lib/ruby_smb/error.rb
+++ b/lib/ruby_smb/error.rb
@@ -16,6 +16,7 @@ module RubySMB
     # Raised when trying to parse raw binary into a Packet and the data
     # is invalid.
     class InvalidPacket < RubySMBError
+      attr_reader :status_code
       def initialize(args = nil)
         if args.nil?
           super
@@ -23,16 +24,18 @@ module RubySMB
           super(args)
         elsif args.is_a? Hash
           expected_proto = args[:expected_proto] ? translate_protocol(args[:expected_proto]) : "???"
-          expected_cmd = args[:expected_cmd] || "???"
-          received_proto = args[:received_proto] ? translate_protocol(args[:received_proto]) : "???"
-          received_cmd = args[:received_cmd] || "???"
+          expected_cmd = args[:expected_cmd] || '???'
+          received_proto = args[:packet]&.packet_smb_version || '???'
+          received_cmd = get_cmd(args[:packet]) || '???'
+          @status_code = args[:packet]&.status_code
           super(
             "Expecting #{expected_proto} protocol "\
             "with command=#{expected_cmd}"\
             "#{(" (" + args[:expected_custom] + ")") if args[:expected_custom]}, "\
             "got #{received_proto} protocol "\
             "with command=#{received_cmd}"\
-            "#{(" (" + args[:received_custom] + ")") if args[:received_custom]}"
+            "#{(" (" + args[:received_custom] + ")") if args[:received_custom]}"\
+            " , Status: #{args[:packet].status_code}"
           )
         else
           raise ArgumentError, "InvalidPacket expects a String or a Hash, got a #{args.class}"
@@ -50,6 +53,19 @@ module RubySMB
         end
       end
       private :translate_protocol
+
+      def get_cmd(packet)
+        return nil unless packet
+        case packet.packet_smb_version
+        when 'SMB1'
+          packet.smb_header.command
+        when 'SMB2'
+          packet.smb2_header.command
+        else
+          nil
+        end
+      end
+      private :get_cmd
     end
 
     # Raised when a response packet has a NTStatus code that was unexpected.

--- a/lib/ruby_smb/error.rb
+++ b/lib/ruby_smb/error.rb
@@ -35,7 +35,7 @@ module RubySMB
             "got #{received_proto} protocol "\
             "with command=#{received_cmd}"\
             "#{(" (" + args[:received_custom] + ")") if args[:received_custom]}"\
-            " , Status: #{args[:packet].status_code}"
+            "#{(", Status: #{@status_code}") if @status_code}"
           )
         else
           raise ArgumentError, "InvalidPacket expects a String or a Hash, got a #{args.class}"

--- a/lib/ruby_smb/smb1/file.rb
+++ b/lib/ruby_smb/smb1/file.rb
@@ -86,8 +86,7 @@ module RubySMB
           raise RubySMB::Error::InvalidPacket.new(
             expected_proto: RubySMB::SMB1::SMB_PROTOCOL_ID,
             expected_cmd:   RubySMB::SMB1::Packet::CloseResponse::COMMAND,
-            received_proto: response.smb_header.protocol,
-            received_cmd:   response.smb_header.command
+            packet:         response
           )
         end
         unless response.status_code == WindowsError::NTStatus::STATUS_SUCCESS
@@ -118,8 +117,7 @@ module RubySMB
             raise RubySMB::Error::InvalidPacket.new(
               expected_proto: RubySMB::SMB1::SMB_PROTOCOL_ID,
               expected_cmd:   RubySMB::SMB1::Packet::ReadAndxResponse::COMMAND,
-              received_proto: response.smb_header.protocol,
-              received_cmd:   response.smb_header.command
+              packet:         response
             )
           end
           unless response.status_code == WindowsError::NTStatus::STATUS_SUCCESS
@@ -167,8 +165,7 @@ module RubySMB
           raise RubySMB::Error::InvalidPacket.new(
             expected_proto: RubySMB::SMB1::SMB_PROTOCOL_ID,
             expected_cmd:   RubySMB::SMB1::Packet::ReadAndxResponse::COMMAND,
-            received_proto: response.smb_header.protocol,
-            received_cmd:   response.smb_header.command
+            packet:         response
           )
         end
         unless response.status_code == WindowsError::NTStatus::STATUS_SUCCESS
@@ -189,8 +186,7 @@ module RubySMB
           raise RubySMB::Error::InvalidPacket.new(
             expected_proto: RubySMB::SMB1::SMB_PROTOCOL_ID,
             expected_cmd:   RubySMB::SMB1::Packet::Trans2::SetFileInformationResponse::COMMAND,
-            received_proto: response.smb_header.protocol,
-            received_cmd:   response.smb_header.command
+            packet:         response
           )
         end
         response.status_code
@@ -231,8 +227,7 @@ module RubySMB
             raise RubySMB::Error::InvalidPacket.new(
               expected_proto: RubySMB::SMB1::SMB_PROTOCOL_ID,
               expected_cmd:   RubySMB::SMB1::Packet::WriteAndxResponse::COMMAND,
-              received_proto: response.smb_header.protocol,
-              received_cmd:   response.smb_header.command
+              packet:         response
             )
           end
           unless response.status_code == WindowsError::NTStatus::STATUS_SUCCESS
@@ -271,8 +266,7 @@ module RubySMB
           raise RubySMB::Error::InvalidPacket.new(
             expected_proto: RubySMB::SMB1::SMB_PROTOCOL_ID,
             expected_cmd:   RubySMB::SMB1::Packet::WriteAndxResponse::COMMAND,
-            received_proto: response.smb_header.protocol,
-            received_cmd:   response.smb_header.command
+            packet:         response
           )
         end
         response.parameter_block.count_low
@@ -290,8 +284,7 @@ module RubySMB
           raise RubySMB::Error::InvalidPacket.new(
             expected_proto: RubySMB::SMB1::SMB_PROTOCOL_ID,
             expected_cmd:   RubySMB::SMB1::Packet::Trans2::SetFileInformationResponse::COMMAND,
-            received_proto: response.smb_header.protocol,
-            received_cmd:   response.smb_header.command
+            packet:         response
           )
         end
         response.status_code

--- a/lib/ruby_smb/smb1/pipe.rb
+++ b/lib/ruby_smb/smb1/pipe.rb
@@ -43,8 +43,7 @@ module RubySMB
           raise RubySMB::Error::InvalidPacket.new(
             expected_proto: RubySMB::SMB1::SMB_PROTOCOL_ID,
             expected_cmd:   RubySMB::SMB1::Packet::Trans::PeekNmpipeRequest::COMMAND,
-            received_proto: response.smb_header.protocol,
-            received_cmd:   response.smb_header.command
+            packet:         response
           )
         end
 
@@ -102,8 +101,7 @@ module RubySMB
           raise RubySMB::Error::InvalidPacket.new(
             expected_proto: RubySMB::SMB1::SMB_PROTOCOL_ID,
             expected_cmd:   RubySMB::SMB1::Packet::Trans::TransactNmpipeResponse::COMMAND,
-            received_proto: trans_nmpipe_response.smb_header.protocol,
-            received_cmd:   trans_nmpipe_response.smb_header.command
+            packet:         trans_nmpipe_response
           )
         end
         unless [WindowsError::NTStatus::STATUS_SUCCESS,

--- a/lib/ruby_smb/smb1/pipe.rb
+++ b/lib/ruby_smb/smb1/pipe.rb
@@ -16,11 +16,11 @@ module RubySMB
       def initialize(tree:, response:, name:)
         raise ArgumentError, 'No Name Provided' if name.nil?
         case name
-        when 'srvsvc'
+        when 'srvsvc', '\\srvsvc'
           extend RubySMB::Dcerpc::Srvsvc
-        when 'winreg'
+        when 'winreg', '\\winreg'
           extend RubySMB::Dcerpc::Winreg
-        when 'svcctl'
+        when 'svcctl', '\\svcctl'
           extend RubySMB::Dcerpc::Svcctl
         end
         super(tree: tree, response: response, name: name)

--- a/lib/ruby_smb/smb1/tree.rb
+++ b/lib/ruby_smb/smb1/tree.rb
@@ -49,8 +49,7 @@ module RubySMB
           raise RubySMB::Error::InvalidPacket.new(
             expected_proto: RubySMB::SMB1::SMB_PROTOCOL_ID,
             expected_cmd:   RubySMB::SMB1::Packet::TreeDisconnectResponse::COMMAND,
-            received_proto: response.smb_header.protocol,
-            received_cmd:   response.smb_header.command
+            packet:         response
           )
         end
         response.status_code
@@ -140,15 +139,14 @@ module RubySMB
           raise RubySMB::Error::InvalidPacket.new(
             expected_proto: RubySMB::SMB1::SMB_PROTOCOL_ID,
             expected_cmd:   RubySMB::SMB1::Packet::NtCreateAndxResponse::COMMAND,
-            received_proto: response.smb_header.protocol,
-            received_cmd:   response.smb_header.command
+            packet:         response
           )
         end
         unless response.status_code == WindowsError::NTStatus::STATUS_SUCCESS
           raise RubySMB::Error::UnexpectedStatusCode, response.status_code
         end
 
-        case response.parameter_block.resource_type 
+        case response.parameter_block.resource_type
         when RubySMB::SMB1::ResourceType::BYTE_MODE_PIPE, RubySMB::SMB1::ResourceType::MESSAGE_MODE_PIPE
           RubySMB::SMB1::Pipe.new(name: filename, tree: self, response: response)
         when RubySMB::SMB1::ResourceType::DISK
@@ -200,8 +198,7 @@ module RubySMB
           raise RubySMB::Error::InvalidPacket.new(
             expected_proto: RubySMB::SMB1::SMB_PROTOCOL_ID,
             expected_cmd:   RubySMB::SMB1::Packet::Trans2::FindFirst2Response::COMMAND,
-            received_proto: response.smb_header.protocol,
-            received_cmd:   response.smb_header.command
+            packet:         response
           )
         end
         unless response.status_code == WindowsError::NTStatus::STATUS_SUCCESS
@@ -235,8 +232,7 @@ module RubySMB
             raise RubySMB::Error::InvalidPacket.new(
               expected_proto: RubySMB::SMB1::SMB_PROTOCOL_ID,
               expected_cmd:   RubySMB::SMB1::Packet::Trans2::FindNext2Response::COMMAND,
-              received_proto: response.smb_header.protocol,
-              received_cmd:   response.smb_header.command
+              packet:         response
             )
           end
           unless response.status_code == WindowsError::NTStatus::STATUS_SUCCESS

--- a/lib/ruby_smb/smb1/tree.rb
+++ b/lib/ruby_smb/smb1/tree.rb
@@ -56,6 +56,11 @@ module RubySMB
         response.status_code
       end
 
+      def open_pipe(opts)
+        opts[:filename].prepend('\\') if opts[:filename][0] != '\\'
+        open_file(opts)
+      end
+
       # Open a file on the remote share.
       #
       # @example

--- a/lib/ruby_smb/smb1/tree.rb
+++ b/lib/ruby_smb/smb1/tree.rb
@@ -59,7 +59,7 @@ module RubySMB
         # Make sure we don't modify the caller's hash options
         opts = opts.dup
         opts[:filename] = opts[:filename].dup
-        opts[:filename].prepend('\\') if opts[:filename][0] != '\\'
+        opts[:filename].prepend('\\') unless opts[:filename].start_with?('\\')
         open_file(opts)
       end
 

--- a/lib/ruby_smb/smb1/tree.rb
+++ b/lib/ruby_smb/smb1/tree.rb
@@ -56,6 +56,9 @@ module RubySMB
       end
 
       def open_pipe(opts)
+        # Make sure we don't modify the caller's hash options
+        opts = opts.dup
+        opts[:filename] = opts[:filename].dup
         opts[:filename].prepend('\\') if opts[:filename][0] != '\\'
         open_file(opts)
       end

--- a/lib/ruby_smb/smb2/file.rb
+++ b/lib/ruby_smb/smb2/file.rb
@@ -95,8 +95,7 @@ module RubySMB
           raise RubySMB::Error::InvalidPacket.new(
             expected_proto: RubySMB::SMB2::SMB2_PROTOCOL_ID,
             expected_cmd:   RubySMB::SMB2::Packet::CloseResponse::COMMAND,
-            received_proto: response.smb2_header.protocol,
-            received_cmd:   response.smb2_header.command
+            packet:         response
           )
         end
         unless response.status_code == WindowsError::NTStatus::STATUS_SUCCESS
@@ -130,8 +129,7 @@ module RubySMB
           raise RubySMB::Error::InvalidPacket.new(
             expected_proto: RubySMB::SMB2::SMB2_PROTOCOL_ID,
             expected_cmd:   RubySMB::SMB2::Packet::ReadResponse::COMMAND,
-            received_proto: response.smb2_header.protocol,
-            received_cmd:   response.smb2_header.command
+            packet:         response
           )
         end
         unless response.status_code == WindowsError::NTStatus::STATUS_SUCCESS
@@ -153,8 +151,7 @@ module RubySMB
             raise RubySMB::Error::InvalidPacket.new(
               expected_proto: RubySMB::SMB2::SMB2_PROTOCOL_ID,
               expected_cmd:   RubySMB::SMB2::Packet::ReadResponse::COMMAND,
-              received_proto: response.smb2_header.protocol,
-              received_cmd:   response.smb2_header.command
+              packet:         response
             )
           end
           unless response.status_code == WindowsError::NTStatus::STATUS_SUCCESS
@@ -189,8 +186,7 @@ module RubySMB
           raise RubySMB::Error::InvalidPacket.new(
             expected_proto: RubySMB::SMB2::SMB2_PROTOCOL_ID,
             expected_cmd:   RubySMB::SMB2::Packet::ReadResponse::COMMAND,
-            received_proto: response.smb2_header.protocol,
-            received_cmd:   response.smb2_header.command
+            packet:         response
           )
         end
         unless response.status_code == WindowsError::NTStatus::STATUS_SUCCESS
@@ -210,8 +206,7 @@ module RubySMB
           raise RubySMB::Error::InvalidPacket.new(
             expected_proto: RubySMB::SMB2::SMB2_PROTOCOL_ID,
             expected_cmd:   RubySMB::SMB2::Packet::SetInfoResponse::COMMAND,
-            received_proto: response.smb2_header.protocol,
-            received_cmd:   response.smb2_header.command
+            packet:         response
           )
         end
         response.smb2_header.nt_status.to_nt_status
@@ -262,8 +257,7 @@ module RubySMB
             raise RubySMB::Error::InvalidPacket.new(
               expected_proto: RubySMB::SMB2::SMB2_PROTOCOL_ID,
               expected_cmd:   RubySMB::SMB2::Packet::WriteResponse::COMMAND,
-              received_proto: response.smb2_header.protocol,
-              received_cmd:   response.smb2_header.command
+              packet:         response
             )
           end
           status        = response.smb2_header.nt_status.to_nt_status
@@ -297,8 +291,7 @@ module RubySMB
           raise RubySMB::Error::InvalidPacket.new(
             expected_proto: RubySMB::SMB2::SMB2_PROTOCOL_ID,
             expected_cmd:   RubySMB::SMB2::Packet::WriteResponse::COMMAND,
-            received_proto: response.smb2_header.protocol,
-            received_cmd:   response.smb2_header.command
+            packet:         response
           )
         end
         unless response.status_code == WindowsError::NTStatus::STATUS_SUCCESS
@@ -319,8 +312,7 @@ module RubySMB
           raise RubySMB::Error::InvalidPacket.new(
             expected_proto: RubySMB::SMB2::SMB2_PROTOCOL_ID,
             expected_cmd:   RubySMB::SMB2::Packet::SetInfoResponse::COMMAND,
-            received_proto: response.smb2_header.protocol,
-            received_cmd:   response.smb2_header.command
+            packet:         response
           )
         end
         response.smb2_header.nt_status.to_nt_status

--- a/lib/ruby_smb/smb2/pipe.rb
+++ b/lib/ruby_smb/smb2/pipe.rb
@@ -42,8 +42,7 @@ module RubySMB
           raise RubySMB::Error::InvalidPacket.new(
             expected_proto: RubySMB::SMB2::SMB2_PROTOCOL_ID,
             expected_cmd:   RubySMB::SMB2::Packet::IoctlResponse::COMMAND,
-            received_proto: response.smb2_header.protocol,
-            received_cmd:   response.smb2_header.command
+            packet:         response
           )
         end
 
@@ -100,8 +99,7 @@ module RubySMB
           raise RubySMB::Error::InvalidPacket.new(
             expected_proto: RubySMB::SMB2::SMB2_PROTOCOL_ID,
             expected_cmd:   RubySMB::SMB2::Packet::IoctlRequest::COMMAND,
-            received_proto: ioctl_response.smb2_header.protocol,
-            received_cmd:   ioctl_response.smb2_header.command
+            packet:         ioctl_response
           )
         end
         unless [WindowsError::NTStatus::STATUS_SUCCESS,

--- a/lib/ruby_smb/smb2/tree.rb
+++ b/lib/ruby_smb/smb2/tree.rb
@@ -50,8 +50,7 @@ module RubySMB
           raise RubySMB::Error::InvalidPacket.new(
             expected_proto: RubySMB::SMB2::SMB2_PROTOCOL_ID,
             expected_cmd:   RubySMB::SMB2::Packet::TreeDisconnectResponse::COMMAND,
-            received_proto: response.smb2_header.protocol,
-            received_cmd:   response.smb2_header.command
+            packet:         response
           )
         end
         response.status_code
@@ -113,8 +112,7 @@ module RubySMB
           raise RubySMB::Error::InvalidPacket.new(
             expected_proto: RubySMB::SMB2::SMB2_PROTOCOL_ID,
             expected_cmd:   RubySMB::SMB2::Packet::CreateResponse::COMMAND,
-            received_proto: response.smb2_header.protocol,
-            received_cmd:   response.smb2_header.command
+            packet:         response
           )
         end
         unless response.status_code == WindowsError::NTStatus::STATUS_SUCCESS
@@ -172,8 +170,7 @@ module RubySMB
             raise RubySMB::Error::InvalidPacket.new(
               expected_proto: RubySMB::SMB2::SMB2_PROTOCOL_ID,
               expected_cmd:   RubySMB::SMB2::Packet::QueryDirectoryResponse::COMMAND,
-              received_proto: directory_response.smb2_header.protocol,
-              received_cmd:   directory_response.smb2_header.command
+              packet:         directory_response
             )
           end
 
@@ -217,8 +214,7 @@ module RubySMB
           raise RubySMB::Error::InvalidPacket.new(
             expected_proto: RubySMB::SMB2::SMB2_PROTOCOL_ID,
             expected_cmd:   RubySMB::SMB2::Packet::CreateResponse::COMMAND,
-            received_proto: response.smb2_header.protocol,
-            received_cmd:   response.smb2_header.command
+            packet:         response
           )
         end
         unless response.status_code == WindowsError::NTStatus::STATUS_SUCCESS

--- a/lib/ruby_smb/smb2/tree.rb
+++ b/lib/ruby_smb/smb2/tree.rb
@@ -57,6 +57,9 @@ module RubySMB
       end
 
       def open_pipe(opts)
+        # Make sure we don't modify the caller's hash options
+        opts = opts.dup
+        opts[:filename] = opts[:filename].dup
         opts[:filename] = opts[:filename][1..-1] if opts[:filename][0] == '\\'
         open_file(opts)
       end

--- a/lib/ruby_smb/smb2/tree.rb
+++ b/lib/ruby_smb/smb2/tree.rb
@@ -57,6 +57,11 @@ module RubySMB
         response.status_code
       end
 
+      def open_pipe(opts)
+        opts[:filename] = opts[:filename][1..-1] if opts[:filename][0] == '\\'
+        open_file(opts)
+      end
+
       def open_file(filename:, attributes: nil, options: nil, disposition: RubySMB::Dispositions::FILE_OPEN,
                     impersonation: RubySMB::ImpersonationLevels::SEC_IMPERSONATE, read: true, write: false, delete: false)
 

--- a/lib/ruby_smb/smb2/tree.rb
+++ b/lib/ruby_smb/smb2/tree.rb
@@ -60,7 +60,7 @@ module RubySMB
         # Make sure we don't modify the caller's hash options
         opts = opts.dup
         opts[:filename] = opts[:filename].dup
-        opts[:filename] = opts[:filename][1..-1] if opts[:filename][0] == '\\'
+        opts[:filename] = opts[:filename][1..-1] if opts[:filename].start_with? '\\'
         open_file(opts)
       end
 

--- a/spec/lib/ruby_smb/dcerpc/winreg_spec.rb
+++ b/spec/lib/ruby_smb/dcerpc/winreg_spec.rb
@@ -669,6 +669,12 @@ RSpec.describe RubySMB::Dcerpc::Winreg do
       expect(winreg).to have_received(:close_key).with(root_key_handle)
     end
 
+    it 'only closes the key once when there is no subkey' do
+      winreg.enum_registry_key(root_key)
+      expect(winreg).to have_received(:close_key).once
+      expect(winreg).to have_received(:close_key).with(root_key_handle)
+    end
+
     it 'returns the expected array of enumerated keys' do
       key1 = 'key1'
       key2 = 'key2'
@@ -739,6 +745,12 @@ RSpec.describe RubySMB::Dcerpc::Winreg do
     it 'closes the key' do
       winreg.enum_registry_values(key)
       expect(winreg).to have_received(:close_key).with(subkey_handle)
+      expect(winreg).to have_received(:close_key).with(root_key_handle)
+    end
+
+    it 'only closes the key once when there is no subkey' do
+      winreg.enum_registry_values(root_key)
+      expect(winreg).to have_received(:close_key).once
       expect(winreg).to have_received(:close_key).with(root_key_handle)
     end
 

--- a/spec/lib/ruby_smb/error_spec.rb
+++ b/spec/lib/ruby_smb/error_spec.rb
@@ -9,16 +9,45 @@ RSpec.describe RubySMB::Error::InvalidPacket do
   end
 
   context 'with a Hash' do
-    it 'outputs the expected error message' do
-      ex = described_class.new(
+    let(:ex) do
+      described_class.new(
         expected_proto:  RubySMB::SMB1::SMB_PROTOCOL_ID,
         expected_cmd:    RubySMB::SMB1::Packet::NegotiateResponseExtended::COMMAND,
         expected_custom: "extended_security=1",
-        received_proto:  RubySMB::SMB2::SMB2_PROTOCOL_ID,
-        received_cmd:    RubySMB::SMB2::Packet::NegotiateResponse::COMMAND,
+        packet:          packet,
         received_custom: "extended_security=0"
       )
-      expect(ex.to_s).to eq('Expecting SMB1 protocol with command=114 (extended_security=1), got SMB2 protocol with command=0 (extended_security=0)')
+    end
+
+    context 'with an SMB2 packet' do
+      let(:packet) { RubySMB::SMB2::Packet::NegotiateResponse.new }
+
+      it 'outputs the expected error message' do
+        expect(ex.to_s).to eq('Expecting SMB1 protocol with command=114 (extended_security=1), got SMB2 protocol with command=0 (extended_security=0), Status: (0x00000000) STATUS_SUCCESS: The operation completed successfully.')
+      end
+    end
+
+    context 'with an SMB1 packet' do
+      let(:packet) { RubySMB::SMB1::Packet::ReadAndxRequest.new }
+
+      it 'outputs the expected error message' do
+        expect(ex.to_s).to eq('Expecting SMB1 protocol with command=114 (extended_security=1), got SMB1 protocol with command=46 (extended_security=0), Status: (0x00000000) STATUS_SUCCESS: The operation completed successfully.')
+      end
+    end
+
+    context 'without packet' do
+      let(:ex) do
+        described_class.new(
+          expected_proto:  RubySMB::SMB1::SMB_PROTOCOL_ID,
+          expected_cmd:    RubySMB::SMB1::Packet::NegotiateResponseExtended::COMMAND,
+          expected_custom: "extended_security=1",
+          received_custom: "extended_security=0"
+        )
+      end
+
+      it 'outputs the expected error message' do
+        expect(ex.to_s).to eq('Expecting SMB1 protocol with command=114 (extended_security=1), got ??? protocol with command=??? (extended_security=0)')
+      end
     end
   end
 

--- a/spec/lib/ruby_smb/generic_packet_spec.rb
+++ b/spec/lib/ruby_smb/generic_packet_spec.rb
@@ -88,6 +88,13 @@ RSpec.describe RubySMB::GenericPacket do
         packet = RubySMB::SMB2::Packet::NegotiateResponse.read(smb2_error_packet.to_binary_s)
         expect(packet.original_command).to eq RubySMB::SMB2::Packet::NegotiateResponse::COMMAND
       end
+
+      context 'when the server returns an SMB1 error packet' do
+        let(:smb1_error_packet) { RubySMB::SMB1::Packet::EmptyPacket.new }
+        it 'returns the empty packet instead of the asked for class' do
+          expect(RubySMB::SMB2::Packet::NegotiateResponse.read(smb1_error_packet.to_binary_s)).to be_a RubySMB::SMB1::Packet::EmptyPacket
+        end
+      end
     end
   end
 

--- a/spec/lib/ruby_smb/smb1/file_spec.rb
+++ b/spec/lib/ruby_smb/smb1/file_spec.rb
@@ -521,9 +521,7 @@ RSpec.describe RubySMB::SMB1::File do
 
     it 'raises an InvalidPacket exception if the response is not valid' do
       allow(response).to receive(:valid?).and_return(false)
-      smb_header = double('SMB Header')
-      allow(response).to receive(:smb_header).and_return(smb_header)
-      allow(smb_header).to receive_messages(:protocol => nil, :command => nil)
+      allow(response).to receive(:packet_smb_version)
       expect { file.close }.to raise_error(RubySMB::Error::InvalidPacket)
     end
 

--- a/spec/lib/ruby_smb/smb1/tree_spec.rb
+++ b/spec/lib/ruby_smb/smb1/tree_spec.rb
@@ -492,4 +492,26 @@ RSpec.describe RubySMB::SMB1::Tree do
     end
   end
 
+  describe '#open_pipe' do
+    let(:opts) { { filename: 'test', write: true } }
+    before :example do
+      allow(tree).to receive(:open_file)
+    end
+
+    it 'calls #open_file with the provided options' do
+      opts[:filename] ='\\test'
+      expect(tree).to receive(:open_file).with(opts)
+      tree.open_pipe(opts)
+    end
+
+    it 'prepends the filename with \\ if needed' do
+      expect(tree).to receive(:open_file).with( { filename: '\\test', write: true } )
+      tree.open_pipe(opts)
+    end
+
+    it 'does not modify the original option hash' do
+      tree.open_pipe(opts)
+      expect(opts).to eq( { filename: 'test', write: true } )
+    end
+  end
 end

--- a/spec/lib/ruby_smb/smb2/file_spec.rb
+++ b/spec/lib/ruby_smb/smb2/file_spec.rb
@@ -459,9 +459,7 @@ RSpec.describe RubySMB::SMB2::File do
 
     it 'raises an InvalidPacket exception if the response is not valid' do
       allow(response).to receive(:valid?).and_return(false)
-      smb2_header = double('SMB2 Header')
-      allow(response).to receive(:smb2_header).and_return(smb2_header)
-      allow(smb2_header).to receive_messages(:protocol => nil, :command => nil)
+      allow(response).to receive(:packet_smb_version)
       expect { file.close }.to raise_error(RubySMB::Error::InvalidPacket)
     end
 

--- a/spec/lib/ruby_smb/smb2/pipe_spec.rb
+++ b/spec/lib/ruby_smb/smb2/pipe_spec.rb
@@ -86,9 +86,7 @@ RSpec.describe RubySMB::SMB2::Pipe do
 
     it 'raises an InvalidPacket exception if the response is not valid' do
       allow(response).to receive(:valid?).and_return(false)
-      smb2_header = double('SMB2 Header')
-      allow(response).to receive(:smb2_header).and_return(smb2_header)
-      allow(smb2_header).to receive_messages(:protocol => nil, :command => nil)
+      allow(response).to receive(:packet_smb_version)
       expect { pipe.peek }.to raise_error(RubySMB::Error::InvalidPacket)
     end
 
@@ -261,8 +259,7 @@ RSpec.describe RubySMB::SMB2::Pipe do
 
     context 'when the response is not an IoctlResponse packet' do
       it 'raises an InvalidPacket exception' do
-        allow(ioctl_response).to receive_message_chain(:smb2_header, :protocol)
-        allow(ioctl_response).to receive_message_chain(:smb2_header, :command)
+        allow(ioctl_response).to receive(:packet_smb_version)
         allow(ioctl_response).to receive(:valid?).and_return(false)
         expect { pipe.ioctl_send_recv(dcerpc_request, options) }.to raise_error(RubySMB::Error::InvalidPacket)
       end

--- a/spec/lib/ruby_smb/smb2/tree_spec.rb
+++ b/spec/lib/ruby_smb/smb2/tree_spec.rb
@@ -531,4 +531,27 @@ RSpec.describe RubySMB::SMB2::Tree do
       end
     end
   end
+
+  describe '#open_pipe' do
+    let(:opts) { { filename: '\\test', write: true } }
+    before :example do
+      allow(tree).to receive(:open_file)
+    end
+
+    it 'calls #open_file with the provided options' do
+      opts[:filename] ='test'
+      expect(tree).to receive(:open_file).with(opts)
+      tree.open_pipe(opts)
+    end
+
+    it 'remove the leading \\ from the filename if needed' do
+      expect(tree).to receive(:open_file).with( { filename: 'test', write: true } )
+      tree.open_pipe(opts)
+    end
+
+    it 'does not modify the original option hash' do
+      tree.open_pipe(opts)
+      expect(opts).to eq( { filename: '\\test', write: true } )
+    end
+  end
 end


### PR DESCRIPTION
This fixes the issue described in https://github.com/rapid7/ruby_smb/issues/161 and other issues related to https://github.com/rapid7/metasploit-framework/issues/13976:
- Handle error packets with older Samba versions:
  It handles the case where an SMB2 error packet is expected, but the server sent an SMB1 empty packet instead. This behavior has been observed with older versions of Samba when something goes wrong on the server side.
- Handle pipe name backslash prefix according to the SMB version (see https://github.com/rapid7/ruby_smb/issues/161):
  Enforce backslash prefix for named pipe with SMB1 and remove backslash prefix for named pipe with SMB2 (if needed).
- Avoid double close_key in `winreg` enum keys and values methods.
- Improve RubySMB::Error::InvalidPacket logic.

## Verification
1. Install [Samba 3.6](https://gitlab.com/samba-team/samba/-/tree/v3-6-stable)
2. Do: `ruby examples/net_share_enum_all.rb <host> <username> <password> 1`
3. Verify it does not fail with a `STATUS_OBJECT_NAME_NOT_FOUND` error
4. Do: `ruby examples/enum_registry_key.rb <host> <username> <password> HKLM`
5. Verify it does not fail with `Not a Response packet (RubySMB::Dcerpc::Error::InvalidPacket)` error
