### PR TITLE
Fix File Read Operations

### DIFF
--- a/examples/read_file.rb
+++ b/examples/read_file.rb
@@ -7,34 +7,75 @@
 # and read the file short.txt
 
 require 'bundler/setup'
+require 'optparse'
 require 'ruby_smb'
 
-address      = ARGV[0]
-username     = ARGV[1]
-password     = ARGV[2]
-share        = ARGV[3]
-file         = ARGV[4]
-smb_versions = ARGV[5]&.split(',') || ['1','2','3']
+args = ARGV.dup
+options = {
+  domain: '.',
+  username: '',
+  password: '',
+  share: nil,
+  smbv1: true,
+  smbv2: true,
+  smbv3: true,
+  target: nil
+}
+options[:file] = args.pop
+options[:share] = args.pop
+options[:target ] = args.pop
+optparser = OptionParser.new do |opts|
+  opts.banner = "Usage: #{File.basename(__FILE__)} [options] target share file"
+  opts.on("--[no-]smbv1", "Enable or disable SMBv1 (default: #{options[:smbv1] ? 'Enabled' : 'Disabled'})") do |smbv1|
+    options[:smbv1] = smbv1
+  end
+  opts.on("--[no-]smbv2", "Enable or disable SMBv2 (default: #{options[:smbv2] ? 'Enabled' : 'Disabled'})") do |smbv2|
+    options[:smbv2] = smbv2
+  end
+  opts.on("--[no-]smbv3", "Enable or disable SMBv3 (default: #{options[:smbv3] ? 'Enabled' : 'Disabled'})") do |smbv3|
+    options[:smbv3] = smbv3
+  end
+  opts.on("--username USERNAME", "The account's username (default: #{options[:username]})") do |username|
+    if username.include?('\\')
+      options[:domain], options[:username] = username.split('\\', 2)
+    else
+      options[:username] = username
+    end
+  end
+  opts.on("--password PASSWORD", "The account's password (default: #{options[:password]})") do |password|
+    options[:password] = password
+  end
+end
+optparser.parse!(args)
 
-path     = "\\\\#{address}\\#{share}"
+if options[:target].nil? || options[:share].nil? || options[:file].nil?
+  abort(optparser.help)
+end
 
-sock = TCPSocket.new address, 445
+path     = "\\\\#{options[:target]}\\#{options[:share]}"
+
+sock = TCPSocket.new options[:target], 445
 dispatcher = RubySMB::Dispatcher::Socket.new(sock)
 
-client = RubySMB::Client.new(dispatcher, smb1: smb_versions.include?('1'), smb2: smb_versions.include?('2'), smb3: smb_versions.include?('3'), username: username, password: password)
+client = RubySMB::Client.new(dispatcher, smb1: options[:smbv1], smb2: options[:smbv2], smb3: options[:smbv3], username: options[:username], password: options[:password], domain: options[:domain])
 protocol = client.negotiate
 status = client.authenticate
 
 puts "#{protocol} : #{status}"
+unless status == WindowsError::NTStatus::STATUS_SUCCESS
+  puts 'Authentication failed!'
+  exit(1)
+end
 
 begin
   tree = client.tree_connect(path)
   puts "Connected to #{path} successfully!"
 rescue StandardError => e
   puts "Failed to connect to #{path}: #{e.message}"
+  exit(1)
 end
 
-file = tree.open_file(filename: file)
+file = tree.open_file(filename: options[:file])
 
 data = file.read
 puts data

--- a/lib/ruby_smb/smb1/tree.rb
+++ b/lib/ruby_smb/smb1/tree.rb
@@ -82,6 +82,9 @@ module RubySMB
       # @raise [RubySMB::Error::UnexpectedStatusCode] if the response NTStatus is not STATUS_SUCCESS
       def open_file(filename:, flags: nil, options: nil, disposition: RubySMB::Dispositions::FILE_OPEN,
                     impersonation: RubySMB::ImpersonationLevels::SEC_IMPERSONATE, read: true, write: false, delete: false)
