### PR TITLE
Adds ntlm_flags & NegotiateResponseExtended

### DIFF
--- a/lib/ruby_smb/client.rb
+++ b/lib/ruby_smb/client.rb
@@ -312,7 +312,7 @@ module RubySMB
         @password,
         workstation: @local_workstation,
         domain: @domain,
-        ntlm_flags: ntlm_flags
+        flags: ntlm_flags
       )
 
       @tree_connects = []
@@ -384,7 +384,7 @@ module RubySMB
           @password,
           workstation: @local_workstation,
           domain: @domain,
-          ntlm_flags: ntlm_flags
+          flags: ntlm_flags
       )
 
       authenticate

--- a/lib/ruby_smb/client/negotiation.rb
+++ b/lib/ruby_smb/client/negotiation.rb
@@ -57,7 +57,6 @@ module RubySMB
 
       # Takes the raw response data from the server and tries
       # parse it into a valid Response packet object.
-      # This method currently assumes that all SMB1 will use Extended Security.
       #
       # @param raw_data [String] the raw binary response from the server
       # @return [RubySMB::SMB1::Packet::NegotiateResponseExtended] when the response is an SMB1 Extended Security Negotiate Response Packet
@@ -65,7 +64,12 @@ module RubySMB
       def negotiate_response(raw_data)
         response = nil
         if smb1
-          packet = RubySMB::SMB1::Packet::NegotiateResponseExtended.read raw_data
+          packet = RubySMB::SMB1::Packet::NegotiateResponse.read raw_data
+
+          if packet.smb_header.flags2.extended_security == 1
+            packet = RubySMB::SMB1::Packet::NegotiateResponseExtended.read raw_data
+          end
+
           response = packet if packet.valid?
         end
         if (smb2 || smb3) && response.nil?

--- a/lib/ruby_smb/client/negotiation.rb
+++ b/lib/ruby_smb/client/negotiation.rb
@@ -60,6 +60,7 @@ module RubySMB
       #
       # @param raw_data [String] the raw binary response from the server
       # @return [RubySMB::SMB1::Packet::NegotiateResponseExtended] when the response is an SMB1 Extended Security Negotiate Response Packet
+      # @return [RubySMB::SMB1::Packet::NegotiateResponse] when the response is an SMB1 Negotiate Response Packet
       # @return [RubySMB::SMB2::Packet::NegotiateResponse] when the response is an SMB2 Negotiate Response Packet
       def negotiate_response(raw_data)
         response = nil
@@ -78,19 +79,10 @@ module RubySMB
         end
         if response.nil?
           if packet.packet_smb_version == 'SMB1'
-            
-            if packet.parameter_block['capabilities'] && packet.parameter_block['capabilities']['extended_security']
-              extended_security = packet.parameter_block['capabilities']['extended_security']
-            else
-              extended_security = 0
-            end
-
             raise RubySMB::Error::InvalidPacket.new(
               expected_proto:  RubySMB::SMB1::SMB_PROTOCOL_ID,
-              expected_cmd:    RubySMB::SMB1::Packet::NegotiateResponseExtended::COMMAND,
-              expected_custom: "extended_security=1",
-              packet:          packet,
-              received_custom: "extended_security=#{extended_security}"
+              expected_cmd:    RubySMB::SMB1::Packet::NegotiateResponse::COMMAND,
+              packet:          packet
             )
           elsif packet.packet_smb_version == 'SMB2'
             raise RubySMB::Error::InvalidPacket.new(

--- a/lib/ruby_smb/client/negotiation.rb
+++ b/lib/ruby_smb/client/negotiation.rb
@@ -78,11 +78,13 @@ module RubySMB
         end
         if response.nil?
           if packet.packet_smb_version == 'SMB1'
-            extended_security = if packet.parameter_block['capabilities'] && packet.parameter_block['capabilities']['extended_security']
-              packet.parameter_block['capabilities']['extended_security']
+            
+            if packet.parameter_block['capabilities'] && packet.parameter_block['capabilities']['extended_security']
+              extended_security = packet.parameter_block['capabilities']['extended_security']
             else
-              0
+              extended_security = 0
             end
+
             raise RubySMB::Error::InvalidPacket.new(
               expected_proto:  RubySMB::SMB1::SMB_PROTOCOL_ID,
               expected_cmd:    RubySMB::SMB1::Packet::NegotiateResponseExtended::COMMAND,

--- a/spec/lib/ruby_smb/client_spec.rb
+++ b/spec/lib/ruby_smb/client_spec.rb
@@ -809,6 +809,18 @@ RSpec.describe RubySMB::Client do
       smb1_extended_response.to_binary_s
     }
 
+    let(:smb1_response) {
+      packet = RubySMB::SMB1::Packet::NegotiateResponse.new
+      smb1_capabilities_dup = smb1_capabilities.dup
+      smb1_capabilities_dup[:extended_security] = 0
+
+      packet.parameter_block.capabilities = smb1_capabilities_dup
+      packet
+    }
+    let(:smb1_response_raw) {
+      smb1_response.to_binary_s
+    }
+
     let(:smb2_response) { RubySMB::SMB2::Packet::NegotiateResponse.new(dialect_revision: 0x200) }
     let(:smb3_response) { RubySMB::SMB2::Packet::NegotiateResponse.new(dialect_revision: 0x300) }
 
@@ -997,8 +1009,12 @@ RSpec.describe RubySMB::Client do
 
     describe '#negotiate_response' do
       context 'with only SMB1' do
-        it 'returns a properly formed packet' do
+        it 'returns a properly formed NegotiateResponseExtended packet if extended_security is set as 1' do
           expect(smb1_client.negotiate_response(smb1_extended_response_raw)).to eq smb1_extended_response
+        end
+
+        it 'returns a properly formed NegotiateResponse packet if extended_security is set as 0' do
+          expect(smb1_client.negotiate_response(smb1_response_raw)).to eq smb1_response
         end
 
         it 'raises an exception if the response is not a SMB packet' do

--- a/spec/lib/ruby_smb/client_spec.rb
+++ b/spec/lib/ruby_smb/client_spec.rb
@@ -1015,12 +1015,6 @@ RSpec.describe RubySMB::Client do
           bogus_response.smb_header.command = 0xff
           expect { smb1_client.negotiate_response(bogus_response.to_binary_s) }.to raise_error(RubySMB::Error::InvalidPacket)
         end
-
-        it 'considers the response invalid if Extended Security is not enabled' do
-          bogus_response = smb1_extended_response
-          bogus_response.parameter_block.capabilities.extended_security = 0
-          expect { smb1_client.negotiate_response(bogus_response.to_binary_s) }.to raise_error(RubySMB::Error::InvalidPacket)
-        end
       end
 
       context 'with only SMB2' do


### PR DESCRIPTION
Required for [eternalblue_win8 port to ruby](https://github.com/rapid7/metasploit-framework/pull/15182).

Extends `Net::NTLM::Client` initializer to include `ntlm_flags`. 

Also allows `negotiate_response` to parse returning `NegotiateResponseExtended` packets into `RubySMB::SMB1::Packet::NegotiateResponseExtended`. This is a useful feature for the entire library, not just this one PR.