### PR TITLE
Fix wipe_state! crash

### DIFF
--- a/lib/ruby_smb/client.rb
+++ b/lib/ruby_smb/client.rb
@@ -597,7 +597,7 @@ module RubySMB
       self.session_id       = 0x00
       self.user_id          = 0x00
       self.session_key      = ''
-      self.session_is_guest = false
+      @session_is_guest = false
       self.sequence_counter = 0
       self.smb2_message_id  = 0
       self.client_encryption_key = nil

--- a/lib/ruby_smb/client.rb
+++ b/lib/ruby_smb/client.rb
@@ -129,6 +129,11 @@ module RubySMB
     #   @return [Integer]
     attr_accessor :session_id
 
+    # Whether or not the current session has the guest flag set
+    # @!attribute [rw] session_is_guest
+    #   @return [Boolean]
+    attr_accessor :session_is_guest
+
     # Whether or not the Server requires signing
     # @!attribute [rw] signing_enabled
     #   @return [Boolean]
@@ -597,7 +602,7 @@ module RubySMB
       self.session_id       = 0x00
       self.user_id          = 0x00
       self.session_key      = ''
-      @session_is_guest = false
+      self.session_is_guest = false
       self.sequence_counter = 0
       self.smb2_message_id  = 0
       self.client_encryption_key = nil

--- a/spec/lib/ruby_smb/client_spec.rb
+++ b/spec/lib/ruby_smb/client_spec.rb
@@ -557,6 +557,16 @@ RSpec.describe RubySMB::Client do
     end
   end
 
+  describe '#wipe_state!' do
+    context 'with SMB1' do
+      it { expect { smb1_client.wipe_state! }.to_not raise_error }
+    end
+
+    context 'with SMB2' do
+      it { expect { smb2_client.wipe_state! }.to_not raise_error }
+    end
+  end
+
   describe '#logoff!' do
     context 'with SMB1' do
       let(:raw_response) { double('Raw response') }


### PR DESCRIPTION
 Fixes a crash within `wipe_state!`

> Module Exception: undefined method `session_is_guest=' for #<RubySMB::Client:0x00007fe2cda07258 dispatcher=#<RubySMB::Dispatcher::Socket:0x00007fe2cda07410 tcp_socket=#<Socket:fd 30>, read_timeout=30>, pid=8944, domain="WORKSTATION", local_workstation="WORKSTATION",  ... etc ...>
> Did you mean?  session_request 

Previous error:

```
  2) RubySMB::Client#wipe_state! with SMB1 is expected not to raise Exception
     Failure/Error: it { expect { smb1_client.wipe_state! }.to_not raise_error }
     
       expected no Exception, got #<NoMethodError: undefined method `session_is_guest=' for #<RubySMB::Client:0x00007fd9e6959a08>
       Did you mean?  session_request> with backtrace:
         # ./lib/ruby_smb/client.rb:600:in `wipe_state!'
         # ./spec/lib/ruby_smb/client_spec.rb:562:in `block (5 levels) in <top (required)>'
```