### PR TITLE
Minimal Netlogon Implementation For CVE-2020-1472 (AKA: Zerologon)

### DIFF
--- a/lib/ruby_smb/dcerpc.rb
+++ b/lib/ruby_smb/dcerpc.rb
@@ -19,6 +19,7 @@ module RubySMB
     require 'ruby_smb/dcerpc/response'
     require 'ruby_smb/dcerpc/bind'
     require 'ruby_smb/dcerpc/bind_ack'
+    require 'ruby_smb/dcerpc/netlogon'
 
 
     # Bind to the remote server interface endpoint.

--- a/lib/ruby_smb/dcerpc.rb
+++ b/lib/ruby_smb/dcerpc.rb
@@ -13,13 +13,14 @@ module RubySMB
     require 'ruby_smb/dcerpc/rpc_security_attributes'
     require 'ruby_smb/dcerpc/pdu_header'
     require 'ruby_smb/dcerpc/srvsvc'
-    require 'ruby_smb/dcerpc/winreg'
     require 'ruby_smb/dcerpc/svcctl'
+    require 'ruby_smb/dcerpc/winreg'
+    require 'ruby_smb/dcerpc/netlogon'
     require 'ruby_smb/dcerpc/request'
     require 'ruby_smb/dcerpc/response'
     require 'ruby_smb/dcerpc/bind'
     require 'ruby_smb/dcerpc/bind_ack'
-    require 'ruby_smb/dcerpc/netlogon'
+
 
 
     # Bind to the remote server interface endpoint.

--- a/lib/ruby_smb/dcerpc/ndr.rb
+++ b/lib/ruby_smb/dcerpc/ndr.rb
@@ -7,6 +7,9 @@ module RubySMB
       VER_MAJOR = 2
       VER_MINOR = 0
 
+      # An NDR Enum type as defined in
+      # [Transfer Syntax NDR - Enumerated Types](https://pubs.opengroup.org/onlinepubs/9629399/chap14.htm#tagcjh_19_02_05_01)
+      class NdrEnum < BinData::Int16le; end
 
       # An NDR Conformant and Varying String representation as defined in
       # [Transfer Syntax NDR - Conformant and Varying Strings](http://pubs.opengroup.org/onlinepubs/9629399/chap14.htm#tagcjh_19_03_04_02)

--- a/lib/ruby_smb/dcerpc/netlogon.rb
+++ b/lib/ruby_smb/dcerpc/netlogon.rb
@@ -13,8 +13,8 @@ module RubySMB
       NETR_SERVER_PASSWORD_SET2 = 30
 
       # see: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-nrpc/d55e2632-7163-4f6c-b662-4b870e8cc1cd
-      class NetlogonCredential < BinData::Uint8Array
-        default_parameters initial_length: 8
+      class NetlogonCredential < BinData::String
+        default_parameters length: 8
       end
 
       # see: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-nrpc/76c93227-942a-4687-ab9d-9d972ffabdab

--- a/lib/ruby_smb/dcerpc/netlogon.rb
+++ b/lib/ruby_smb/dcerpc/netlogon.rb
@@ -2,7 +2,7 @@ module RubySMB
   module Dcerpc
     module Netlogon
 
-      # https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-nrpc/592edbc8-f6f1-40c0-9ab3-fe6725ac6d7e
+      # see: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-nrpc/592edbc8-f6f1-40c0-9ab3-fe6725ac6d7e
       UUID = '12345678-1234-abcd-ef00-01234567cffb'
       VER_MAJOR = 1
       VER_MINOR = 0
@@ -30,8 +30,8 @@ module RubySMB
       require 'ruby_smb/dcerpc/netlogon/netr_server_authenticate3_request'
       require 'ruby_smb/dcerpc/netlogon/netr_server_authenticate3_response'
 
-      # Calculate the netlogon session key from the provided share secret and
-      # challenges. The share secret is an NTLM hash.
+      # Calculate the netlogon session key from the provided shared secret and
+      # challenges. The shared secret is an NTLM hash.
       #
       # @param shared_secret [String] the share secret between the client and the server
       # @param client_challenge [String] the client challenge portion of the negotiation

--- a/lib/ruby_smb/dcerpc/netlogon.rb
+++ b/lib/ruby_smb/dcerpc/netlogon.rb
@@ -30,6 +30,20 @@ module RubySMB
       require 'ruby_smb/dcerpc/netlogon/netr_server_authenticate3_request'
       require 'ruby_smb/dcerpc/netlogon/netr_server_authenticate3_response'
 
