### PR TITLE
Bump the minor version

### DIFF
--- a/lib/ruby_smb/version.rb
+++ b/lib/ruby_smb/version.rb
@@ -1,3 +1,3 @@
 module RubySMB
-  VERSION = '2.1.0'.freeze
+  VERSION = '3.0.0'.freeze
 end

--- a/lib/ruby_smb/version.rb
+++ b/lib/ruby_smb/version.rb
@@ -1,3 +1,3 @@
 module RubySMB
-  VERSION = '2.0.14'.freeze
+  VERSION = '2.1.0'.freeze
 end


### PR DESCRIPTION
Since the redesign of the NDR structures changed some exposed API's, bumping the patch version was not enough.