### PR TITLE
Add New DCERPC Definitions

### DIFF
--- a/lib/ruby_smb/dcerpc.rb
+++ b/lib/ruby_smb/dcerpc.rb
@@ -50,8 +50,7 @@ module RubySMB
     require 'ruby_smb/dcerpc/rpc_auth3'
     require 'ruby_smb/dcerpc/bind'
     require 'ruby_smb/dcerpc/bind_ack'
-
-
+    require 'ruby_smb/dcerpc/print_system'
 
     # Bind to the remote server interface endpoint.
     #

--- a/lib/ruby_smb/dcerpc.rb
+++ b/lib/ruby_smb/dcerpc.rb
@@ -51,6 +51,7 @@ module RubySMB
     require 'ruby_smb/dcerpc/bind'
     require 'ruby_smb/dcerpc/bind_ack'
     require 'ruby_smb/dcerpc/print_system'
+    require 'ruby_smb/dcerpc/encrypting_file_system'
 
     # Bind to the remote server interface endpoint.
     #

--- a/lib/ruby_smb/dcerpc/encrypting_file_system.rb
+++ b/lib/ruby_smb/dcerpc/encrypting_file_system.rb
@@ -2,7 +2,8 @@ module RubySMB
   module Dcerpc
     module EncryptingFileSystem
       # see: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-efsr/403c7ae0-1a3a-4e96-8efc-54e79a2cc451
-      UUID = 'df1941c5-fe89-4e79-bf10-463657acf44d'.freeze
+      UUID = EFSRPC_UUID = 'df1941c5-fe89-4e79-bf10-463657acf44d'.freeze
+      LSARPC_UUID = 'c681d488-d850-11d0-8c52-00c04fd90f7e'.freeze
       VER_MAJOR = 1
       VER_MINOR = 0
 

--- a/lib/ruby_smb/dcerpc/encrypting_file_system.rb
+++ b/lib/ruby_smb/dcerpc/encrypting_file_system.rb
@@ -1,0 +1,36 @@
+module RubySMB
+  module Dcerpc
+    module EncryptingFileSystem
+      # see: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-efsr/403c7ae0-1a3a-4e96-8efc-54e79a2cc451
+      UUID = 'df1941c5-fe89-4e79-bf10-463657acf44d'.freeze
+      VER_MAJOR = 1
+      VER_MINOR = 0
+
+      # Operation numbers
+      EFS_RPC_OPEN_FILE_RAW = 0
+      EFS_RPC_WRITE_FILE_RAW = 1
+      EFS_RPC_CLOSE_RAW = 3
+      EFS_RPC_ENCRYPT_FILE_SRV = 4
+      EFS_RPC_DECRYPT_FILE_SRV = 5
+      EFS_RPC_QUERY_USERS_ON_FILE = 6
+      EFS_RPC_QUERY_RECOVERY_AGENTS = 7
+      EFS_RPC_REMOVE_USERS_FROM_FILE = 8
+      EFS_RPC_ADD_USERS_TO_FILE = 9
+      EFS_RPC_NOT_SUPPORTED = 11
+      EFS_RPC_FILE_KEY_INFO = 12
+      EFS_RPC_DUPLICATE_ENCRYPTION_INFO_FILE = 13
+      EFS_RPC_ADD_USERS_TO_FILE_EX = 15
+      EFS_RPC_FILE_KEY_INFO_EX = 16
+      EFS_RPC_GET_ENCRYPTED_FILE_METADATA = 18
+      EFS_RPC_SET_ENCRYPTED_FILE_METADATA = 19
+      EFS_RPC_FLUSH_EFS_CACHE = 20
+      EFS_RPC_ENCRYPT_FILE_EX_SRV = 21
+      EFS_RPC_QUERY_PROTECTORS = 22
+
+      require 'ruby_smb/dcerpc/encrypting_file_system/efs_rpc_encrypt_file_srv_request'
+      require 'ruby_smb/dcerpc/encrypting_file_system/efs_rpc_encrypt_file_srv_response'
+      require 'ruby_smb/dcerpc/encrypting_file_system/efs_rpc_open_file_raw_request'
+      require 'ruby_smb/dcerpc/encrypting_file_system/efs_rpc_open_file_raw_response'
+    end
+  end
+end