+
+        filename = filename.dup
+        filename = filename[1..-1] if filename.start_with?('\\'.encode(filename.encoding))
         nt_create_andx_request = RubySMB::SMB1::Packet::NtCreateAndxRequest.new
         nt_create_andx_request = set_header_fields(nt_create_andx_request)
 

--- a/lib/ruby_smb/smb1/tree.rb
+++ b/lib/ruby_smb/smb1/tree.rb
@@ -59,8 +59,8 @@ module RubySMB
         # Make sure we don't modify the caller's hash options
         opts = opts.dup
         opts[:filename] = opts[:filename].dup
-        opts[:filename].prepend('\\') unless opts[:filename].start_with?('\\')
-        open_file(**opts)
+        opts[:filename].prepend('\\') unless opts[:filename].start_with?('\\'.encode(opts[:filename].encoding))
+        _open(**opts)
       end
 
       # Open a file on the remote share.
@@ -80,86 +80,12 @@ module RubySMB
       # @return [RubySMB::SMB1::File] handle to the created file
       # @raise [RubySMB::Error::InvalidPacket] if the response command is not SMB_COM_NT_CREATE_ANDX
       # @raise [RubySMB::Error::UnexpectedStatusCode] if the response NTStatus is not STATUS_SUCCESS
-      def open_file(filename:, flags: nil, options: nil, disposition: RubySMB::Dispositions::FILE_OPEN,
-                    impersonation: RubySMB::ImpersonationLevels::SEC_IMPERSONATE, read: true, write: false, delete: false)
-
-        filename = filename.dup
-        filename = filename[1..-1] if filename.start_with?('\\'.encode(filename.encoding))
-        nt_create_andx_request = RubySMB::SMB1::Packet::NtCreateAndxRequest.new
-        nt_create_andx_request = set_header_fields(nt_create_andx_request)
-
-        nt_create_andx_request.parameter_block.ext_file_attributes.normal = 1
-
-        if flags
-          nt_create_andx_request.parameter_block.flags = flags
-        else
-          nt_create_andx_request.parameter_block.flags.request_extended_response = 1
-        end
-
-        if options
-          nt_create_andx_request.parameter_block.create_options = options
-        else
-          nt_create_andx_request.parameter_block.create_options.directory_file     = 0
-          nt_create_andx_request.parameter_block.create_options.non_directory_file = 1
-        end
-
-        if read
-          nt_create_andx_request.parameter_block.share_access.share_read     = 1
-          nt_create_andx_request.parameter_block.desired_access.read_data    = 1
-          nt_create_andx_request.parameter_block.desired_access.read_ea      = 1
-          nt_create_andx_request.parameter_block.desired_access.read_attr    = 1
-          nt_create_andx_request.parameter_block.desired_access.read_control = 1
-        end
-
-        if write
-          nt_create_andx_request.parameter_block.share_access.share_write   = 1
-          nt_create_andx_request.parameter_block.desired_access.write_data  = 1
-          nt_create_andx_request.parameter_block.desired_access.append_data = 1
-          nt_create_andx_request.parameter_block.desired_access.write_ea    = 1
-          nt_create_andx_request.parameter_block.desired_access.write_attr  = 1
-        end
-
-        if delete
-          nt_create_andx_request.parameter_block.share_access.share_delete    = 1
-          nt_create_andx_request.parameter_block.desired_access.delete_access = 1
-        end
-
-        nt_create_andx_request.parameter_block.impersonation_level = impersonation
-        nt_create_andx_request.parameter_block.create_disposition  = disposition
-
-        unicode_enabled = nt_create_andx_request.smb_header.flags2.unicode == 1
-        nt_create_andx_request.data_block.file_name = add_null_termination(str: filename, unicode: unicode_enabled)
-
-        raw_response = @client.send_recv(nt_create_andx_request)
-        response = RubySMB::SMB1::Packet::NtCreateAndxResponse.read(raw_response)
-        unless response.valid?
-          if response.is_a?(RubySMB::SMB1::Packet::EmptyPacket) &&
-               response.smb_header.protocol == RubySMB::SMB1::SMB_PROTOCOL_ID &&
-               response.smb_header.command == response.original_command
-            raise RubySMB::Error::InvalidPacket.new(
-              'The response seems to be an SMB1 NtCreateAndxResponse but an '\
-              'error occurs while parsing it. It is probably missing the '\
-              'required extended information.'
-            )
-          end
-          raise RubySMB::Error::InvalidPacket.new(
-            expected_proto: RubySMB::SMB1::SMB_PROTOCOL_ID,
-            expected_cmd:   RubySMB::SMB1::Packet::NtCreateAndxResponse::COMMAND,
-            packet:         response
-          )
-        end
-        unless response.status_code == WindowsError::NTStatus::STATUS_SUCCESS
-          raise RubySMB::Error::UnexpectedStatusCode, response.status_code
-        end
-
-        case response.parameter_block.resource_type
-        when RubySMB::SMB1::ResourceType::BYTE_MODE_PIPE, RubySMB::SMB1::ResourceType::MESSAGE_MODE_PIPE
-          RubySMB::SMB1::Pipe.new(name: filename, tree: self, response: response)
-        when RubySMB::SMB1::ResourceType::DISK
-          RubySMB::SMB1::File.new(name: filename, tree: self, response: response)
-        else
-          raise RubySMB::Error::RubySMBError
-        end
+      def open_file(opts)
+        # Make sure we don't modify the caller's hash options
+        opts = opts.dup
+        opts[:filename] = opts[:filename].dup
+        opts[:filename] = opts[:filename][1..-1] if opts[:filename].start_with?('\\'.encode(opts[:filename].encoding))
+        _open(**opts)
       end
 
       # List `directory` on the remote share.
