### PR TITLE
Improve Compression Capabilities

### DIFF
--- a/lib/ruby_smb.rb
+++ b/lib/ruby_smb.rb
@@ -8,8 +8,8 @@ require 'windows_error'
 require 'windows_error/nt_status'
 # A packet parsing and manipulation library for the SMB1 and SMB2 protocols
 #
-# [[MS-SMB] Server Mesage Block (SMB) Protocol Version 1](https://msdn.microsoft.com/en-us/library/cc246482.aspx)
-# [[MS-SMB2] Server Mesage Block (SMB) Protocol Versions 2 and 3](https://msdn.microsoft.com/en-us/library/cc246482.aspx)
+# [[MS-SMB] Server Message Block (SMB) Protocol Version 1](https://msdn.microsoft.com/en-us/library/cc246482.aspx)
+# [[MS-SMB2] Server Message Block (SMB) Protocol Versions 2 and 3](https://msdn.microsoft.com/en-us/library/cc246482.aspx)
 module RubySMB
   require 'ruby_smb/error'
   require 'ruby_smb/dispositions'
@@ -26,4 +26,5 @@ module RubySMB
   require 'ruby_smb/smb1'
   require 'ruby_smb/client'
   require 'ruby_smb/crypto'
+  require 'ruby_smb/compression'
 end

--- a/lib/ruby_smb/client.rb
+++ b/lib/ruby_smb/client.rb
@@ -296,7 +296,7 @@ module RubySMB
       @smb3              = smb3
       @username          = username.encode('utf-8') || ''.encode('utf-8')
       @max_buffer_size   = MAX_BUFFER_SIZE
-      # These sizes will be modifed during negotiation
+      # These sizes will be modified during negotiation
       @server_max_buffer_size = SERVER_MAX_BUFFER_SIZE
       @server_max_read_size   = RubySMB::SMB2::File::MAX_PACKET_SIZE
       @server_max_write_size  = RubySMB::SMB2::File::MAX_PACKET_SIZE
@@ -431,7 +431,7 @@ module RubySMB
     end
 
     # Sends a packet and receives the raw response through the Dispatcher.
-    # It will also sign the packet if neccessary.
+    # It will also sign the packet if necessary.
     #
     # @param packet [RubySMB::GenericPacket] the request to be sent
     # @param encrypt [Boolean] true if encryption has to be enabled for this transaction

--- a/lib/ruby_smb/client/negotiation.rb
+++ b/lib/ruby_smb/client/negotiation.rb
@@ -275,8 +275,8 @@ module RubySMB
             context_type: RubySMB::SMB2::NegotiateContext::SMB2_COMPRESSION_CAPABILITIES
           )
           # Adding all possible compression algorithm even if we don't support
-          # them yet. This will force the server to disclose the support
-          # algorithms in the repsonse.
+          # them yet. This will force the server to disclose the supported
+          # algorithms in the response.
           nc.data.compression_algorithms << RubySMB::SMB2::CompressionCapabilities::LZNT1
           nc.data.compression_algorithms << RubySMB::SMB2::CompressionCapabilities::LZ77
           nc.data.compression_algorithms << RubySMB::SMB2::CompressionCapabilities::LZ77_Huffman

--- a/lib/ruby_smb/compression.rb
+++ b/lib/ruby_smb/compression.rb
@@ -1,0 +1,7 @@
+module RubySMB
+  module Compression
+
+    require 'ruby_smb/compression/lznt1'
+
+  end
+end

--- a/lib/ruby_smb/compression/lznt1.rb
+++ b/lib/ruby_smb/compression/lznt1.rb
@@ -72,7 +72,7 @@ module RubySMB
       def self.decompress(buf, length_check: true)
         out = ''
         until buf.empty?
-          header = buf[0..2].unpack1('v')
+          header = buf.unpack1('v')
           length = (header & 0xfff) + 1
           raise EncodingError, 'invalid chunk length' if length_check && length > (buf.length - 2)
 
@@ -98,7 +98,7 @@ module RubySMB
               out << chunk[0]
               chunk = chunk[1..-1]
             else
-              flag = chunk[0..2].unpack1('v')
+              flag = chunk.unpack1('v')
               pos = out.length - 1
               l_mask = 0xfff
               o_shift = 12
@@ -119,9 +119,8 @@ module RubySMB
                 out << out[-offset..-offset + length - 1]
               end
               chunk = chunk[2..-1]
-
-              break if chunk.empty?
             end
+            break if chunk.empty?
           end
         end
 