+      # Calculate the netlogon session key from the provided share secret and
+      # challenges. The share secret is an NTLM hash.
+      #
+      # @param shared_secret [String] the share secret between the client and the server
+      # @param client_challenge [String] the client challenge portion of the negotiation
+      # @param server_challenge [String] the server challenge portion of the negotiation
+      # @return [String] the session key for encryption
+      def self.calculate_session_key(shared_secret, client_challenge, server_challenge)
+        hmac = OpenSSL::HMAC.new(shared_secret, OpenSSL::Digest::SHA256.new)
+        hmac << client_challenge
+        hmac << server_challenge
+        hmac.digest.first(16)
+      end
+
     end
   end
 end

--- a/lib/ruby_smb/dcerpc/netlogon.rb
+++ b/lib/ruby_smb/dcerpc/netlogon.rb
@@ -58,10 +58,12 @@ module RubySMB
         end
       end
 
-      require 'ruby_smb/dcerpc/netlogon/netr_server_req_challenge_request'
-      require 'ruby_smb/dcerpc/netlogon/netr_server_req_challenge_response'
       require 'ruby_smb/dcerpc/netlogon/netr_server_authenticate3_request'
       require 'ruby_smb/dcerpc/netlogon/netr_server_authenticate3_response'
+      require 'ruby_smb/dcerpc/netlogon/netr_server_password_set2_request'
+      require 'ruby_smb/dcerpc/netlogon/netr_server_password_set2_response'
+      require 'ruby_smb/dcerpc/netlogon/netr_server_req_challenge_request'
+      require 'ruby_smb/dcerpc/netlogon/netr_server_req_challenge_response'
 
       # Calculate the netlogon session key from the provided shared secret and
       # challenges. The shared secret is an NTLM hash.
@@ -80,6 +82,20 @@ module RubySMB
         hmac.digest.first(16)
       end
 
+      # Encrypt the input data using the specified session key. This is used for
+      # certain Netlogon service operations including the authentication
+      # process. Per the specification, this uses AES-128-CFB8 with an all zero
+      # initialization vector.
+      #
+      # @param session_key [String] the session key to use for encryption (must be 16 bytes long)
+      # @param input_data [String] the data to encrypt
+      # @return [String] the encrypted data
+      def self.encrypt_credential(session_key, input_data)
+        cipher = OpenSSL::Cipher.new('AES-128-CFB8').encrypt
+        cipher.iv = "\x00" * 16
+        cipher.key = session_key
+        cipher.update(input_data) + cipher.final
+      end
     end
   end
 end

--- a/lib/ruby_smb/dcerpc/netlogon.rb
+++ b/lib/ruby_smb/dcerpc/netlogon.rb
@@ -13,7 +13,7 @@ module RubySMB
       NETR_SERVER_PASSWORD_SET2 = 30
 
       # see: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-nrpc/3b224201-b531-43e2-8c79-b61f6dea8640
-      class LogonSrvHandle < Ndr::NdrLpStr; end
+      class LogonsrvHandle < Ndr::NdrLpStr; end
 
       # see: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-nrpc/d55e2632-7163-4f6c-b662-4b870e8cc1cd
       class NetlogonCredential < Ndr::NdrFixedByteArray
@@ -46,6 +46,15 @@ module RubySMB
 
         def as_enum
           ALL[value]
+        end
+
+        def assign(val)
+          if val.is_a? Symbol
+            val = ALL.key(val)
+            raise ArgumentError, 'invalid value name' if val.nil?
+          end
+
+          super
         end
       end
 

--- a/lib/ruby_smb/dcerpc/netlogon.rb
+++ b/lib/ruby_smb/dcerpc/netlogon.rb
@@ -1,0 +1,23 @@
+module RubySMB
+  module Dcerpc
+    module Netlogon
+
+      # https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-nrpc/592edbc8-f6f1-40c0-9ab3-fe6725ac6d7e
+      UUID = '12345678-1234-abcd-ef00-01234567cffb'
+      VER_MAJOR = 1
+      VER_MINOR = 0
+
+      # Operation numbers
+      NETR_SERVER_REQ_CHALLENGE = 4
+      NETR_SERVER_AUTHENTICATE3 = 26
+
+      class NetlogonCredential < BinData::Uint8Array
+        default_parameters length: 8
+      end
+
+      require 'ruby_smb/dcerpc/netlogon/netr_server_req_challenge_request'
+      require 'ruby_smb/dcerpc/netlogon/netr_server_authenticate3_request'
+
+    end
+  end
+end