@@ -266,6 +192,85 @@ module RubySMB
       end
 
       private
+
+      def _open(filename:, flags: nil, options: nil, disposition: RubySMB::Dispositions::FILE_OPEN,
+                impersonation: RubySMB::ImpersonationLevels::SEC_IMPERSONATE, read: true, write: false, delete: false)
+        nt_create_andx_request = RubySMB::SMB1::Packet::NtCreateAndxRequest.new
+        nt_create_andx_request = set_header_fields(nt_create_andx_request)
+
+        nt_create_andx_request.parameter_block.ext_file_attributes.normal = 1
+
+        if flags
+          nt_create_andx_request.parameter_block.flags = flags
+        else
+          nt_create_andx_request.parameter_block.flags.request_extended_response = 1
+        end
+
+        if options
+          nt_create_andx_request.parameter_block.create_options = options
+        else
+          nt_create_andx_request.parameter_block.create_options.directory_file     = 0
+          nt_create_andx_request.parameter_block.create_options.non_directory_file = 1
+        end
+
+        if read
+          nt_create_andx_request.parameter_block.share_access.share_read     = 1
+          nt_create_andx_request.parameter_block.desired_access.read_data    = 1
+          nt_create_andx_request.parameter_block.desired_access.read_ea      = 1
+          nt_create_andx_request.parameter_block.desired_access.read_attr    = 1
+          nt_create_andx_request.parameter_block.desired_access.read_control = 1
+        end
+
+        if write
+          nt_create_andx_request.parameter_block.share_access.share_write   = 1
+          nt_create_andx_request.parameter_block.desired_access.write_data  = 1
+          nt_create_andx_request.parameter_block.desired_access.append_data = 1
+          nt_create_andx_request.parameter_block.desired_access.write_ea    = 1
+          nt_create_andx_request.parameter_block.desired_access.write_attr  = 1
+        end
+
+        if delete
+          nt_create_andx_request.parameter_block.share_access.share_delete    = 1
+          nt_create_andx_request.parameter_block.desired_access.delete_access = 1
+        end
+
+        nt_create_andx_request.parameter_block.impersonation_level = impersonation
+        nt_create_andx_request.parameter_block.create_disposition  = disposition
+
+        unicode_enabled = nt_create_andx_request.smb_header.flags2.unicode == 1
+        nt_create_andx_request.data_block.file_name = add_null_termination(str: filename, unicode: unicode_enabled)
+
+        raw_response = @client.send_recv(nt_create_andx_request)
+        response = RubySMB::SMB1::Packet::NtCreateAndxResponse.read(raw_response)
+        unless response.valid?
+          if response.is_a?(RubySMB::SMB1::Packet::EmptyPacket) &&
+               response.smb_header.protocol == RubySMB::SMB1::SMB_PROTOCOL_ID &&
+               response.smb_header.command == response.original_command
+            raise RubySMB::Error::InvalidPacket.new(
+              'The response seems to be an SMB1 NtCreateAndxResponse but an '\
+              'error occurs while parsing it. It is probably missing the '\
+              'required extended information.'
+            )
+          end
+          raise RubySMB::Error::InvalidPacket.new(
+            expected_proto: RubySMB::SMB1::SMB_PROTOCOL_ID,
+            expected_cmd:   RubySMB::SMB1::Packet::NtCreateAndxResponse::COMMAND,
+            packet:         response
+          )
+        end
+        unless response.status_code == WindowsError::NTStatus::STATUS_SUCCESS
+          raise RubySMB::Error::UnexpectedStatusCode, response.status_code
+        end
+
+        case response.parameter_block.resource_type
+        when RubySMB::SMB1::ResourceType::BYTE_MODE_PIPE, RubySMB::SMB1::ResourceType::MESSAGE_MODE_PIPE
+          RubySMB::SMB1::Pipe.new(name: filename, tree: self, response: response)
+        when RubySMB::SMB1::ResourceType::DISK
+          RubySMB::SMB1::File.new(name: filename, tree: self, response: response)
+        else
+          raise RubySMB::Error::RubySMBError
+        end
+      end
 
       # Sets ParameterBlock options for FIND_FIRST2 and
       # FIND_NEXT2 requests. In particular we need to do this

