### PR TITLE
Use the correct message ID in SMB2/3 responses

### DIFF
--- a/lib/ruby_smb/server/server_client.rb
+++ b/lib/ruby_smb/server/server_client.rb
@@ -22,7 +22,6 @@ module RubySMB
         @dispatcher = dispatcher
         @state = :negotiate
         @dialect = nil
-        @message_id = 0
         @session_id = nil
         @session_key = nil
         @gss_authenticator = server.gss_provider.new_authenticator(self)

--- a/lib/ruby_smb/server/server_client/negotiation.rb
+++ b/lib/ruby_smb/server/server_client/negotiation.rb
@@ -85,6 +85,7 @@ module RubySMB
 
           response = SMB2::Packet::NegotiateResponse.new
           response.smb2_header.credits = 1
+          response.smb2_header.message_id = request.smb2_header.message_id
           response.security_mode.signing_enabled = 1
           response.server_guid = @server.guid
           response.max_transact_size = 0x800000

--- a/lib/ruby_smb/server/server_client/session_setup.rb
+++ b/lib/ruby_smb/server/server_client/session_setup.rb
@@ -60,7 +60,7 @@ module RubySMB
           response = SMB2::Packet::SessionSetupResponse.new
           response.smb2_header.nt_status = gss_result.nt_status.value
           response.smb2_header.credits = 1
-          response.smb2_header.message_id = @message_id += 1
+          response.smb2_header.message_id = request.smb2_header.message_id
           response.smb2_header.session_id = @session_id = @session_id || SecureRandom.random_bytes(4).unpack1('V')
           response.buffer = gss_result.buffer
 


### PR DESCRIPTION
This fixes a message ID synchronization issue between the requests and the responses that would cause there to be a noticeable delay when a Windows client authenticates to the server.

To test this and reproduce the original issue run the `examples/auth_capture.rb` script. Use a Windows client that uses SMB2/3 (I tested with Server 2019) and connect to the capture server. Notice that it takes a while ~30 seconds or so. You can load Wireshark and follow the negotiation and session setup requests and replies and notice that the message ID is out of sync.

With this change in place, the correct message ID is used and it appears to fix the delay causing the connection to occur much faster. In the example of the auth capture server, the authentication/connection will still fail which is intended, however, it'll do so without the delay.