### PR TITLE
Add double splat operator for ruby 3.0.1 support

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -20,6 +20,7 @@ jobs:
           - 2.5
           - 2.6
           - 2.7
+          - 3.0
         test_cmd:
           - bundle exec rspec
 

--- a/lib/ruby_smb/smb1/tree.rb
+++ b/lib/ruby_smb/smb1/tree.rb
@@ -60,7 +60,7 @@ module RubySMB
         opts = opts.dup
         opts[:filename] = opts[:filename].dup
         opts[:filename].prepend('\\') unless opts[:filename].start_with?('\\')
-        open_file(opts)
+        open_file(**opts)
       end
 
       # Open a file on the remote share.

--- a/lib/ruby_smb/smb2/tree.rb
+++ b/lib/ruby_smb/smb2/tree.rb
@@ -61,7 +61,7 @@ module RubySMB
         opts = opts.dup
         opts[:filename] = opts[:filename].dup
         opts[:filename] = opts[:filename][1..-1] if opts[:filename].start_with? '\\'
-        open_file(opts)
+        open_file(**opts)
       end
 
       def open_file(filename:, attributes: nil, options: nil, disposition: RubySMB::Dispositions::FILE_OPEN,

--- a/spec/lib/ruby_smb/smb1/tree_spec.rb
+++ b/spec/lib/ruby_smb/smb1/tree_spec.rb
@@ -501,16 +501,16 @@ RSpec.describe RubySMB::SMB1::Tree do
     it 'calls #open_file with the provided options' do
       opts[:filename] ='\\test'
       expect(tree).to receive(:open_file).with(opts)
-      tree.open_pipe(opts)
+      tree.open_pipe(**opts)
     end
 
     it 'prepends the filename with \\ if needed' do
-      expect(tree).to receive(:open_file).with( { filename: '\\test', write: true } )
-      tree.open_pipe(opts)
+      expect(tree).to receive(:open_file).with(filename: '\\test', write: true)
+      tree.open_pipe(**opts)
     end
 
     it 'does not modify the original option hash' do
-      tree.open_pipe(opts)
+      tree.open_pipe(**opts)
       expect(opts).to eq( { filename: 'test', write: true } )
     end
   end

--- a/spec/lib/ruby_smb/smb2/tree_spec.rb
+++ b/spec/lib/ruby_smb/smb2/tree_spec.rb
@@ -540,17 +540,17 @@ RSpec.describe RubySMB::SMB2::Tree do
 
     it 'calls #open_file with the provided options' do
       opts[:filename] ='test'
-      expect(tree).to receive(:open_file).with(opts)
-      tree.open_pipe(opts)
+      expect(tree).to receive(:open_file).with(**opts)
+      tree.open_pipe(**opts)
     end
 
     it 'remove the leading \\ from the filename if needed' do
-      expect(tree).to receive(:open_file).with( { filename: 'test', write: true } )
-      tree.open_pipe(opts)
+      expect(tree).to receive(:open_file).with(filename: 'test', write: true)
+      tree.open_pipe(**opts)
     end
 
     it 'does not modify the original option hash' do
-      tree.open_pipe(opts)
+      tree.open_pipe(**opts)
       expect(opts).to eq( { filename: '\\test', write: true } )
     end
   end


### PR DESCRIPTION
Fixes a Ruby 3.0.1 issue for metasploit console when attempting to enumerate shares:

```
msf6 auxiliary(scanner/smb/smb_enumshares) > run

[-] 192.168.222.151:139   - Login Failed: Unable to negotiate SMB1 with the remote host: Not a valid SMB packet
[-] 192.168.222.151:      - Auxiliary failed: ArgumentError wrong number of arguments (given 1, expected 0; required keyword: filename)
[-] 192.168.222.151:      - Call stack:
[-] 192.168.222.151:      -   /Users/user/.rvm/gems/ruby-3.0.1/gems/ruby_smb-2.0.9/lib/ruby_smb/smb2/tree.rb:67:in `open_file'
[-] 192.168.222.151:      -   /Users/user/.rvm/gems/ruby-3.0.1/gems/ruby_smb-2.0.9/lib/ruby_smb/smb2/tree.rb:64:in `open_pipe'
[-] 192.168.222.151:      -   /Users/user/.rvm/gems/ruby-3.0.1/gems/ruby_smb-2.0.9/lib/ruby_smb/client/utils.rb:29:in `open'
[-] 192.168.222.151:      -   /Users/user/.rvm/gems/ruby-3.0.1/gems/ruby_smb-2.0.9/lib/ruby_smb/client/utils.rb:45:in `create_pipe'
[-] 192.168.222.151:      -   /Users/user/Documents/code/metasploit-framework/lib/rex/proto/smb/simple_client.rb:232:in `create_pipe'
[-] 192.168.222.151:      -   /Users/user/Documents/code/metasploit-framework/lib/rex/proto/dcerpc/client.rb:124:in `smb_connect'
[-] 192.168.222.151:      -   /Users/user/Documents/code/metasploit-framework/lib/rex/proto/dcerpc/client.rb:62:in `socket_check'
[-] 192.168.222.151:      -   /Users/user/Documents/code/metasploit-framework/lib/rex/proto/dcerpc/client.rb:37:in `initialize'
[-] 192.168.222.151:      -   /Users/user/Documents/code/metasploit-framework/lib/msf/core/exploit/remote/dcerpc.rb:120:in `new'
[-] 192.168.222.151:      -   /Users/user/Documents/code/metasploit-framework/lib/msf/core/exploit/remote/dcerpc.rb:120:in `dcerpc_bind'
[-] 192.168.222.151:      -   /Users/user/Documents/code/metasploit-framework/lib/msf/core/exploit/remote/smb/client.rb:751:in `smb_srvsvc_netshareenumall'
[-] 192.168.222.151:      -   /Users/user/Documents/code/metasploit-framework/lib/msf/core/exploit/remote/smb/client.rb:736:in `smb_netshareenumall'
[-] 192.168.222.151:      -   /Users/user/Documents/code/metasploit-framework/modules/auxiliary/scanner/smb/smb_enumshares.rb:335:in `block in run_host'
[-] 192.168.222.151:      -   /Users/user/Documents/code/metasploit-framework/modules/auxiliary/scanner/smb/smb_enumshares.rb:328:in `each'
[-] 192.168.222.151:      -   /Users/user/Documents/code/metasploit-framework/modules/auxiliary/scanner/smb/smb_enumshares.rb:328:in `run_host'
[-] 192.168.222.151:      -   /Users/user/Documents/code/metasploit-framework/lib/msf/core/auxiliary/scanner.rb:121:in `block (2 levels) in run'
[-] 192.168.222.151:      -   /Users/user/Documents/code/metasploit-framework/lib/msf/core/thread_manager.rb:105:in `block in spawn'
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/smb/smb_enumshares) > 
```

This code path was being exercised within the rspec test suite, however, they're wrapped in rspec 'expect(...).to receive(opts)` - so they were passing, when they shouldn't have been.

Article:
https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

I tested framework and ruby_smb together by updating the gemfile to point to my local directory and rerunning `bundle`

```ruby
# metasploit-framework/Gemfile
gem 'ruby_smb', path: '../ruby_smb'
```