--- a/lib/ruby_smb/dcerpc/encrypting_file_system/efs_rpc_encrypt_file_srv_request.rb
+++ b/lib/ruby_smb/dcerpc/encrypting_file_system/efs_rpc_encrypt_file_srv_request.rb
@@ -1,0 +1,20 @@
+module RubySMB
+  module Dcerpc
+    module EncryptingFileSystem
+
+      # [3.1.4.2.5 EfsRpcEncryptFileSrv (Opnum 4)](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-efsr/0d599976-758c-4dbd-ac8c-c9db2a922d76)
+      class EfsRpcEncryptFileSrvRequest < BinData::Record
+        attr_reader :opnum
+
+        endian :little
+
+        ndr_conf_var_wide_stringz :file_name
+
+        def initialize_instance
+          super
+          @opnum = EFS_RPC_ENCRYPT_FILE_SRV
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby_smb/dcerpc/encrypting_file_system/efs_rpc_encrypt_file_srv_response.rb
+++ b/lib/ruby_smb/dcerpc/encrypting_file_system/efs_rpc_encrypt_file_srv_response.rb
@@ -1,0 +1,20 @@
+module RubySMB
+  module Dcerpc
+    module EncryptingFileSystem
+
+      # [3.1.4.2.5 EfsRpcEncryptFileSrv (Opnum 4)](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-efsr/0d599976-758c-4dbd-ac8c-c9db2a922d76)
+      class EfsRpcEncryptFileSrvResponse < BinData::Record
+        attr_reader :opnum
+
+        endian :little
+
+        ndr_uint32         :error_status
+
+        def initialize_instance
+          super
+          @opnum = EFS_RPC_ENCRYPT_FILE_SRV
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby_smb/dcerpc/encrypting_file_system/efs_rpc_open_file_raw_request.rb
+++ b/lib/ruby_smb/dcerpc/encrypting_file_system/efs_rpc_open_file_raw_request.rb
@@ -1,0 +1,21 @@
+module RubySMB
+  module Dcerpc
+    module EncryptingFileSystem
+
+      # [3.1.4.2.1 EfsRpcOpenFileRaw (Opnum 0)](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-efsr/ccc4fb75-1c86-41d7-bbc4-b278ec13bfb8)
+      class EfsRpcOpenFileRawRequest < BinData::Record
+        attr_reader :opnum
+
+        endian :little
+
+        ndr_conf_var_wide_stringz :file_name
+        ndr_uint32                :flags
+
+        def initialize_instance
+          super
+          @opnum = EFS_RPC_OPEN_FILE_RAW
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby_smb/dcerpc/encrypting_file_system/efs_rpc_open_file_raw_response.rb
+++ b/lib/ruby_smb/dcerpc/encrypting_file_system/efs_rpc_open_file_raw_response.rb
@@ -1,0 +1,21 @@
+module RubySMB
+  module Dcerpc
+    module EncryptingFileSystem
+
+      # [3.1.4.2.1 EfsRpcOpenFileRaw (Opnum 0)](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-efsr/ccc4fb75-1c86-41d7-bbc4-b278ec13bfb8)
+      class EfsRpcOpenFileRawResponse < BinData::Record
+        attr_reader :opnum
+
+        endian :little
+
+        ndr_context_handle :h_context
+        ndr_uint32         :error_status
+
+        def initialize_instance
+          super
+          @opnum = EFS_RPC_OPEN_FILE_RAW
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby_smb/dcerpc/print_system.rb
+++ b/lib/ruby_smb/dcerpc/print_system.rb
@@ -1,0 +1,69 @@
+module RubySMB
+  module Dcerpc
+    module PrintSystem
+
+      # see: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rprn/848b8334-134a-4d02-aea4-03b673d6c515
+      UUID = '12345678-1234-abcd-ef00-0123456789ab'.freeze
+      VER_MAJOR = 1
+      VER_MINOR = 0
+
+      # Operation numbers
+      RPC_ENUM_PRINTER_DRIVERS = 10
+      RPC_GET_PRINTER_DRIVER_DIRECTORY = 12
+      RPC_ADD_PRINTER_DRIVER_EX = 89
+
+      # see: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rprn/b96cc497-59e5-4510-ab04-5484993b259b
+      APD_STRICT_UPGRADE = 0x00000001
+      APD_STRICT_DOWNGRADE = 0x00000002
+      APD_COPY_ALL_FILES = 0x00000004
+      APD_COPY_NEW_FILES = 0x00000008
+      APD_COPY_FROM_DIRECTORY = 0x00000010
+      APD_DONT_COPY_FILES_TO_CLUSTER = 0x00001000
+      APD_COPY_TO_ALL_SPOOLERS = 0x00002000
+      APD_INSTALL_WARNED_DRIVER = 0x00008000
+      APD_RETURN_BLOCKING_STATUS_CODE = 0x00010000
+
+      # [2.2.1.5.2 DRIVER_INFO_2](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rprn/39bbfc30-8768-4cd4-9930-434857e2c2a2)
+      class DriverInfo2 < RubySMB::Dcerpc::Ndr::NdrStruct
+        default_parameter byte_align: 4
+        endian :little
+
+        ndr_uint32 :c_version
+        ndr_wide_stringz_ptr :p_name
+        ndr_wide_stringz_ptr :p_environment
+        ndr_wide_stringz_ptr :p_driver_path
+        ndr_wide_stringz_ptr :p_data_file
+        ndr_wide_stringz_ptr :p_config_file
+      end
+
+      class PDriverInfo2 < DriverInfo2
+        extend RubySMB::Dcerpc::Ndr::PointerClassPlugin
+      end
+
+      # [2.2.1.2.3 DRIVER_CONTAINER](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rprn/3a3f9cf7-8ec4-4921-b1f6-86cf8d139bc2)
+      class DriverContainer < RubySMB::Dcerpc::Ndr::NdrStruct
+        default_parameter byte_align: 4
+        endian :little
+
+        ndr_uint32 :level, check_value: -> { [2].include?(value) }
+        ndr_uint32 :tag
+        choice :driver_info, selection: :level, byte_align: 4 do
+          p_driver_info2 2
+        end
+      end
+
+      # for RpcEnumPrinterDrivers and RpcGetPrinterDriverDirectory `BYTE*` fields
+      class RprnByteArrayPtr < RubySMB::Dcerpc::Ndr::NdrConfArray
+        default_parameters type: :ndr_uint8
+        extend RubySMB::Dcerpc::Ndr::PointerClassPlugin
+      end
+
+      require 'ruby_smb/dcerpc/print_system/rpc_add_printer_driver_ex_request'
+      require 'ruby_smb/dcerpc/print_system/rpc_add_printer_driver_ex_response'
+      require 'ruby_smb/dcerpc/print_system/rpc_enum_printer_drivers_request'
+      require 'ruby_smb/dcerpc/print_system/rpc_enum_printer_drivers_response'
+      require 'ruby_smb/dcerpc/print_system/rpc_get_printer_driver_directory_request'
+      require 'ruby_smb/dcerpc/print_system/rpc_get_printer_driver_directory_response'
+    end
+  end
+end

