### PR TITLE
Add additional specs to #open_file for slashes

### DIFF
--- a/spec/lib/ruby_smb/smb1/tree_spec.rb
+++ b/spec/lib/ruby_smb/smb1/tree_spec.rb
@@ -118,6 +118,11 @@ RSpec.describe RubySMB::SMB1::Tree do
         end
         tree.open_file(filename: unicode_filename.chop)
       end
+
+      it 'removes the leading \\ from the filename if needed' do
+        expect(tree).to receive(:_open).with(filename: filename)
+        tree.open_file(filename: '\\' + filename)
+      end
     end
 
     describe 'flags' do

--- a/spec/lib/ruby_smb/smb2/tree_spec.rb
+++ b/spec/lib/ruby_smb/smb2/tree_spec.rb
@@ -348,6 +348,11 @@ RSpec.describe RubySMB::SMB2::Tree do
         end
         tree.open_file(filename: filename)
       end
+
+       it 'removes the leading \\ from the filename if needed' do
+        expect(tree).to receive(:_open).with(filename: filename)
+        tree.open_file(filename: "\\".encode('UTF-16LE') + filename)
+      end
     end
 
     describe 'attributes' do
@@ -544,7 +549,7 @@ RSpec.describe RubySMB::SMB2::Tree do
       tree.open_pipe(**opts)
     end
 
-    it 'remove the leading \\ from the filename if needed' do
+    it 'removes the leading \\ from the filename if needed' do
       expect(tree).to receive(:_open).with(filename: 'test', write: true)
       tree.open_pipe(**opts)
     end


### PR DESCRIPTION
This adds additional tests for `#open_file` to ensure that slashes are normalized correctly as they are for `#open_pipe`. This tests both SMB1 and SMB2/3. These changes were originally [requested](https://github.com/rapid7/ruby_smb/pull/193#discussion_r804847639) as part of #193 but were submitted in a separate PR to avoid postponing that one which was a fix.

# Testing
- [ ] Seeing the unit tests pass should be sufficient, no lib changes were made only the specs were updated