### PR TITLE
Fix the default offsets for create_request fields

### DIFF
--- a/lib/ruby_smb/smb2/packet/create_request.rb
+++ b/lib/ruby_smb/smb2/packet/create_request.rb
@@ -36,9 +36,9 @@ module RubySMB
 
         uint32                :create_disposition, label: 'Create Disposition'
         create_options        :create_options
-        uint16                :name_offset,         label: 'Name Offset'
-        uint16                :name_length,         label: 'Name Length', initial_value: -> { name.num_bytes }
-        uint32                :contexts_offset,     label: 'Create Contexts Offset'
+        uint16                :name_offset,         label: 'Name Offset',            initial_value: -> { calc_name_offset }
+        uint16                :name_length,         label: 'Name Length',            initial_value: -> { name.num_bytes }
+        uint32                :contexts_offset,     label: 'Create Contexts Offset', initial_value: -> { calc_contexts_offset }
         uint32                :contexts_length,     label: 'Create Contexts Length'
         count_bytes_remaining :bytes_remaining
         string                :buffer,              label: 'Buffer', initial_value: -> { build_buffer }, read_length: :bytes_remaining
@@ -61,6 +61,23 @@ module RubySMB
           buf << "\x00".b * ((align - buf.length % align) % align)
           buf << contexts.map(&:to_binary_s).join
           buf << "\x00".b * ((align - buf.length % align) % align)
+        end
+
+        def calc_contexts_offset
+          if contexts.num_bytes == 0
+            0
+          else
+            align = 8
+            buffer.rel_offset + name_length + ((align - name_length % align) % align)
+          end
+        end
+
+        def calc_name_offset
+          if name.num_bytes == 0
+            0
+          else
+            buffer.rel_offset
+          end
         end
       end
     end


### PR DESCRIPTION
In PR #181 the name and context fields of the SMB 2/3 create request were updated to delayed_io fields. When that happened the initial value of their respective offsets was removed. This PR adds that calculation back in.

Without this issue, create requests would fail. This problem manifests itself by way of psexec failures within Metasploit.

To test this, use these changes and run the psexec module. It should work. Without these changes, one of the following two exceptions may be seen depending on the negotiated version of SMB.

```
msf6 exploit(windows/smb/psexec) > exploit

[*] Started reverse TCP handler on 192.168.250.134:4444 
[*] 192.168.159.41:445 - Connecting to the server...
[*] 192.168.159.41:445 - Authenticating to 192.168.159.41:445 as user 'Spencer McIntyre'...
[-] 192.168.159.41:445 - Exploit failed: RubySMB::Error::EncryptionError Error while decrypting RubySMB::SMB2::Packet::TransformHeader packet (SMB 0x0311}): Error while decrypting with 'AES-128-CCM' (OpenSSL::Cipher::CipherError: OpenSSL::Cipher::CipherError)
[*] Exploit completed, but no session was created.
msf6 exploit(windows/smb/psexec) > set SMB::PROTOCOLVERSION 2
SMB::PROTOCOLVERSION => 2
msf6 exploit(windows/smb/psexec) > exploit

[*] Started reverse TCP handler on 192.168.250.134:4444 
[*] 192.168.159.41:445 - Connecting to the server...
[*] 192.168.159.41:445 - Authenticating to 192.168.159.41:445 as user 'Spencer McIntyre'...
[*] 192.168.159.41:445 - Selecting native target
[!] 192.168.159.41:445 - peer_native_os is only available with SMB1 (current version: SMB2)
[*] 192.168.159.41:445 - Uploading payload... nvgblQXX.exe
[-] 192.168.159.41:445 - Exploit failed: RubySMB::Error::UnexpectedStatusCode The server responded with an unexpected status code: STATUS_INVALID_PARAMETER
[*] Exploit completed, but no session was created.
msf6 exploit(windows/smb/psexec) >
```