### PR TITLE
Changes to support smb_relay versions smb2/smb3

### DIFF
--- a/lib/ruby_smb/client.rb
+++ b/lib/ruby_smb/client.rb
@@ -29,10 +29,26 @@ module RubySMB
     # It indicates that the server implements SMB 2.1 or future dialect revisions
     # Note that this must be used for SMB3
     SMB1_DIALECT_SMB2_WILDCARD = 'SMB 2.???'.freeze
+
+    SMB2_DIALECT_0202 = '0x0202'.freeze
+    SMB2_DIALECT_0210 = '0x0210'.freeze
+    SMB2_DIALECT_0300  = '0x0300'.freeze
+    SMB2_DIALECT_0302  = '0x0302'.freeze
+    SMB2_DIALECT_0311  = '0x0311'.freeze
+
     # Dialect values for SMB2
-    SMB2_DIALECT_DEFAULT = ['0x0202', '0x0210']
+    SMB2_DIALECT_DEFAULT = [
+      SMB2_DIALECT_0202,
+      SMB2_DIALECT_0210,
+    ].freeze
+
     # Dialect values for SMB3
-    SMB3_DIALECT_DEFAULT = ['0x0300', '0x0302', '0x0311']
+    SMB3_DIALECT_DEFAULT = [
+      SMB2_DIALECT_0300,
+      SMB2_DIALECT_0302,
+      SMB2_DIALECT_0311
+    ].freeze
+
     # The default maximum size of a SMB message that the Client accepts (in bytes)
     MAX_BUFFER_SIZE = 64512
     # The default maximum size of a SMB message that the Server accepts (in bytes)

--- a/lib/ruby_smb/client/negotiation.rb
+++ b/lib/ruby_smb/client/negotiation.rb
@@ -251,7 +251,7 @@ module RubySMB
           raise ArgumentError, 'Must be an array of strings' unless dialect.is_a? String
           packet.add_dialect(dialect.to_i(16))
         end
-        packet.capabilities.encryption = 1
+        packet.capabilities.encryption = @session_encrypt_data ? 1 : 0
 
         if packet.dialects.include?(0x0311)
           nc = RubySMB::SMB2::NegotiateContext.new(

--- a/lib/ruby_smb/server/session.rb
+++ b/lib/ruby_smb/server/session.rb
@@ -13,6 +13,7 @@ module RubySMB
         @user_id = user_id
         @state = state
         @signing_required = false
+        @metadata = {}
         # tree id => provider processor instance
         @tree_connect_table = {}
         @creation_time = Time.now
@@ -61,6 +62,11 @@ module RubySMB
       # @!attribute [rw] tree_connect_table
       #   @return [Hash]
       attr_accessor :tree_connect_table
+
+      # Untyped hash for storing additional arbitrary metadata about the current session
+      # @!attribute [rw] metadaa
+      #   @return [Hash]
+      attr_accessor :metadata
 
       # The time at which this session was created.
       # @!attribute [r] creation_time

--- a/lib/ruby_smb/smb2/packet/session_setup_request.rb
+++ b/lib/ruby_smb/smb2/packet/session_setup_request.rb
@@ -18,6 +18,17 @@ module RubySMB
         uint64                     :previous_session_id,     label: 'Previous Session ID'
         string                     :buffer,                  label: 'Security Buffer', length: -> { security_buffer_length }
 
+        # Takes the specified security buffer string and inserts it into the {RubySMB::SMB2::Packet::SessionSetupRequest#buffer}
+        # as well as updating the {RubySMB::SMB2::Packet::SessionSetupRequest#security_buffer_length}
+        # This method DOES NOT wrap the security buffer in any way.
+        #
+        # @param type1_message [String] the security buffer
+        # @return [void]
+        def set_security_buffer(buffer)
+          self.security_buffer_length = buffer.length
+          self.buffer = buffer
+        end
+
         # Takes a serialized NTLM Type 1 message and wraps it in the GSS ASN1 encoding
         # and inserts it into the {RubySMB::SMB2::Packet::SessionSetupRequest#buffer}
         # as well as updating the {RubySMB::SMB2::Packet::SessionSetupRequest#security_buffer_length}


### PR DESCRIPTION
Draft pull request with minimal changes to allow Metasploit-framework to support ntlm relaying with smb2/3

Framework PR https://github.com/rapid7/metasploit-framework/pull/16098