### PR TITLE
Enable server-side SMB encryption

### DIFF
--- a/lib/ruby_smb/server/server_client.rb
+++ b/lib/ruby_smb/server/server_client.rb
@@ -404,6 +404,12 @@ module RubySMB
           if response.is_a?(SMB2::Packet::ErrorPacket)
             response.smb2_header.command = header.command if response.smb2_header.command == 0
             response.smb2_header.flags.reply = 1
+            nt_status = response.smb2_header.nt_status.to_i
+            message = "Sending an error packet for SMB2 command: #{SMB2::Commands.name(header.command)}, status: 0x#{nt_status.to_s(16).rjust(8, '0')}"
+            if (nt_status_name = WindowsError::NTStatus.find_by_retval(nt_status).first&.name)
+              message << " (#{nt_status_name})"
+            end
+            logger.info(message)
           end
 
           response.smb2_header.credits = 1 if response.smb2_header.credits == 0

--- a/lib/ruby_smb/server/server_client.rb
+++ b/lib/ruby_smb/server/server_client.rb
@@ -6,12 +6,14 @@ module RubySMB
 
       require 'ruby_smb/dialect'
       require 'ruby_smb/signing'
+      require 'ruby_smb/server/server_client/encryption'
       require 'ruby_smb/server/server_client/negotiation'
       require 'ruby_smb/server/server_client/session_setup'
       require 'ruby_smb/server/server_client/share_io'
       require 'ruby_smb/server/server_client/tree_connect'
 
       include RubySMB::Signing
+      include RubySMB::Server::ServerClient::Encryption
       include RubySMB::Server::ServerClient::Negotiation
       include RubySMB::Server::ServerClient::SessionSetup
       include RubySMB::Server::ServerClient::ShareIO
@@ -26,6 +28,7 @@ module RubySMB
         @dispatcher = dispatcher
         @dialect = nil
         @sequence_counter = 0
+        @cipher_id = 0
         @gss_authenticator = server.gss_provider.new_authenticator(self)
         @preauth_integrity_hash_algorithm = nil
         @preauth_integrity_hash_value = nil
@@ -104,41 +107,23 @@ module RubySMB
             response.smb_header.mid = header.mid if response.smb_header.mid == 0
           end
         when RubySMB::SMB2::SMB2_PROTOCOL_ID
+          response = _handle_smb2(raw_request)
+        when RubySMB::SMB2::SMB2_TRANSFORM_PROTOCOL_ID
           begin
-            header = RubySMB::SMB2::SMB2Header.read(raw_request)
+            header = RubySMB::SMB2::Packet::TransformHeader.read(raw_request)
           rescue IOError => e
-            logger.error("Caught a #{e.class} while reading the SMB2 header (#{e.message})")
+            logger.error("Caught a #{e.class} while reading the SMB3 Transform header")
             disconnect!
             return
           end
 
           begin
-            response = handle_smb2(raw_request, header)
-          rescue NotImplementedError => e
-            message = "Caught a NotImplementedError while handling a #{SMB2::Commands.name(header.command)} request"
-            message << " (#{e.message})" if e.message
-            logger.error(message)
+            response = handle_smb3_transform(raw_request, header)
+          rescue NotImplementedError
+            logger.error("Caught a NotImplementedError while handling a SMB3 Transform request")
             response = SMB2::Packet::ErrorPacket.new
             response.smb2_header.nt_status = WindowsError::NTStatus::STATUS_NOT_SUPPORTED
-          end
-
-          unless response.nil?
-            # set these header fields if they were not initialized
-            if response.is_a?(SMB2::Packet::ErrorPacket)
-              response.smb2_header.command = header.command if response.smb2_header.command == 0
-              response.smb2_header.flags.reply = 1
-              nt_status = response.smb2_header.nt_status.to_i
-              message = "Sending an error packet for SMB2 command: #{SMB2::Commands.name(header.command)}, status: 0x#{nt_status.to_s(16).rjust(8, '0')}"
-              if (nt_status_name = WindowsError::NTStatus.find_by_retval(nt_status).first&.name)
-                message << " (#{nt_status_name})"
-              end
-              logger.info(message)
-            end
-
-            response.smb2_header.credits = 1 if response.smb2_header.credits == 0
-            response.smb2_header.message_id = header.message_id if response.smb2_header.message_id == 0
-            response.smb2_header.session_id = header.session_id if response.smb2_header.session_id == 0
-            response.smb2_header.tree_id = header.tree_id if response.smb2_header.tree_id == 0
+            response.smb2_header.session_id = header.session_id
           end
         end
 