--- a/lib/ruby_smb/dcerpc/netlogon.rb
+++ b/lib/ruby_smb/dcerpc/netlogon.rb
@@ -10,13 +10,25 @@ module RubySMB
       # Operation numbers
       NETR_SERVER_REQ_CHALLENGE = 4
       NETR_SERVER_AUTHENTICATE3 = 26
+      NETR_SERVER_PASSWORD_SET2 = 30
 
+      # see: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-nrpc/d55e2632-7163-4f6c-b662-4b870e8cc1cd
       class NetlogonCredential < BinData::Uint8Array
-        default_parameters length: 8
+        default_parameters initial_length: 8
+      end
+
+      # see: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-nrpc/76c93227-942a-4687-ab9d-9d972ffabdab
+      class NetlogonAuthenticator < BinData::Record
+        endian :little
+
+        netlogon_credential :credential
+        uint32              :timestamp
       end
 
       require 'ruby_smb/dcerpc/netlogon/netr_server_req_challenge_request'
+      require 'ruby_smb/dcerpc/netlogon/netr_server_req_challenge_response'
       require 'ruby_smb/dcerpc/netlogon/netr_server_authenticate3_request'
+      require 'ruby_smb/dcerpc/netlogon/netr_server_authenticate3_response'
 
     end
   end

--- a/lib/ruby_smb/dcerpc/netlogon/netr_server_authenticate3_request.rb
+++ b/lib/ruby_smb/dcerpc/netlogon/netr_server_authenticate3_request.rb
@@ -10,12 +10,12 @@ module RubySMB
 
         endian :little
 
-        ndr_lp_str          :primary_name
-        ndr_string          :account_name
-        ndr_enum            :secure_channel_type
-        ndr_string          :computer_name
-        netlogon_credential :client_credential
-        uint32              :flags
+        logon_srv_handle             :primary_name
+        ndr_string                   :account_name
+        netlogon_secure_channel_type :secure_channel_type
+        ndr_string                   :computer_name
+        netlogon_credential          :client_credential
+        uint32                       :flags
 
         def initialize_instance
           super

--- a/lib/ruby_smb/dcerpc/netlogon/netr_server_authenticate3_request.rb
+++ b/lib/ruby_smb/dcerpc/netlogon/netr_server_authenticate3_request.rb
@@ -1,0 +1,28 @@
+require 'ruby_smb/dcerpc/ndr'
+
+module RubySMB
+  module Dcerpc
+    module Netlogon
+
+      # [3.5.4.4.2 NetrServerAuthenticate3 (Opnum 26)](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-nrpc/3a9ed16f-8014-45ae-80af-c0ecb06e2db9)
+      class NetrServerAuthenticate3Request < BinData::Record
+        attr_reader :opnum
+
+        endian :little
+
+        ndr_lp_str          :primary_name
+        ndr_string          :account_name
+        ndr_enum            :secure_channel_type
+        ndr_string          :computer_name
+        netlogon_credential :client_credential
+        uint32              :flags
+
+        def initialize_instance
+          super
+          @opnum = NETR_SERVER_AUTHENTICATE3
+        end
+
+      end
+    end
+  end
+end

--- a/lib/ruby_smb/dcerpc/netlogon/netr_server_authenticate3_request.rb
+++ b/lib/ruby_smb/dcerpc/netlogon/netr_server_authenticate3_request.rb
@@ -10,7 +10,7 @@ module RubySMB
 
         endian :little
 
-        logon_srv_handle             :primary_name
+        logonsrv_handle              :primary_name
         ndr_string                   :account_name
         netlogon_secure_channel_type :secure_channel_type
         ndr_string                   :computer_name

--- a/lib/ruby_smb/dcerpc/netlogon/netr_server_authenticate3_response.rb
+++ b/lib/ruby_smb/dcerpc/netlogon/netr_server_authenticate3_response.rb
@@ -13,7 +13,7 @@ module RubySMB
         netlogon_credential :server_credential
         uint32              :negotiate_flags
         uint32              :account_rid
-        uint32              :status
+        uint32              :error_status
 
         def initialize_instance
           super

--- a/lib/ruby_smb/dcerpc/netlogon/netr_server_authenticate3_response.rb
+++ b/lib/ruby_smb/dcerpc/netlogon/netr_server_authenticate3_response.rb
@@ -1,0 +1,26 @@
+require 'ruby_smb/dcerpc/ndr'
+
+module RubySMB
+  module Dcerpc
+    module Netlogon
+
+      # [3.5.4.4.2 NetrServerAuthenticate3 (Opnum 26)](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-nrpc/3a9ed16f-8014-45ae-80af-c0ecb06e2db9)
+      class NetrServerAuthenticate3Response < BinData::Record
+        attr_reader :opnum
+
+        endian :little
+
+        netlogon_credential :server_credential
+        uint32              :negotiate_flags
+        uint32              :account_rid
+        uint32              :status
+
+        def initialize_instance
+          super
+          @opnum = NETR_SERVER_AUTHENTICATE3
+        end
+
+      end
+    end
+  end
+end