--- a/lib/ruby_smb/compression/lznt1.rb
+++ b/lib/ruby_smb/compression/lznt1.rb
@@ -1,0 +1,165 @@
+module RubySMB
+  module Compression
+    module LZNT1
+      def self.compress(buf, chunk_size: 0x1000)
+        out = ''
+        until buf.empty?
+          chunk = buf[0...chunk_size]
+          compressed = compress_chunk(chunk)
+          # chunk is compressed
+          if compressed.length < chunk.length
+            out << [ 0xb000 | (compressed.length - 1) ].pack('v')
+            out << compressed
+          else
+            out << [ 0x3000 | (chunk.length - 1) ].pack('v')
+            out << chunk
+          end
+          buf = buf[chunk_size..-1]
+          break if buf.nil?
+        end
+
+        out
+      end
+
+      def self.compress_chunk(chunk)
+        blob = chunk
+        out = ''
+        pow2 = 0x10
+        l_mask3 = 0x1002
+        o_shift = 12
+        until blob.empty?
+          bits = 0
+          tmp = ''
+          i = -1
+          loop do
+            i += 1
+            bits >>= 1
+            while pow2 < (chunk.length - blob.length)
+              pow2 <<= 1
+              l_mask3 = (l_mask3 >> 1) + 1
+              o_shift -= 1
+            end
+
+            max_len = [blob.length, l_mask3].min
+            offset, length = find(chunk[0...(chunk.length - blob.length)], blob, max_len)
+
+            # try to find more compressed pattern
+            _offset2, length2 = find(chunk[0...chunk.length - blob.length + 1], blob[1..-1], max_len)
+
+            length = 0 if length < length2
+
+            if length > 0
+              symbol = ((offset - 1) << o_shift) | (length - 3)
+              tmp << [symbol].pack('v')
+              # set the highest bit
+              bits |= 0x80
+              blob = blob[length..-1]
+            else
+              tmp += blob[0]
+              blob = blob[1..-1]
+            end
+
+            break if blob.empty? || i == 7
+          end
+
+          out << [bits >> (7 - i)].pack('C')
+          out << tmp
+        end
+
+        out
+      end
+
+      def self.decompress(buf, length_check: true)
+        out = ''
+        until buf.empty?
+          header = buf[0..2].unpack('v').first
+          length = (header & 0xfff) + 1
+          raise EncodingError, 'invalid chunk length' if length_check && length > (buf.length - 2)
+
+          chunk = buf[2...length + 2]
+          if header & 0x8000 == 0
+            out << chunk
+          else
+            out << decompress_chunk(chunk)
+          end
+          buf = buf[length + 2..-1]
+        end
+
+        out
+      end
+
+      def self.decompress_chunk(chunk)
+        out = ''
+        until chunk.empty?
+          flags = chunk[0].unpack('C').first
+          chunk = chunk[1..-1]
+          8.times do |i|
+            if (flags >> i & 1) == 0
+              out << chunk[0]
+              chunk = chunk[1..-1]
+            else
+              flag = chunk[0..2].unpack('v').first
+              pos = out.length - 1
+              l_mask = 0xfff
+              o_shift = 12
+              while pos >= 0x10
+                l_mask >>= 1
+                o_shift -= 1
+                pos >>= 1
+              end
+
+              length = (flag & l_mask) + 3
+              offset = (flag >> o_shift) + 1
+
+              if length >= offset
+                out_offset = out[-offset..-1]
+                tmp = out_offset * (0xfff / out_offset.length + 1)
+                out << tmp[0...length]
+              else
+                out << out[-offset..-offset + length - 1]
+              end
+              chunk = chunk[2..-1]
+
+              break if chunk.empty?
+            end
+          end
+        end
+
+        out
+      end
+
+      class << self
+        private
+
+        def find(src, target, max_len)
+          result_offset = 0
+          result_length = 0
+          1.upto(max_len - 1) do |i|
+            offset = src.rindex(target[0...i])
+            next if offset.nil?
+
+            tmp_offset = src.length - offset
+            tmp_length = i
+            if tmp_offset == tmp_length
+              src_offset = src[offset..-1]
+              tmp = src_offset * (0xfff / src_offset.length + 1)
+              i.upto(max_len) do |j|
+                offset = tmp.rindex(target[0...j])
+                break if offset.nil?
+
+                tmp_length = j
+              end
+            end
+
+            if tmp_length > result_length
+              result_offset = tmp_offset
+              result_length = tmp_length
+            end
+          end
+
+          result_length < 3 ? [0, 0] : [result_offset, result_length]
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby_smb/dispatcher/socket.rb
+++ b/lib/ruby_smb/dispatcher/socket.rb
@@ -55,7 +55,7 @@ module RubySMB
 
       # Read a packet off the wire and parse it into a string
       #