--- a/lib/ruby_smb/dcerpc/print_system/rpc_add_printer_driver_ex_request.rb
+++ b/lib/ruby_smb/dcerpc/print_system/rpc_add_printer_driver_ex_request.rb
@@ -1,0 +1,22 @@
+module RubySMB
+  module Dcerpc
+    module PrintSystem
+
+      # [3.1.4.4.8 RpcAddPrinterDriverEx (Opnum 89)](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rprn/b96cc497-59e5-4510-ab04-5484993b259b)
+      class RpcAddPrinterDriverExRequest < BinData::Record
+        attr_reader :opnum
+
+        endian :little
+
+        ndr_wide_stringz_ptr :p_name
+        driver_container     :p_driver_container
+        ndr_uint32           :dw_file_copy_flags
+
+        def initialize_instance
+          super
+          @opnum = RPC_ADD_PRINTER_DRIVER_EX
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby_smb/dcerpc/print_system/rpc_add_printer_driver_ex_response.rb
+++ b/lib/ruby_smb/dcerpc/print_system/rpc_add_printer_driver_ex_response.rb
@@ -1,0 +1,20 @@
+module RubySMB
+  module Dcerpc
+    module PrintSystem
+
+      # [3.1.4.4.8 RpcAddPrinterDriverEx (Opnum 89)](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rprn/b96cc497-59e5-4510-ab04-5484993b259b)
+      class RpcAddPrinterDriverExResponse < BinData::Record
+        attr_reader :opnum
+
+        endian :little
+
+        def initialize_instance
+          super
+          @opnum = RPC_ADD_PRINTER_DRIVER_EX
+        end
+
+        ndr_uint32 :error_status
+      end
+    end
+  end
+end