--- a/lib/ruby_smb/dcerpc/netlogon/netr_server_password_set2_request.rb
+++ b/lib/ruby_smb/dcerpc/netlogon/netr_server_password_set2_request.rb
@@ -1,0 +1,27 @@
+require 'ruby_smb/dcerpc/ndr'
+
+module RubySMB
+  module Dcerpc
+    module Netlogon
+
+      # [3.5.4.4.5 NetrServerPasswordSet2 (Opnum 30)](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-nrpc/14b020a8-0bcf-4af5-ab72-cc92bc6b1d81)
+      class NetrServerPasswordSet2Request < BinData::Record
+        attr_reader :opnum
+
+        endian :little
+
+        logonsrv_handle              :primary_name
+        ndr_string                   :account_name
+        netlogon_secure_channel_type :secure_channel_type
+        ndr_string                   :computer_name
+        netlogon_authenticator       :authenticator
+        ndr_fixed_byte_array         :clear_new_password, length: 516 # this is an encrypted NL_TRUST_PASSWORD
+
+        def initialize_instance
+          super
+          @opnum = Netlogon::NETR_SERVER_PASSWORD_SET2
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby_smb/dcerpc/netlogon/netr_server_password_set2_response.rb
+++ b/lib/ruby_smb/dcerpc/netlogon/netr_server_password_set2_response.rb
@@ -1,0 +1,23 @@
+require 'ruby_smb/dcerpc/ndr'
+
+module RubySMB
+  module Dcerpc
+    module Netlogon
+
+      # [3.5.4.4.5 NetrServerPasswordSet2 (Opnum 30)](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-nrpc/14b020a8-0bcf-4af5-ab72-cc92bc6b1d81)
+      class NetrServerPasswordSet2Response < BinData::Record
+        attr_reader :opnum
+
+        endian :little
+
+        netlogon_authenticator :return_authenticator
+        uint32                 :error_status
+
+        def initialize_instance
+          super
+          @opnum = Netlogon::NETR_SERVER_PASSWORD_SET2
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby_smb/dcerpc/netlogon/netr_server_req_challenge_request.rb
+++ b/lib/ruby_smb/dcerpc/netlogon/netr_server_req_challenge_request.rb
@@ -10,7 +10,7 @@ module RubySMB
 
         endian :little
 
-        logon_srv_handle    :primary_name
+        logonsrv_handle     :primary_name
         ndr_string          :computer_name
         netlogon_credential :client_challenge
 

--- a/lib/ruby_smb/dcerpc/netlogon/netr_server_req_challenge_request.rb
+++ b/lib/ruby_smb/dcerpc/netlogon/netr_server_req_challenge_request.rb
@@ -1,0 +1,25 @@
+require 'ruby_smb/dcerpc/ndr'
+
+module RubySMB
+  module Dcerpc
+    module Netlogon
+
+      # [3.5.4.4.1 NetrServerReqChallenge (Opnum 4)](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-nrpc/5ad9db9f-7441-4ce5-8c7b-7b771e243d32)
+      class NetrServerReqChallengeRequest < BinData::Record
+        attr_reader :opnum
+
+        endian :little
+
+        ndr_lp_str          :primary_name
+        ndr_string          :computer_name
+        netlogon_credential :client_challenge
+
+        def initialize_instance
+          super
+          @opnum = NETR_SERVER_REQ_CHALLENGE
+        end
+
+      end
+    end
+  end
+end

--- a/lib/ruby_smb/dcerpc/netlogon/netr_server_req_challenge_request.rb
+++ b/lib/ruby_smb/dcerpc/netlogon/netr_server_req_challenge_request.rb
@@ -10,7 +10,7 @@ module RubySMB
 
         endian :little
 
-        ndr_lp_str          :primary_name
+        logon_srv_handle    :primary_name
         ndr_string          :computer_name
         netlogon_credential :client_challenge
 

