### PR TITLE
Bump the windows_error gem to v0.1.4

### DIFF
--- a/ruby_smb.gemspec
+++ b/ruby_smb.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'yard'
 
   spec.add_runtime_dependency 'rubyntlm'
-  spec.add_runtime_dependency 'windows_error', '>= 0.1.3'
+  spec.add_runtime_dependency 'windows_error', '>= 0.1.4'
   spec.add_runtime_dependency 'bindata'
   spec.add_runtime_dependency 'openssl-ccm'
   spec.add_runtime_dependency 'openssl-cmac'


### PR DESCRIPTION
This bumps the windows_error gem to v.0.1.4 to pull in https://github.com/rapid7/windows_error/pull/4 which should fix our unit tests.

Once our unit tests pass this should be good to land. After that PRs that are currently failing should be rebased.

Fixes #198 