### PR TITLE
Add Anonymous Authentication Support for SMB2 and SMB3

### DIFF
--- a/examples/anonymous_auth.rb
+++ b/examples/anonymous_auth.rb
@@ -27,4 +27,4 @@ username = ''
 password = ''
 
 # Negotiate with only SMB1 enabled
-run_authentication(address, true, false, false, username, password)
+run_authentication(address, true, true, true, username, password)

--- a/lib/ruby_smb/client/authentication.rb
+++ b/lib/ruby_smb/client/authentication.rb
@@ -204,6 +204,10 @@ module RubySMB
         @session_id = challenge_packet.smb2_header.session_id
         type2_b64_message = smb2_type2_message(challenge_packet)
         type3_message = @ntlm_client.init_context(type2_b64_message)
+        if username.empty? && password.empty?
+          type3_message.lm_response = ''
+          type3_message.ntlm_response = ''
+        end
 
         @session_key = @ntlm_client.session_key
         challenge_message = ntlm_client.session.challenge_message

--- a/lib/ruby_smb/client/authentication.rb
+++ b/lib/ruby_smb/client/authentication.rb
@@ -213,8 +213,13 @@ module RubySMB
         raw = smb2_ntlmssp_authenticate(type3_message, @session_id)
         response = smb2_ntlmssp_final_packet(raw)
 
-        if @smb3 && !@session_encrypt_data && response.session_flags.encrypt_data == 1
-          @session_encrypt_data = true
+        if @smb3
+          if username == '' && password == ''
+            # don't encrypt anonymous sessions
+            @session_encrypt_data = false
+          elsif !@session_encrypt_data && response.session_flags.encrypt_data == 1
+            @session_encrypt_data = true
+          end
         end
         ######
         # DEBUG

--- a/lib/ruby_smb/client/authentication.rb
+++ b/lib/ruby_smb/client/authentication.rb
@@ -204,10 +204,6 @@ module RubySMB
         @session_id = challenge_packet.smb2_header.session_id
         type2_b64_message = smb2_type2_message(challenge_packet)
         type3_message = @ntlm_client.init_context(type2_b64_message)
-        if username.empty? && password.empty?
-          type3_message.lm_response = ''
-          type3_message.ntlm_response = ''
-        end
 
         @session_key = @ntlm_client.session_key
         challenge_message = ntlm_client.session.challenge_message


### PR DESCRIPTION
This adds anonymous authentication support for SMB versions 2 and 3. It requires the changes proposed in WinRB/rubyntlm#45 to be in place. The tiny block in `lib/ruby_smb/client/authentication.rb` is really the only bit necessary for the fix, it disables encryption when the session has been authenticated anonymously.

I also updated the two example files that I used while testing this. While the `examples/anonymous_auth.rb` example shows that the session was properly authenticated, it does not prove that the session key was correctly calculated. This makes it a bit misleading and is why I also updated and tested more thoroughly with the `examples/tree_connect.rb` script. This example makes a TreeConnect request, that is always signed. When the session has been authenticated anonymously, this proves that the session key is correct.

## Testing
Use the updated tree_connect script, which now has some nice options so the code doesn't need to be changed for various configurations. By default, it will perform anonymous authentication. A username and password can optionally be specified.

- [ ] Connect to the IPC share on a domain controller with both SMB2 and SMB3
- [ ] Run: `ruby examples/tree_connect.rb --no-smbv1 --no-smbv2 target_ip IPC$`
- [ ] Run: `ruby examples/tree_connect.rb --no-smbv1 --no-smbv3 target_ip IPC$`

## Demo
In this example 192.168.159.96 is a Server 2019 domain controller.

```
[smcintyre@localhost ruby_smb]$ ruby examples/tree_connect.rb --no-smbv1 --no-smbv2 192.168.159.96 IPC$
SMB3 : (0x00000000) STATUS_SUCCESS: The operation completed successfully.
Connected to \\192.168.159.96\IPC$ successfully!
[smcintyre@localhost ruby_smb]$ ruby examples/tree_connect.rb --no-smbv1 --no-smbv3 192.168.159.96 IPC$
SMB2 : (0x00000000) STATUS_SUCCESS: The operation completed successfully.
Connected to \\192.168.159.96\IPC$ successfully!
[smcintyre@localhost ruby_smb]$ 
```