--- a/lib/ruby_smb/dcerpc/netlogon/netr_server_req_challenge_response.rb
+++ b/lib/ruby_smb/dcerpc/netlogon/netr_server_req_challenge_response.rb
@@ -1,0 +1,24 @@
+require 'ruby_smb/dcerpc/ndr'
+
+module RubySMB
+  module Dcerpc
+    module Netlogon
+
+      # [3.5.4.4.1 NetrServerReqChallenge (Opnum 4)](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-nrpc/5ad9db9f-7441-4ce5-8c7b-7b771e243d32)
+      class NetrServerReqChallengeResponse < BinData::Record
+        attr_reader :opnum
+
+        endian :little
+
+        netlogon_credential :server_challenge
+        uint32              :status
+
+        def initialize_instance
+          super
+          @opnum = NETR_SERVER_REQ_CHALLENGE
+        end
+
+      end
+    end
+  end
+end

--- a/lib/ruby_smb/dcerpc/netlogon/netr_server_req_challenge_response.rb
+++ b/lib/ruby_smb/dcerpc/netlogon/netr_server_req_challenge_response.rb
@@ -11,7 +11,7 @@ module RubySMB
         endian :little
 
         netlogon_credential :server_challenge
-        uint32              :status
+        uint32              :error_status
 
         def initialize_instance
           super

--- a/lib/ruby_smb/dcerpc/request.rb
+++ b/lib/ruby_smb/dcerpc/request.rb
@@ -33,6 +33,7 @@ module RubySMB
         end
         choice 'Netlogon', selection: -> { opnum } do
           netr_server_authenticate3_request RubySMB::Dcerpc::Netlogon::NETR_SERVER_AUTHENTICATE3
+          netr_server_password_set2_request RubySMB::Dcerpc::Netlogon::NETR_SERVER_PASSWORD_SET2
           netr_server_req_challenge_request RubySMB::Dcerpc::Netlogon::NETR_SERVER_REQ_CHALLENGE
           string                            :default
         end

--- a/lib/ruby_smb/dcerpc/request.rb
+++ b/lib/ruby_smb/dcerpc/request.rb
@@ -31,6 +31,11 @@ module RubySMB
           save_key_request       RubySMB::Dcerpc::Winreg::REG_SAVE_KEY
           string                 :default
         end
+        choice 'Netlogon', selection: -> { opnum } do
+          netr_server_authenticate3_request RubySMB::Dcerpc::Netlogon::NETR_SERVER_AUTHENTICATE3
+          netr_server_req_challenge_request RubySMB::Dcerpc::Netlogon::NETR_SERVER_REQ_CHALLENGE
+          string                            :default
+        end
         choice 'Srvsvc', selection: -> { opnum } do
           net_share_enum_all RubySMB::Dcerpc::Srvsvc::NET_SHARE_ENUM_ALL, host: -> { host rescue '' }
           string             :default

--- a/lib/ruby_smb/smb1/pipe.rb
+++ b/lib/ruby_smb/smb1/pipe.rb
@@ -16,12 +16,14 @@ module RubySMB
       def initialize(tree:, response:, name:)
         raise ArgumentError, 'No Name Provided' if name.nil?
         case name
+        when 'netlogon', '\\netlogon'
+          extend RubySMB::Dcerpc::Netlogon
         when 'srvsvc', '\\srvsvc'
           extend RubySMB::Dcerpc::Srvsvc
-        when 'winreg', '\\winreg'
-          extend RubySMB::Dcerpc::Winreg
         when 'svcctl', '\\svcctl'
           extend RubySMB::Dcerpc::Svcctl
+        when 'winreg', '\\winreg'
+          extend RubySMB::Dcerpc::Winreg
         end
         super(tree: tree, response: response, name: name)
       end

--- a/lib/ruby_smb/smb2/pipe.rb
+++ b/lib/ruby_smb/smb2/pipe.rb
@@ -13,12 +13,14 @@ module RubySMB
       def initialize(tree:, response:, name:)
         raise ArgumentError, 'No Name Provided' if name.nil?
         case name
-        when 'srvsvc'
+        when 'netlogon', '\\netlogon'
+          extend RubySMB::Dcerpc::Netlogon
+        when 'srvsvc', '\\srvsvc'
           extend RubySMB::Dcerpc::Srvsvc
-        when 'winreg'
-          extend RubySMB::Dcerpc::Winreg
-        when 'svcctl'
+        when 'svcctl', '\\svcctl'
           extend RubySMB::Dcerpc::Svcctl
+        when 'winreg', '\\winreg'
+          extend RubySMB::Dcerpc::Winreg
         end
         super(tree: tree, response: response, name: name)
       end