@@ -231,15 +216,21 @@ module RubySMB
       #
       # @param [GenericPacket] packet the packet to send
       def send_packet(packet)
-        case metadialect&.order
-        when Dialect::ORDER_SMB1
+        case metadialect&.family
+        when Dialect::FAMILY_SMB1
           session_id = packet.smb_header.uid
-        when Dialect::ORDER_SMB2
+        when Dialect::FAMILY_SMB2
           session_id = packet.smb2_header.session_id
+        when Dialect::FAMILY_SMB3
+          if packet.is_a?(RubySMB::SMB2::Packet::TransformHeader)
+            session_id = packet.session_id
+          else
+            session_id = packet.smb2_header.session_id
+          end
         end
         session = @session_table[session_id]
 
-        unless session.nil? || session.is_anonymous || session.key.nil?
+        unless session.nil? || session.is_anonymous || session.key.nil? || packet.is_a?(RubySMB::SMB2::Packet::TransformHeader)
           case metadialect&.family
           when Dialect::FAMILY_SMB1
             packet = Signing::smb1_sign(packet, session.key, @sequence_counter)
@@ -398,6 +389,54 @@ module RubySMB
 
         logger.debug("Dispatching request to #{dispatcher} (session: #{session.inspect})")
         send(dispatcher, request, session)
+      end
+
+      def _handle_smb2(raw_request)
+        begin
+          header = RubySMB::SMB2::SMB2Header.read(raw_request)
+        rescue IOError => e
+          logger.error("Caught a #{e.class} while reading the SMB2 header (#{e.message})")
+          disconnect!
+          return
+        end
+
+        begin
+          response = handle_smb2(raw_request, header)
+        rescue NotImplementedError
+          logger.error("Caught a NotImplementedError while handling a #{SMB2::Commands.name(header.command)} request")
+          response = SMB2::Packet::ErrorPacket.new
+          response.smb2_header.nt_status = WindowsError::NTStatus::STATUS_NOT_SUPPORTED
+        end
+
+        unless response.nil?
+          # set these header fields if they were not initialized
+          if response.is_a?(SMB2::Packet::ErrorPacket)
+            response.smb2_header.command = header.command if response.smb2_header.command == 0
+            response.smb2_header.flags.reply = 1
+          end
+
+          response.smb2_header.credits = 1 if response.smb2_header.credits == 0
+          response.smb2_header.message_id = header.message_id if response.smb2_header.message_id == 0
+          response.smb2_header.session_id = header.session_id if response.smb2_header.session_id == 0
+          response.smb2_header.tree_id = header.tree_id if response.smb2_header.tree_id == 0
+        end
+
+        response
+      end
+
+      def handle_smb3_transform(raw_request, header)
+        session = @session_table[header.session_id]
+        if session.nil?
+          response = SMB2::Packet::ErrorPacket.new
+          response.smb2_header.nt_status = WindowsError::NTStatus::STATUS_USER_SESSION_DELETED
+          return response
+        end
+
+        pt_raw_request = smb3_decrypt(header, session)
+        pt_response = _handle_smb2(pt_raw_request)
+        return unless pt_response
+
+        smb3_encrypt(pt_response.to_binary_s, session)
       end
     end
   end

--- a/lib/ruby_smb/server/server_client/encryption.rb
+++ b/lib/ruby_smb/server/server_client/encryption.rb
@@ -22,7 +22,7 @@ module RubySMB
           end
 
           th = RubySMB::SMB2::Packet::TransformHeader.new(flags: 1, session_id: session.id)