-      # @param full_response [Boolean] whether to include the NetBios Session Service header in the repsonse
+      # @param full_response [Boolean] whether to include the NetBios Session Service header in the response
       # @return [String] the raw response (including the NetBios Session Service header if full_response is true)
       # @raise [RubySMB::Error::NetBiosSessionService] if there's an error reading the first 4 bytes,
       #   which are assumed to be the NetBiosSessionService header.

--- a/lib/ruby_smb/smb2/packet/compression_transform_header.rb
+++ b/lib/ruby_smb/smb2/packet/compression_transform_header.rb
@@ -11,6 +11,7 @@ module RubySMB
         uint16           :compression_algorithm,            label: 'Compression Algorithm'
         uint16           :flags,                            label: 'Flags'
         uint32           :offset,                           label: 'Offset / Length'
+        array            :compressed_data,                  label: 'Compressed Data', type: :uint8, read_until: :eof
       end
 
       # An SMB2 SMB2_COMPRESSION_TRANSFORM_HEADER_PAYLOAD Packet as defined in

--- a/lib/ruby_smb/smb2/packet/compression_transform_header.rb
+++ b/lib/ruby_smb/smb2/packet/compression_transform_header.rb
@@ -3,6 +3,9 @@ module RubySMB
     module Packet
       # An SMB2 COMPRESSION_TRANSFORM_HEADER Packet as defined in
       # [2.2.42 SMB2 COMPRESSION_TRANSFORM_HEADER](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/1d435f21-9a21-4f4c-828e-624a176cf2a0)
+      # NOTE: On 2021-04-06 the official documentation split the definition of COMPRESSION_TRANSFORM_HEADER into the following two variants:
+      #   * SMB2_COMPRESSION_TRANSFORM_HEADER_CHAINED
+      #   * SMB2_COMPRESSION_TRANSFORM_HEADER_UNCHAINED
       class CompressionTransformHeader < BinData::Record
         endian :little
 

--- a/spec/lib/ruby_smb/compression/lznt1_spec.rb
+++ b/spec/lib/ruby_smb/compression/lznt1_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+RSpec.describe RubySMB::Compression::LZNT1 do
+  describe '.compress' do
+    it 'generates an empty blob when provided an empty blob' do
+      expected = "".b
+      expect(described_class.compress('')).to eq(expected)
+    end
+
+    it 'generates a compressed blob when provided a string with non-reoccurring characters' do
+      expect(described_class.compress('RubySMB')).to eq("\x060RubySMB".b)
+    end
+
+    it 'generates a compressed blob when provided a string of reoccurring characters' do
+      expect(described_class.compress("\x01" * 0x200)).to eq("\x03\xB0\x02\x01\xFC\x01".b)
+    end
+  end
+
+  describe '.decompress' do
+    it 'generates a decompressed blob for a string with non-reoccurring characters' do
+      expect(described_class.decompress("\x060RubySMB".b)).to eq('RubySMB')
+    end
+
+    it 'generates a decompressed blob for a string of reoccurring characters' do
+      expect(described_class.decompress("\x03\xB0\x02\x01\xFC\x01".b)).to eq("\x01" * 0x200)
+    end
+
+    it 'raises an EncodingError when the length is invalid' do
+      expect { described_class.decompress("\x010".b) }.to raise_error(EncodingError)
+    end
+  end
+end


### PR DESCRIPTION
This makes a few changes to allow RubySMB to be used for exploiting CVE-2020-0796 (SMBGhost). The changes include:

* Adding a `#compressed_data` field to the `CompressionTransformHeader` so the payload can be included which is required for sending this data. This mirrors how the `TransformHeader` works with the `#encrypted_data`, which is the same idea (the transformed payload needs to be included.
* Added an LZNT1 algorithm implementation along with some basic unit tests that get decent coverage. The implementation was ported to Ruby from [this Python implementation](https://github.com/you0708/lznt1).
    * The specs are intended to test blocks that are copied as-is and blocks that are compressed. They should help us identify errors we might introduce into the algorithm later on since the inputs and outputs should be deterministic.
* Fixed a whole bunch of typos I found while reading through RubySMB and working on SMBGhost.

## Testing
This will be required by the exploit that I'll be submitting to Metasploit and can be partially tested in conjunction with that. The LZNT1 compression capabilities are required as is the `#compressed_data` field.

- [ ] Make sure the unit tests pass and the code looks good, from RubySMB's perspective it's all dead code