--- a/spec/lib/ruby_smb/dcerpc/netlogon/netr_server_authenticate3_request_spec.rb
+++ b/spec/lib/ruby_smb/dcerpc/netlogon/netr_server_authenticate3_request_spec.rb
@@ -1,0 +1,69 @@
+RSpec.describe RubySMB::Dcerpc::Netlogon::NetrServerAuthenticate3Request do
+  subject(:packet) { described_class.new }
+
+  it { is_expected.to respond_to :primary_name }
+  it { is_expected.to respond_to :account_name }
+  it { is_expected.to respond_to :secure_channel_type }
+  it { is_expected.to respond_to :computer_name }
+  it { is_expected.to respond_to :client_credential }
+  it { is_expected.to respond_to :flags }
+
+  it 'is little endian' do
+    expect(described_class.fields.instance_variable_get(:@hints)[:endian]).to eq :little
+  end
+
+  describe '#primary_name' do
+    it 'is a LogonsrvHandle structure' do
+      expect(packet.primary_name).to be_a RubySMB::Dcerpc::Netlogon::LogonsrvHandle
+    end
+  end
+
+  describe '#account_name' do
+    it 'is a NdrString structure' do
+      expect(packet.account_name).to be_a RubySMB::Dcerpc::Ndr::NdrString
+    end
+  end
+
+  describe '#secure_channel_type' do
+    it 'is a NetlogonSecureChannelType enum' do
+      expect(packet.secure_channel_type).to be_a RubySMB::Dcerpc::Netlogon::NetlogonSecureChannelType
+    end
+  end
+
+  describe '#computer_name' do
+    it 'is a NdrString structure' do
+      expect(packet.computer_name).to be_a RubySMB::Dcerpc::Ndr::NdrString
+    end
+  end
+
+  describe '#client_credential' do
+    it 'is a NetlogonCredential structure' do
+      expect(packet.client_credential).to be_a RubySMB::Dcerpc::Netlogon::NetlogonCredential
+    end
+  end
+
+  describe '#flags' do
+    it 'is a 32-bit unsigned integer' do
+      expect(packet.flags).to be_a BinData::Uint32le
+    end
+  end
+
+  describe '#initialize_instance' do
+    it 'sets #opnum to NETR_SERVER_AUTHENTICATE3 constant' do
+      expect(packet.opnum).to eq(RubySMB::Dcerpc::Netlogon::NETR_SERVER_AUTHENTICATE3)
+    end
+  end
+
+  it 'reads its own binary representation and outputs the same packet' do
+    packet = described_class.new(
+      primary_name: 'primary_name',
+      account_name: 'account_name',
+      secure_channel_type: 0,
+      computer_name: 'computer_name',
+      client_credential: "\x00" * 8,
+      flags: rand(0xffffffff)
+    )
+    binary = packet.to_binary_s
+    expect(described_class.read(binary)).to eq(packet)
+  end
+end

--- a/spec/lib/ruby_smb/dcerpc/netlogon/netr_server_authenticate3_response_spec.rb
+++ b/spec/lib/ruby_smb/dcerpc/netlogon/netr_server_authenticate3_response_spec.rb
@@ -1,0 +1,53 @@
+RSpec.describe RubySMB::Dcerpc::Netlogon::NetrServerAuthenticate3Response do
+  subject(:packet) { described_class.new }
+
+  it { is_expected.to respond_to :server_credential }
+  it { is_expected.to respond_to :negotiate_flags }
+  it { is_expected.to respond_to :account_rid }
+  it { is_expected.to respond_to :error_status }
+
+  it 'is little endian' do
+    expect(described_class.fields.instance_variable_get(:@hints)[:endian]).to eq :little
+  end
+
+  describe '#server_credential' do
+    it 'is a NetlogonCredential structure' do
+      expect(packet.server_credential).to be_a RubySMB::Dcerpc::Netlogon::NetlogonCredential
+    end
+  end
+
+  describe '#negotiate_flags' do
+    it 'is a 32-bit unsigned integer' do
+      expect(packet.negotiate_flags).to be_a BinData::Uint32le
+    end
+  end
+
+  describe '#account_rid' do
+    it 'is a 32-bit unsigned integer' do
+      expect(packet.account_rid).to be_a BinData::Uint32le
+    end
+  end
+
+  describe '#error_status' do
+    it 'is a 32-bit unsigned integer' do
+      expect(packet.error_status).to be_a BinData::Uint32le
+    end
+  end
+
+  describe '#initialize_instance' do
+    it 'sets #opnum to NETR_SERVER_AUTHENTICATE3 constant' do
+      expect(packet.opnum).to eq(RubySMB::Dcerpc::Netlogon::NETR_SERVER_AUTHENTICATE3)
+    end
+  end
+
+  it 'reads its own binary representation and outputs the same packet' do
+    packet = described_class.new(
+      server_credential: "\x00" * 8,
+      negotiate_flags: rand(0xffffffff),
+      account_rid: rand(0xffffffff),
+      error_status: rand(0xffffffff)
+    )
+    binary = packet.to_binary_s
+    expect(described_class.read(binary)).to eq(packet)
+  end
+end