--- a/lib/ruby_smb/dcerpc/print_system/rpc_enum_printer_drivers_request.rb
+++ b/lib/ruby_smb/dcerpc/print_system/rpc_enum_printer_drivers_request.rb
@@ -1,0 +1,24 @@
+module RubySMB
+  module Dcerpc
+    module PrintSystem
+
+      # [3.1.4.4.2 RpcEnumPrinterDrivers (Opnum 10)](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rprn/857d00ac-3682-4a0d-86ca-3d3c372e5e4a)
+      class RpcEnumPrinterDriversRequest < BinData::Record
+        attr_reader :opnum
+
+        endian :little
+
+        def initialize_instance
+          super
+          @opnum = RPC_ENUM_PRINTER_DRIVERS
+        end
+
+        ndr_wide_stringz_ptr :p_name
+        ndr_wide_stringz_ptr :p_environment
+        ndr_uint32           :level
+        rprn_byte_array_ptr  :p_drivers
+        ndr_uint32           :cb_buf
+      end
+    end
+  end
+end

--- a/lib/ruby_smb/dcerpc/print_system/rpc_enum_printer_drivers_response.rb
+++ b/lib/ruby_smb/dcerpc/print_system/rpc_enum_printer_drivers_response.rb
@@ -1,0 +1,23 @@
+module RubySMB
+  module Dcerpc
+    module PrintSystem
+
+      # [3.1.4.4.2 RpcEnumPrinterDrivers (Opnum 10)](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rprn/857d00ac-3682-4a0d-86ca-3d3c372e5e4a)
+      class RpcEnumPrinterDriversResponse < BinData::Record
+        attr_reader :opnum
+
+        endian :little
+
+        def initialize_instance
+          super
+          @opnum = RPC_ENUM_PRINTER_DRIVERS
+        end
+
+        rprn_byte_array_ptr  :p_drivers
+        ndr_uint32           :pcb_needed
+        ndr_uint32           :pc_returned
+        ndr_uint32           :error_status
+      end
+    end
+  end
+end

--- a/lib/ruby_smb/dcerpc/print_system/rpc_get_printer_driver_directory_request.rb
+++ b/lib/ruby_smb/dcerpc/print_system/rpc_get_printer_driver_directory_request.rb
@@ -1,0 +1,24 @@
+module RubySMB
+  module Dcerpc
+    module PrintSystem
+
+      # [3.1.4.4.4 RpcGetPrinterDriverDirectory (Opnum 12)](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rprn/9df11cf4-4098-4852-ad72-d1f75a82bffe)
+      class RpcGetPrinterDriverDirectoryRequest < BinData::Record
+        attr_reader :opnum
+
+        endian :little
+
+        def initialize_instance
+          super
+          @opnum = RPC_GET_PRINTER_DRIVER_DIRECTORY
+        end
+
+        ndr_wide_stringz_ptr :p_name
+        ndr_wide_stringz_ptr :p_environment
+        ndr_uint32           :level
+        rprn_byte_array_ptr  :p_driver_directory
+        ndr_uint32           :cb_buf
+      end
+    end
+  end
+end

--- a/lib/ruby_smb/dcerpc/print_system/rpc_get_printer_driver_directory_response.rb
+++ b/lib/ruby_smb/dcerpc/print_system/rpc_get_printer_driver_directory_response.rb
@@ -1,0 +1,22 @@
+module RubySMB
+  module Dcerpc
+    module PrintSystem
+
+      # [3.1.4.4.4 RpcGetPrinterDriverDirectory (Opnum 12)](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rprn/9df11cf4-4098-4852-ad72-d1f75a82bffe)
+      class RpcGetPrinterDriverDirectoryResponse < BinData::Record
+        attr_reader :opnum
+
+        endian :little
+
+        def initialize_instance
+          super
+          @opnum = RPC_GET_PRINTER_DRIVER_DIRECTORY
+        end
+
+        rprn_byte_array_ptr :p_driver_directory
+        ndr_uint32          :pcb_needed
+        ndr_uint32          :error_status
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds more DCERPC definitions for EFSRPC and RPRN. The EFSRPC definitions will be used by a new PetitPotam module that will be submitted shortly. The RPRN definitions were moved from the [PrintNightmare](https://github.com/rapid7/metasploit-framework/blob/master/modules/auxiliary/admin/dcerpc/cve_2021_1675_printnightmare.rb#L10) Metasploit module.

Testing this will be easiest with the corresponding module changes.

The RPRN definitions were originally added directly to the module because at the time the RubySMB DCERPC code was in the process of a large refactor/redesign which has since been completed.