-          th.encrypt(data, server_encryption_key, algorithm: 'AES-128-CCM')
+          th.encrypt(data, server_encryption_key, algorithm: SMB2::EncryptionCapabilities::ENCRYPTION_ALGORITHM_MAP[@cipher_id])
           th
         end
 
@@ -44,7 +44,7 @@ module RubySMB
             raise RubySMB::Error::EncryptionError.new('Dialect is incompatible with SMBv3 encryption')
           end
 
-          encrypted_request.decrypt(client_encryption_key, algorithm: 'AES-128-CCM')
+          encrypted_request.decrypt(client_encryption_key, algorithm: SMB2::EncryptionCapabilities::ENCRYPTION_ALGORITHM_MAP[@cipher_id])
         end
       end
     end

--- a/lib/ruby_smb/server/server_client/encryption.rb
+++ b/lib/ruby_smb/server/server_client/encryption.rb
@@ -1,0 +1,52 @@
+module RubySMB
+  class Server
+    class ServerClient
+      # Contains the methods for handling encryption / decryption
+      module Encryption
+        def smb3_encrypt(data, session)
+          case @dialect
+          when '0x0300', '0x0302'
+            server_encryption_key = RubySMB::Crypto::KDF.counter_mode(
+              session.key,
+              "SMB2AESCCM\x00",
+              "ServerOut\x00"
+            )
+          when '0x0311'
+            server_encryption_key = RubySMB::Crypto::KDF.counter_mode(
+              session.key,
+              "SMBS2CCipherKey\x00",
+              @preauth_integrity_hash_value
+            )
+          else
+            raise RubySMB::Error::EncryptionError.new('Dialect is incompatible with SMBv3 decryption')
+          end
+
+          th = RubySMB::SMB2::Packet::TransformHeader.new(flags: 1, session_id: session.id)
+          th.encrypt(data, server_encryption_key, algorithm: 'AES-128-CCM')
+          th
+        end
+
+        def smb3_decrypt(encrypted_request, session)
+          case @dialect
+          when '0x0300', '0x0302'
+            client_encryption_key = RubySMB::Crypto::KDF.counter_mode(
+              session.key,
+              "SMB2AESCCM\x00",
+              "ServerIn \x00"
+            )
+          when '0x0311'
+            client_encryption_key = RubySMB::Crypto::KDF.counter_mode(
+              session.key,
+              "SMBC2SCipherKey\x00",
+              @preauth_integrity_hash_value
+            )
+          else
+            raise RubySMB::Error::EncryptionError.new('Dialect is incompatible with SMBv3 encryption')
+          end
+
+          encrypted_request.decrypt(client_encryption_key, algorithm: 'AES-128-CCM')
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby_smb/server/server_client/negotiation.rb
+++ b/lib/ruby_smb/server/server_client/negotiation.rb
@@ -120,13 +120,19 @@ module RubySMB
 
             nc = request.find_negotiate_context(SMB2::NegotiateContext::SMB2_ENCRYPTION_CAPABILITIES)
             cipher = nc&.data&.ciphers&.first
-            cipher = 0 unless SMB2::EncryptionCapabilities::ENCRYPTION_ALGORITHM_MAP.include? cipher
+            if SMB2::EncryptionCapabilities::ENCRYPTION_ALGORITHM_MAP.include? cipher
+              @cipher_id = cipher
+            else
+              cipher = 0
+            end
             contexts << SMB2::NegotiateContext.new(
               context_type: SMB2::NegotiateContext::SMB2_ENCRYPTION_CAPABILITIES,
               data: {
                 ciphers: [ cipher ]
               }
             )
+          elsif dialect == '0x0300' || dialect == '0x0302'
+            @cipher_id = SMB2::EncryptionCapabilities::AES_128_CCM
           end
 
           # the order in which the response is built is important to ensure it is valid

--- a/lib/ruby_smb/server/server_client/negotiation.rb
+++ b/lib/ruby_smb/server/server_client/negotiation.rb
@@ -132,7 +132,12 @@ module RubySMB
               }
             )
           elsif dialect == '0x0300' || dialect == '0x0302'