--- a/spec/lib/ruby_smb/dcerpc/netlogon/netr_server_password_set2_request_spec.rb
+++ b/spec/lib/ruby_smb/dcerpc/netlogon/netr_server_password_set2_request_spec.rb
@@ -1,0 +1,69 @@
+RSpec.describe RubySMB::Dcerpc::Netlogon::NetrServerPasswordSet2Request do
+  subject(:packet) { described_class.new }
+
+  it { is_expected.to respond_to :primary_name }
+  it { is_expected.to respond_to :account_name }
+  it { is_expected.to respond_to :secure_channel_type }
+  it { is_expected.to respond_to :computer_name }
+  it { is_expected.to respond_to :authenticator }
+  it { is_expected.to respond_to :clear_new_password }
+
+  it 'is little endian' do
+    expect(described_class.fields.instance_variable_get(:@hints)[:endian]).to eq :little
+  end
+
+  describe '#primary_name' do
+    it 'is a LogonsrvHandle structure' do
+      expect(packet.primary_name).to be_a RubySMB::Dcerpc::Netlogon::LogonsrvHandle
+    end
+  end
+
+  describe '#account_name' do
+    it 'is a NdrString structure' do
+      expect(packet.account_name).to be_a RubySMB::Dcerpc::Ndr::NdrString
+    end
+  end
+
+  describe '#secure_channel_type' do
+    it 'is a NetlogonSecureChannelType enum' do
+      expect(packet.secure_channel_type).to be_a RubySMB::Dcerpc::Netlogon::NetlogonSecureChannelType
+    end
+  end
+
+  describe '#computer_name' do
+    it 'is a NdrString structure' do
+      expect(packet.computer_name).to be_a RubySMB::Dcerpc::Ndr::NdrString
+    end
+  end
+
+  describe '#authenticator' do
+    it 'is a NetlogonAuthenticator structure' do
+      expect(packet.authenticator).to be_a RubySMB::Dcerpc::Netlogon::NetlogonAuthenticator
+    end
+  end
+
+  describe '#clear_new_password' do
+    it 'is a NdrFixedByteArray structure' do
+      expect(packet.clear_new_password).to be_a RubySMB::Dcerpc::Ndr::NdrFixedByteArray
+    end
+  end
+
+  describe '#initialize_instance' do
+    it 'sets #opnum to NETR_SERVER_PASSWORD_SET2 constant' do
+      expect(packet.opnum).to eq(RubySMB::Dcerpc::Netlogon::NETR_SERVER_PASSWORD_SET2)
+    end
+  end
+
+  it 'reads its own binary representation and outputs the same packet' do
+    packet = described_class.new(
+      primary_name: 'primary_name',
+      account_name: 'account_name',
+      secure_channel_type: 0,
+      computer_name: 'computer_name',
+      authenticator: RubySMB::Dcerpc::Netlogon::NetlogonAuthenticator.new,
+      clear_new_password: "\x00" * 516
+    )
+    binary = packet.to_binary_s
+    expect(described_class.read(binary)).to eq(packet)
+  end
+end

--- a/spec/lib/ruby_smb/dcerpc/netlogon/netr_server_password_set2_response_spec.rb
+++ b/spec/lib/ruby_smb/dcerpc/netlogon/netr_server_password_set2_response_spec.rb
@@ -1,0 +1,37 @@
+RSpec.describe RubySMB::Dcerpc::Netlogon::NetrServerPasswordSet2Response do
+  subject(:packet) { described_class.new }
+
+  it { is_expected.to respond_to :return_authenticator }
+  it { is_expected.to respond_to :error_status }
+
+  it 'is little endian' do
+    expect(described_class.fields.instance_variable_get(:@hints)[:endian]).to eq :little
+  end
+
+  describe '#return_authenticator' do
+    it 'is a NetlogonAuthenticator structure' do
+      expect(packet.return_authenticator).to be_a RubySMB::Dcerpc::Netlogon::NetlogonAuthenticator
+    end
+  end
+
+  describe '#error_status' do
+    it 'is a 32-bit unsigned integer' do
+      expect(packet.error_status).to be_a BinData::Uint32le
+    end
+  end
+
+  describe '#initialize_instance' do
+    it 'sets #opnum to NETR_SERVER_PASSWORD_SET2 constant' do
+      expect(packet.opnum).to eq(RubySMB::Dcerpc::Netlogon::NETR_SERVER_PASSWORD_SET2)
+    end
+  end
+
+  it 'reads its own binary representation and outputs the same packet' do
+    packet = described_class.new(
+      return_authenticator: RubySMB::Dcerpc::Netlogon::NetlogonAuthenticator.new,
+      error_status: rand(0xffffffff)
+    )
+    binary = packet.to_binary_s
+    expect(described_class.read(binary)).to eq(packet)
+  end
+end

