### PR TITLE
refactor: rename fields from maximum to maximum_allowed

### DIFF
--- a/lib/ruby_smb/dcerpc/winreg.rb
+++ b/lib/ruby_smb/dcerpc/winreg.rb
@@ -274,7 +274,7 @@ module RubySMB
           lp_sub_key:             sub_key,
           lp_class:               opts[:lp_class] || :null,
           dw_options:             opts[:dw_options] || RubySMB::Dcerpc::Winreg::CreateKeyRequest::REG_KEY_TYPE_VOLATILE,
-          sam_desired:            opts[:sam_desired] || RubySMB::Dcerpc::Winreg::Regsam.new(maximum: 1),
+          sam_desired:            opts[:sam_desired] || RubySMB::Dcerpc::Winreg::Regsam.new(maximum_allowed: 1),
           lp_security_attributes: opts[:lp_security_attributes] || RubySMB::Dcerpc::RpcSecurityAttributes.new,
           lpdw_disposition:       opts[:lpdw_disposition] || RubySMB::Dcerpc::Winreg::CreateKeyRequest::REG_CREATED_NEW_KEY,
         }

--- a/lib/ruby_smb/dcerpc/winreg/open_root_key_request.rb
+++ b/lib/ruby_smb/dcerpc/winreg/open_root_key_request.rb
@@ -33,7 +33,7 @@ module RubySMB
           super
           @opnum = get_parameter(:opnum) if has_parameter?(:opnum)
           self.server_name = :null
-          self.sam_desired.maximum = 1 unless [OPEN_HKPD, OPEN_HKPT, OPEN_HKPN].include?(@opnum)
+          self.sam_desired.maximum_allowed = 1 unless [OPEN_HKPD, OPEN_HKPT, OPEN_HKPN].include?(@opnum)
         end
       end
 

--- a/lib/ruby_smb/dcerpc/winreg/regsam.rb
+++ b/lib/ruby_smb/dcerpc/winreg/regsam.rb
@@ -33,7 +33,7 @@ module RubySMB
         bit1    :generic_execute,        label: 'Generic Execute'
         bit1    :generic_all,            label: 'Generic All'
         bit2    :reserved4,              label: 'Reserved Space'
-        bit1    :maximum,                label: 'Maximum Allowed'
+        bit1    :maximum_allowed,        label: 'Maximum Allowed'
         bit1    :system_security,        label: 'System Security'
       end
 

--- a/lib/ruby_smb/smb1/bit_field/directory_access_mask.rb
+++ b/lib/ruby_smb/smb1/bit_field/directory_access_mask.rb
@@ -30,7 +30,7 @@ module RubySMB
         bit1    :generic_execute, label: 'Generic Execute'
         bit1    :generic_all,     label: 'Generic All'
         bit2    :reserved3
-        bit1    :maximum,         label: 'Maximum Allowed'
+        bit1    :maximum_allowed, label: 'Maximum Allowed'
         bit1    :system_security, label: 'System Security'
       end
     end

--- a/lib/ruby_smb/smb1/bit_field/file_access_mask.rb
+++ b/lib/ruby_smb/smb1/bit_field/file_access_mask.rb
@@ -30,7 +30,7 @@ module RubySMB
         bit1    :generic_execute, label: 'Generic Execute'
         bit1    :generic_all,     label: 'Generic All'
         bit2    :reserved3
-        bit1    :maximum,         label: 'Maximum Allowed'
+        bit1    :maximum_allowed, label: 'Maximum Allowed'
         bit1    :system_security, label: 'System Security'
       end
     end

--- a/lib/ruby_smb/smb2/bit_field/directory_access_mask.rb
+++ b/lib/ruby_smb/smb2/bit_field/directory_access_mask.rb
@@ -30,7 +30,7 @@ module RubySMB
         bit1    :generic_execute, label: 'Generic Execute'
         bit1    :generic_all,     label: 'Generic All'
         bit2    :reserved3
-        bit1    :maximum,         label: 'Maximum Allowed'
+        bit1    :maximum_allowed, label: 'Maximum Allowed'
         bit1    :system_security, label: 'System Security'
       end
     end

--- a/lib/ruby_smb/smb2/bit_field/file_access_mask.rb
+++ b/lib/ruby_smb/smb2/bit_field/file_access_mask.rb
@@ -30,7 +30,7 @@ module RubySMB
         bit1    :generic_execute, label: 'Generic Execute'
         bit1    :generic_all,     label: 'Generic All'
         bit2    :reserved3
-        bit1    :maximum,         label: 'Maximum Allowed'
+        bit1    :maximum_allowed, label: 'Maximum Allowed'
         bit1    :system_security, label: 'System Security'
       end
     end