--- a/lib/ruby_smb/smb2/tree.rb
+++ b/lib/ruby_smb/smb2/tree.rb
@@ -60,13 +60,15 @@ module RubySMB
         # Make sure we don't modify the caller's hash options
         opts = opts.dup
         opts[:filename] = opts[:filename].dup
-        opts[:filename] = opts[:filename][1..-1] if opts[:filename].start_with? '\\'
+        opts[:filename] = opts[:filename][1..-1] if opts[:filename].start_with?('\\')
         open_file(**opts)
       end
 
       def open_file(filename:, attributes: nil, options: nil, disposition: RubySMB::Dispositions::FILE_OPEN,
                     impersonation: RubySMB::ImpersonationLevels::SEC_IMPERSONATE, read: true, write: false, delete: false)
 
+        filename = filename.dup
+        filename = filename[1..-1] if filename.start_with?('\\'.encode(filename.encoding))
         create_request = RubySMB::SMB2::Packet::CreateRequest.new
         create_request = set_header_fields(create_request)
 

--- a/spec/lib/ruby_smb/smb1/tree_spec.rb
+++ b/spec/lib/ruby_smb/smb1/tree_spec.rb
@@ -495,17 +495,17 @@ RSpec.describe RubySMB::SMB1::Tree do
   describe '#open_pipe' do
     let(:opts) { { filename: 'test', write: true } }
     before :example do
-      allow(tree).to receive(:open_file)
+      allow(tree).to receive(:_open)
     end
 
     it 'calls #open_file with the provided options' do
       opts[:filename] ='\\test'
-      expect(tree).to receive(:open_file).with(opts)
+      expect(tree).to receive(:_open).with(opts)
       tree.open_pipe(**opts)
     end
 
     it 'prepends the filename with \\ if needed' do
-      expect(tree).to receive(:open_file).with(filename: '\\test', write: true)
+      expect(tree).to receive(:_open).with(filename: '\\test', write: true)
       tree.open_pipe(**opts)
     end
 

--- a/spec/lib/ruby_smb/smb2/tree_spec.rb
+++ b/spec/lib/ruby_smb/smb2/tree_spec.rb
@@ -535,17 +535,17 @@ RSpec.describe RubySMB::SMB2::Tree do
   describe '#open_pipe' do
     let(:opts) { { filename: '\\test', write: true } }
     before :example do
