### PR TITLE
Adds support for smb1 negotiate response packets

### DIFF
--- a/lib/ruby_smb/client.rb
+++ b/lib/ruby_smb/client.rb
@@ -138,6 +138,11 @@ module RubySMB
     #   @return [Boolean]
     attr_accessor :smb1
 
+    # Challenge value returned by the server during SMB1 negotiation with Extended Security turned off
+    # @!attribute [rw] challenge
+    #       @return [String]
+    attr_accessor :challenge
+
     # Whether or not the Client should support SMB2
     # @!attribute [rw] smb2
     #   @return [Boolean]


### PR DESCRIPTION
Extends the ruby_smb client to include a `challenge` field, which is populated by an additional case statement in the `parse_negotiate_response` method. An extension to the `negotiate` API to allow callers to pass in their own negotiate SMB packet is also added.