--- a/spec/lib/ruby_smb/dcerpc/winreg/open_root_key_request_spec.rb
+++ b/spec/lib/ruby_smb/dcerpc/winreg/open_root_key_request_spec.rb
@@ -57,30 +57,30 @@ RSpec.describe RubySMB::Dcerpc::Winreg::OpenRootKeyRequest do
     end
 
     context 'when #opnum is not OPEN_HKPD, OPEN_HKPT or OPEN_HKPN' do
-      it 'sets the #sam_desired.maximum flag' do
+      it 'sets the #sam_desired.maximum_allowed flag' do
         packet = described_class.new(opnum: RubySMB::Dcerpc::Winreg::OPEN_HKCR)
-        expect(packet.sam_desired.maximum).to eq(1)
+        expect(packet.sam_desired.maximum_allowed).to eq(1)
       end
     end
 
     context 'when #opnum is OPEN_HKPD' do
-      it 'does not set the #sam_desired.maximum flag' do
+      it 'does not set the #sam_desired.maximum_allowed flag' do
         packet = described_class.new(opnum: RubySMB::Dcerpc::Winreg::OPEN_HKPD)
-        expect(packet.sam_desired.maximum).to eq(0)
+        expect(packet.sam_desired.maximum_allowed).to eq(0)
       end
     end
 
     context 'when #opnum is OPEN_HKPT' do
-      it 'does not set the #sam_desired.maximum flag' do
+      it 'does not set the #sam_desired.maximum_allowed flag' do
         packet = described_class.new(opnum: RubySMB::Dcerpc::Winreg::OPEN_HKPT)
-        expect(packet.sam_desired.maximum).to eq(0)
+        expect(packet.sam_desired.maximum_allowed).to eq(0)
       end
     end
 
     context 'when #opnum is OPEN_HKPN' do
-      it 'does not set the #sam_desired.maximum flag' do
+      it 'does not set the #sam_desired.maximum_allowed flag' do
         packet = described_class.new(opnum: RubySMB::Dcerpc::Winreg::OPEN_HKPN)
-        expect(packet.sam_desired.maximum).to eq(0)
+        expect(packet.sam_desired.maximum_allowed).to eq(0)
       end
     end
   end

--- a/spec/lib/ruby_smb/dcerpc/winreg/regsam_spec.rb
+++ b/spec/lib/ruby_smb/dcerpc/winreg/regsam_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe RubySMB::Dcerpc::Winreg::Regsam do
   it { is_expected.to respond_to :generic_execute }
   it { is_expected.to respond_to :generic_all }
   it { is_expected.to respond_to :reserved4 }
-  it { is_expected.to respond_to :maximum }
+  it { is_expected.to respond_to :maximum_allowed }
   it { is_expected.to respond_to :system_security }
 
 

--- a/spec/lib/ruby_smb/dcerpc/winreg_spec.rb
+++ b/spec/lib/ruby_smb/dcerpc/winreg_spec.rb
@@ -755,7 +755,7 @@ RSpec.describe RubySMB::Dcerpc::Winreg do
         lp_sub_key:             sub_key,
         lp_class:               :null,
         dw_options:             RubySMB::Dcerpc::Winreg::CreateKeyRequest::REG_KEY_TYPE_VOLATILE,
-        sam_desired:            RubySMB::Dcerpc::Winreg::Regsam.new(maximum: 1),
+        sam_desired:            RubySMB::Dcerpc::Winreg::Regsam.new(maximum_allowed: 1),
         lp_security_attributes: RubySMB::Dcerpc::RpcSecurityAttributes.new,
         lpdw_disposition:       RubySMB::Dcerpc::Winreg::CreateKeyRequest::REG_CREATED_NEW_KEY
       }

--- a/spec/lib/ruby_smb/smb1/bit_field/directory_access_mask_spec.rb
+++ b/spec/lib/ruby_smb/smb1/bit_field/directory_access_mask_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe RubySMB::SMB1::BitField::DirectoryAccessMask do
   it { is_expected.to respond_to :generic_write }
   it { is_expected.to respond_to :generic_execute }
   it { is_expected.to respond_to :generic_all }
-  it { is_expected.to respond_to :maximum }
+  it { is_expected.to respond_to :maximum_allowed }
   it { is_expected.to respond_to :system_security }
 
   it 'is little endian' do
@@ -146,12 +146,12 @@ RSpec.describe RubySMB::SMB1::BitField::DirectoryAccessMask do
     it_behaves_like 'bit field with one flag set', :system_security, 'V', 0x01000000
   end
 