-            @cipher_id = SMB2::EncryptionCapabilities::AES_128_CCM
+            if request.capabilities.encryption == 1
+              response.capabilities.encryption = 1
+              @cipher_id = SMB2::EncryptionCapabilities::AES_128_CCM
+            else
+              response.capabilities = 0
+            end
           end
 
           # the order in which the response is built is important to ensure it is valid

--- a/lib/ruby_smb/server/server_client/session_setup.rb
+++ b/lib/ruby_smb/server/server_client/session_setup.rb
@@ -84,7 +84,8 @@ module RubySMB
             session.signing_required = request.security_mode.signing_required == 1
 
             response.smb2_header.credits = 32
-            response.session_flags.encrypt_data = 1 if metadialect&.family == Dialect::FAMILY_SMB3 && @cipher_id != 0
+            @cipher_id = 0 if session.is_anonymous # disable encryption for anonymous users
+            response.session_flags.encrypt_data = 1 unless @cipher_id == 0
           elsif gss_result.nt_status == WindowsError::NTStatus::STATUS_MORE_PROCESSING_REQUIRED && @dialect == '0x0311'
             update_preauth_hash(response)
           end

--- a/lib/ruby_smb/smb2.rb
+++ b/lib/ruby_smb/smb2.rb
@@ -5,6 +5,7 @@ module RubySMB
   module SMB2
     # Protocol ID value. Translates to \xFESMB
     SMB2_PROTOCOL_ID = 0xFE534D42
+    SMB2_TRANSFORM_PROTOCOL_ID = 0xFD534D42
     # Wildcard revision, see: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/63abf97c-0d09-47e2-88d6-6bfa552949a5
     SMB2_WILDCARD_REVISION = 0x02ff
 

--- a/lib/ruby_smb/smb2/packet/transform_header.rb
+++ b/lib/ruby_smb/smb2/packet/transform_header.rb
@@ -8,7 +8,7 @@ module RubySMB
         hide   :reserved0
 
         endian           :little
-        bit32            :protocol,              label: 'Protocol ID Field',      initial_value: 0xFD534D42
+        bit32            :protocol,              label: 'Protocol ID Field',      initial_value: RubySMB::SMB2::SMB2_TRANSFORM_PROTOCOL_ID
         string           :signature,             label: 'Signature', length: 16
         string           :nonce,                 label: 'Nonce',     length: 16
         uint32           :original_message_size, label: 'Original Message Size'


### PR DESCRIPTION
This enables encryption for the established session. It is only available when the client supports it and the dialect is one in SMB3. When enabled though, it's enabled at the session level to enable encrypting the most requests as opposed to enabling it at the share / tree-connect level. This is akin to running:

> To enable SMB Encryption for the entire file server, type the following script on the server:
```
Set-SmbServerConfiguration –EncryptData $true
```
https://docs.microsoft.com/en-us/windows-server/storage/file-server/smb-security

I tested the 3.1.1 and 3.0.2 dialects since they execute slightly different code paths, using a Windows Server 2019 client and the RubySMB client. To force the client to negotiate 3.1.1, I modified the code to remove the 3.1.1 from the dialects that are offered during negotiation. From there I confirmed that 3.0.2 was negotiated from the log output and within Wireshark. Encrypted requests can contain multiple requests within themselves. To accommodate this, some edits were made to the dispatcher code to keep things from being repeated too many places. Basically the encrypted handler will also break apart the chain and process each request individually. At first I tried to reply with a single encrypted frame containing all of the responses, but that didn't seem to be accepted by the Windows client. What it does instead is send each response in it's own encrypted frame as it's done being processed. This is also how the server processes plaintext-chained commands where again the responses are sent individually after they are processed.

# Testing

- [ ] Start the file server
- [ ] Request a file from a Windows client that supports the 3.1.1 dialect, see the traffic is all encrypted after the session is setup
- [ ] Request a file from a Windows client that supports the 3.0.2 dialect, see the traffic is all encrypted after the session is setup
    * Alternatively you can edit the server code to not negotiate 3.1.1