-      allow(tree).to receive(:open_file)
+      allow(tree).to receive(:_open)
     end
 
     it 'calls #open_file with the provided options' do
       opts[:filename] ='test'
-      expect(tree).to receive(:open_file).with(**opts)
+      expect(tree).to receive(:_open).with(**opts)
       tree.open_pipe(**opts)
     end
 
     it 'remove the leading \\ from the filename if needed' do
-      expect(tree).to receive(:open_file).with(filename: 'test', write: true)
+      expect(tree).to receive(:_open).with(filename: 'test', write: true)
       tree.open_pipe(**opts)
     end
 


### PR DESCRIPTION
Since commit 6cca27c, the open file operations no longer remove the `\` prefix on file paths. This broke file read operations as used by Metasploit. This resulted in execution failures when Metasploit's `psexec` module was used with the Command target which needs to read the file output. This readds the logic to remove the unnecessary prefix when opening files. This change has been tested using the newly updated read_file example on SMB versions 1, 2, 3 with and without a path with a `\` prefix.

- [ ] Use the example read_file to read a file path containing a leading `\`
- [ ] See the example script work
- [ ] Try it again with different SMB versions
    * Enable SMB 1 by following these instructions: https://docs.microsoft.com/en-us/windows-server/storage/file-server/troubleshoot/detect-enable-and-disable-smbv1-v2-v3

## Demo
This example shows reading a file from the temp directory that was created using psexec. SMB3 is used, but can be disabled using the CLI options on the example. Note that the file path contains a `\` prefix.
```
ruby read_file.rb --username smcintyre --password Password1 192.168.159.96 C$ "\\Windows\\Temp\\uDDauZxRI.txt"
SMB3 : (0x00000000) STATUS_WAIT_0: The caller specified WaitAny for WaitType and one of the dispatcher objects in the Object array has been set to the signaled state.
Connected to \\192.168.159.96\C$ successfully!

User accounts for \\

-------------------------------------------------------------------------------
$431000-ERJAFULIQUSS     Administrator            aliddle                  
Guest                    HealthMailbox0896988     HealthMailbox23c9938     
HealthMailbox256d6c9     HealthMailbox3dd648f     HealthMailbox3ef3d8d     
HealthMailbox8710d04     HealthMailbox8c45655     HealthMailboxa04271a     
HealthMailboxcad83a9     HealthMailboxde93ebe     HealthMailboxf4602f9     
jdoe                     krbtgt                   SM_2e9af84fe4c6473ea     
SM_3879f1f6de9b49818     SM_3c6a2d0a4c8648c9b     SM_5784a59a716948118     
SM_97642fc203314e6f8     SM_9db3f69793764fde9     SM_ac24b3f263bb427f9     
SM_c2d9a2c8d3844cd29     SM_f5faf24b3b1c46efa     smcintyre                
The command completed with one or more errors.

```

<details>
<summary>PSexec bug output</summary>

Using the "Command" target.

```
[*] 192.168.159.96:445 - Connecting to the server...
[*] 192.168.159.96:445 - Authenticating to 192.168.159.96:445 as user 'smcintyre'...
[+] 192.168.159.96:445 - Service start timed out, OK if running a command or non-service executable...
[-] 192.168.159.96:445 - Unable to get handle: The server responded with an unexpected status code: STATUS_INVALID_PARAMETER
[-] 192.168.159.96:445 - Command seems to still be executing. Try increasing RETRY and DELAY
[*] 192.168.159.96:445 - Getting the command output...
[-] 192.168.159.96:445 - Unable to read file \Windows\Temp\uDDauZxRI.txt. RubySMB::Error::UnexpectedStatusCode: The server responded with an unexpected status code: STATUS_INVALID_PARAMETER.
[-] 192.168.159.96:445 - Error getting command output
[*] 192.168.159.96:445 - Executing cleanup...
[-] 192.168.159.96:445 - Unable to cleanup \Windows\Temp\HvXgAIlbtIRw.bat. Error: The server responded with an unexpected status code: STATUS_INVALID_PARAMETER
[+] 192.168.159.96:445 - Cleanup was successful
[*] Exploit completed, but no session was created.
```
</details>