-  describe '#maximum' do
+  describe '#maximum_allowed' do
     it 'should be a 1-bit field per the SMB spec' do
-      expect(flags.maximum).to be_a BinData::Bit1
+      expect(flags.maximum_allowed).to be_a BinData::Bit1
     end
 
-    it_behaves_like 'bit field with one flag set', :maximum, 'V', 0x02000000
+    it_behaves_like 'bit field with one flag set', :maximum_allowed, 'V', 0x02000000
   end
 
   describe '#generic_all' do

--- a/spec/lib/ruby_smb/smb1/bit_field/file_access_mask_spec.rb
+++ b/spec/lib/ruby_smb/smb1/bit_field/file_access_mask_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe RubySMB::SMB1::BitField::FileAccessMask do
   it { is_expected.to respond_to :generic_write }
   it { is_expected.to respond_to :generic_execute }
   it { is_expected.to respond_to :generic_all }
-  it { is_expected.to respond_to :maximum }
+  it { is_expected.to respond_to :maximum_allowed }
   it { is_expected.to respond_to :system_security }
 
   it 'is little endian' do
@@ -146,12 +146,12 @@ RSpec.describe RubySMB::SMB1::BitField::FileAccessMask do
     it_behaves_like 'bit field with one flag set', :system_security, 'V', 0x01000000
   end
 
-  describe '#maximum' do
+  describe '#maximum_allowed' do
     it 'should be a 1-bit field per the SMB spec' do
-      expect(flags.maximum).to be_a BinData::Bit1
+      expect(flags.maximum_allowed).to be_a BinData::Bit1
     end
 
-    it_behaves_like 'bit field with one flag set', :maximum, 'V', 0x02000000
+    it_behaves_like 'bit field with one flag set', :maximum_allowed, 'V', 0x02000000
   end
 
   describe '#generic_all' do

--- a/spec/lib/ruby_smb/smb2/bit_field/directory_access_mask_spec.rb
+++ b/spec/lib/ruby_smb/smb2/bit_field/directory_access_mask_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe RubySMB::SMB2::BitField::DirectoryAccessMask do
   it { is_expected.to respond_to :generic_write }
   it { is_expected.to respond_to :generic_execute }
   it { is_expected.to respond_to :generic_all }
-  it { is_expected.to respond_to :maximum }
+  it { is_expected.to respond_to :maximum_allowed }
   it { is_expected.to respond_to :system_security }
 
   it 'is little endian' do
@@ -146,12 +146,12 @@ RSpec.describe RubySMB::SMB2::BitField::DirectoryAccessMask do
     it_behaves_like 'bit field with one flag set', :system_security, 'V', 0x01000000
   end
 
-  describe '#maximum' do
+  describe '#maximum_allowed' do
     it 'should be a 1-bit field per the SMB spec' do
-      expect(flags.maximum).to be_a BinData::Bit1
+      expect(flags.maximum_allowed).to be_a BinData::Bit1
     end
 
-    it_behaves_like 'bit field with one flag set', :maximum, 'V', 0x02000000
+    it_behaves_like 'bit field with one flag set', :maximum_allowed, 'V', 0x02000000
   end
 
   describe '#generic_all' do

--- a/spec/lib/ruby_smb/smb2/bit_field/file_access_mask_spec.rb
+++ b/spec/lib/ruby_smb/smb2/bit_field/file_access_mask_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe RubySMB::SMB2::BitField::FileAccessMask do
   it { is_expected.to respond_to :generic_write }
   it { is_expected.to respond_to :generic_execute }
   it { is_expected.to respond_to :generic_all }
-  it { is_expected.to respond_to :maximum }
+  it { is_expected.to respond_to :maximum_allowed }
   it { is_expected.to respond_to :system_security }
 
   it 'is little endian' do
@@ -146,12 +146,12 @@ RSpec.describe RubySMB::SMB2::BitField::FileAccessMask do
     it_behaves_like 'bit field with one flag set', :system_security, 'V', 0x01000000
   end
 
-  describe '#maximum' do
+  describe '#maximum_allowed' do
     it 'should be a 1-bit field per the SMB spec' do
-      expect(flags.maximum).to be_a BinData::Bit1
+      expect(flags.maximum_allowed).to be_a BinData::Bit1
     end
 
-    it_behaves_like 'bit field with one flag set', :maximum, 'V', 0x02000000
+    it_behaves_like 'bit field with one flag set', :maximum_allowed, 'V', 0x02000000
   end
 
   describe '#generic_all' do


### PR DESCRIPTION
For compatibility with ActiveSupport 7 which monkey-patches `Enumerable` with a method called `maximum`.

Closes #182 