--- a/spec/lib/ruby_smb/dcerpc/netlogon/netr_server_req_challenge_request_spec.rb
+++ b/spec/lib/ruby_smb/dcerpc/netlogon/netr_server_req_challenge_request_spec.rb
@@ -1,0 +1,45 @@
+RSpec.describe RubySMB::Dcerpc::Netlogon::NetrServerReqChallengeRequest do
+  subject(:packet) { described_class.new }
+
+  it { is_expected.to respond_to :primary_name }
+  it { is_expected.to respond_to :computer_name }
+  it { is_expected.to respond_to :client_challenge }
+
+  it 'is little endian' do
+    expect(described_class.fields.instance_variable_get(:@hints)[:endian]).to eq :little
+  end
+
+  describe '#primary_name' do
+    it 'is a LogonsrvHandle structure' do
+      expect(packet.primary_name).to be_a RubySMB::Dcerpc::Netlogon::LogonsrvHandle
+    end
+  end
+
+  describe '#computer_name' do
+    it 'is a NdrString structure' do
+      expect(packet.computer_name).to be_a RubySMB::Dcerpc::Ndr::NdrString
+    end
+  end
+
+  describe '#client_challenge' do
+    it 'is a NetlogonCredential structure' do
+      expect(packet.client_challenge).to be_a RubySMB::Dcerpc::Netlogon::NetlogonCredential
+    end
+  end
+
+  describe '#initialize_instance' do
+    it 'sets #opnum to NETR_SERVER_REQ_CHALLENGE constant' do
+      expect(packet.opnum).to eq(RubySMB::Dcerpc::Netlogon::NETR_SERVER_REQ_CHALLENGE)
+    end
+  end
+
+  it 'reads its own binary representation and outputs the same packet' do
+    packet = described_class.new(
+      primary_name: 'primary_name',
+      computer_name: 'computer_name',
+      client_challenge: "\x00" * 8,
+    )
+    binary = packet.to_binary_s
+    expect(described_class.read(binary)).to eq(packet)
+  end
+end

--- a/spec/lib/ruby_smb/dcerpc/netlogon/netr_server_req_challenge_response_spec.rb
+++ b/spec/lib/ruby_smb/dcerpc/netlogon/netr_server_req_challenge_response_spec.rb
@@ -1,0 +1,37 @@
+RSpec.describe RubySMB::Dcerpc::Netlogon::NetrServerReqChallengeResponse do
+  subject(:packet) { described_class.new }
+
+  it { is_expected.to respond_to :server_challenge }
+  it { is_expected.to respond_to :error_status }
+
+  it 'is little endian' do
+    expect(described_class.fields.instance_variable_get(:@hints)[:endian]).to eq :little
+  end
+
+  describe '#server_challenge' do
+    it 'is a NetlogonCredential structure' do
+      expect(packet.server_challenge).to be_a RubySMB::Dcerpc::Netlogon::NetlogonCredential
+    end
+  end
+
+  describe '#error_status' do
+    it 'is a 32-bit unsigned integer' do
+      expect(packet.error_status).to be_a BinData::Uint32le
+    end
+  end
+
+  describe '#initialize_instance' do
+    it 'sets #opnum to NETR_SERVER_REQ_CHALLENGE constant' do
+      expect(packet.opnum).to eq(RubySMB::Dcerpc::Netlogon::NETR_SERVER_REQ_CHALLENGE)
+    end
+  end
+
+  it 'reads its own binary representation and outputs the same packet' do
+    packet = described_class.new(
+      server_challenge: "\x00" * 8,
+      error_status: rand(0xffffffff)
+    )
+    binary = packet.to_binary_s
+    expect(described_class.read(binary)).to eq(packet)
+  end
+end


### PR DESCRIPTION
This implements the basic functionality for exploiting CVE-2020-1472, also known as Zerologon which is a vulnerability within the authentication process of the Netlogon service.

This adds two request and response pairs as well as a function for calculating the session key used for encryption.

I'll be opening a PR to Metasploit for the module which will leverage this later today. The easiest way to test this would be to use that module which takes advantage of all of the functionality that I add here.