### PR TITLE
Work around GitHub actions failing for Ruby 3.1

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -20,7 +20,7 @@ jobs:
           - 2.5
           - 2.6
           - 2.7
-          - 3.0
+          - 3.0.3
         test_cmd:
           - bundle exec rspec
 


### PR DESCRIPTION
This works around an issue where GitHub actions are failing due to a compatibility issue with Ruby 3.1. This works around it by pinning the version to 3.0.3 for now. See rapid7/metasploit-framework#16003 which is related to the same issue.