### PR TITLE
Add AES-256 support

### DIFF
--- a/lib/ruby_smb/client/encryption.rb
+++ b/lib/ruby_smb/client/encryption.rb
@@ -4,6 +4,8 @@ module RubySMB
     module Encryption
       def smb3_encrypt(data)
         unless @client_encryption_key
+          raise RubySMB::Error::EncryptionError.new('The encryption algorithm has not be set') if @encryption_algorithm.nil?
+
           key_bit_len = OpenSSL::Cipher.new(@encryption_algorithm).key_len * 8
 
           case @dialect
@@ -37,6 +39,8 @@ module RubySMB
 
       def smb3_decrypt(th)
         unless @server_encryption_key
+          raise RubySMB::Error::EncryptionError.new('The encryption algorithm has not be set') if @encryption_algorithm.nil?
+
           key_bit_len = OpenSSL::Cipher.new(@encryption_algorithm).key_len * 8
 
           case @dialect

--- a/lib/ruby_smb/client/negotiation.rb
+++ b/lib/ruby_smb/client/negotiation.rb
@@ -265,8 +265,10 @@ module RubySMB
           nc = RubySMB::SMB2::NegotiateContext.new(
             context_type: RubySMB::SMB2::NegotiateContext::SMB2_ENCRYPTION_CAPABILITIES
           )
-          nc.data.ciphers << RubySMB::SMB2::EncryptionCapabilities::AES_128_CCM
+          nc.data.ciphers << RubySMB::SMB2::EncryptionCapabilities::AES_256_GCM
+          nc.data.ciphers << RubySMB::SMB2::EncryptionCapabilities::AES_256_CCM
           nc.data.ciphers << RubySMB::SMB2::EncryptionCapabilities::AES_128_GCM
+          nc.data.ciphers << RubySMB::SMB2::EncryptionCapabilities::AES_128_CCM
           packet.add_negotiate_context(nc)
 
           nc = RubySMB::SMB2::NegotiateContext.new(

--- a/lib/ruby_smb/smb2/negotiate_context.rb
+++ b/lib/ruby_smb/smb2/negotiate_context.rb
@@ -22,9 +22,13 @@ module RubySMB
     class EncryptionCapabilities < BinData::Record
       AES_128_CCM = 0x0001
       AES_128_GCM = 0x0002
+      AES_256_CCM = 0x0003
+      AES_256_GCM = 0x0004
       ENCRYPTION_ALGORITHM_MAP = {
         AES_128_CCM => 'AES-128-CCM',
-        AES_128_GCM => 'AES-128-GCM'
+        AES_128_GCM => 'AES-128-GCM',
+        AES_256_CCM => 'AES-256-CCM',
+        AES_256_GCM => 'AES-256-GCM'
       }
 
       endian  :little

--- a/spec/lib/ruby_smb/client_spec.rb
+++ b/spec/lib/ruby_smb/client_spec.rb
@@ -962,8 +962,10 @@ RSpec.describe RubySMB::Client do
           expect(nc.length).to eq(1)
           expect(nc.first.data.ciphers).to eq(
             [
-              RubySMB::SMB2::EncryptionCapabilities::AES_128_CCM,
-              RubySMB::SMB2::EncryptionCapabilities::AES_128_GCM
+              RubySMB::SMB2::EncryptionCapabilities::AES_256_GCM,
+              RubySMB::SMB2::EncryptionCapabilities::AES_256_CCM,
+              RubySMB::SMB2::EncryptionCapabilities::AES_128_GCM,
+              RubySMB::SMB2::EncryptionCapabilities::AES_128_CCM
             ]
           )
         end
@@ -2681,13 +2683,15 @@ RSpec.describe RubySMB::Client do
         context "with #{dialect} dialect" do
           before :example do
             client.dialect = dialect
+            client.encryption_algorithm = 'AES-128-CCM'
           end
 
           it 'generates the client encryption key with the expected parameters' do
             expect(RubySMB::Crypto::KDF).to receive(:counter_mode).with(
               session_key,
               "SMB2AESCCM\x00",
-              "ServerIn \x00"
+              "ServerIn \x00",
+              {length: 128}
             ).and_call_original
             client.smb3_encrypt(data)
           end
@@ -2698,10 +2702,12 @@ RSpec.describe RubySMB::Client do
         it 'generates the client encryption key with the expected parameters' do
           client.preauth_integrity_hash_value = ''
           client.dialect = '0x0311'
+          client.encryption_algorithm = 'AES-128-CCM'
           expect(RubySMB::Crypto::KDF).to receive(:counter_mode).with(
             session_key,
             "SMBC2SCipherKey\x00",
-            ''
+            '',
+            {length: 128}
           ).and_call_original
           client.smb3_encrypt(data)
         end
@@ -2723,6 +2729,7 @@ RSpec.describe RubySMB::Client do
 
       it 'generates the expected client encryption key with 0x0302 dialect' do
         client.dialect = '0x0302'
+        client.encryption_algorithm = 'AES-128-CCM'
         expected_enc_key =
           "\xa4\xfa\x23\xc1\xb0\x65\x84\xce\x47\x08\x5b\xe0\x64\x98\xd7\x87".b
         client.smb3_encrypt(data)
@@ -2731,6 +2738,7 @@ RSpec.describe RubySMB::Client do
 
       it 'generates the expected client encryption key with 0x0311 dialect' do
         client.dialect = '0x0311'
+        client.encryption_algorithm = 'AES-128-CCM'
         client.session_key =
           "\x5c\x00\x4a\x3b\xf0\xa2\x4f\x75\x4c\xb2\x74\x0a\xcf\xc4\x8e\x1a".b
         client.preauth_integrity_hash_value =
@@ -2765,13 +2773,15 @@ RSpec.describe RubySMB::Client do
         context "with #{dialect} dialect" do
           before :example do
             client.dialect = dialect
+            client.encryption_algorithm = 'AES-128-CCM'
           end
 
           it 'generates the client encryption key with the expected parameters' do
             expect(RubySMB::Crypto::KDF).to receive(:counter_mode).with(
               session_key,
               "SMB2AESCCM\x00",
-              "ServerOut\x00"
+              "ServerOut\x00",
+              {length: 128}
             ).and_call_original
             client.smb3_decrypt(transform_packet)
           end
@@ -2782,10 +2792,12 @@ RSpec.describe RubySMB::Client do
         it 'generates the client encryption key with the expected parameters' do
           client.preauth_integrity_hash_value = ''
           client.dialect = '0x0311'
+          client.encryption_algorithm = 'AES-128-CCM'
           expect(RubySMB::Crypto::KDF).to receive(:counter_mode).with(
             session_key,
             "SMBS2CCipherKey\x00",
-            ''
+            '',
+            {length: 128}
           ).and_call_original
           client.smb3_decrypt(transform_packet)
         end
@@ -2806,6 +2818,7 @@ RSpec.describe RubySMB::Client do
 
       it 'generates the expected server encryption key with 0x0302 dialect' do
         client.dialect = '0x0302'
+        client.encryption_algorithm = 'AES-128-CCM'
         expected_enc_key =
           "\x65\x21\xd3\x6d\xe9\xe3\x5a\x66\x09\x61\xae\x3e\xc6\x49\x6b\xdf".b
         client.smb3_decrypt(transform_packet)
@@ -2814,6 +2827,7 @@ RSpec.describe RubySMB::Client do
 
       it 'generates the expected server encryption key with 0x0311 dialect' do
         client.dialect = '0x0311'
+        client.encryption_algorithm = 'AES-128-CCM'
         client.session_key =
           "\x5c\x00\x4a\x3b\xf0\xa2\x4f\x75\x4c\xb2\x74\x0a\xcf\xc4\x8e\x1a".b
         client.preauth_integrity_hash_value =

--- a/spec/lib/ruby_smb/smb2/packet/transform_header_spec.rb
+++ b/spec/lib/ruby_smb/smb2/packet/transform_header_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe RubySMB::SMB2::Packet::TransformHeader do
     it 'raises the expected exception if the given algorithm is invalid' do
       expect { packet.decrypt(key, algorithm: 'RC4') }.to raise_error(
         RubySMB::Error::EncryptionError,
-        'Error while decrypting with \'RC4\' (ArgumentError: Invalid algorithm, must be either AES-128-CCM or AES-128-GCM)'
+        'Error while decrypting with \'RC4\' (ArgumentError: Invalid algorithm, must be one of AES-128-CCM, AES-128-GCM, AES-256-CCM, or AES-256-GCM)'
       )
     end
 
@@ -141,7 +141,7 @@ RSpec.describe RubySMB::SMB2::Packet::TransformHeader do
     it 'raises the expected exception if the given algorithm is invalid' do
       expect { packet.encrypt(struct, key, algorithm: 'RC4') }.to raise_error(
         RubySMB::Error::EncryptionError,
-        'Error while encrypting with \'RC4\' (ArgumentError: Invalid algorithm, must be either AES-128-CCM or AES-128-GCM)'
+        'Error while encrypting with \'RC4\' (ArgumentError: Invalid algorithm, must be one of AES-128-CCM, AES-128-GCM, AES-256-CCM, or AES-256-GCM)'
       )
     end
 


### PR DESCRIPTION
Closes #203.

This adds AES-256 support which was recently added by Microsoft. Luckily the KDF remains the same. It also swaps the order of the algorithms, it looks like Windows expects them to be in order of priority. This will prefer the AES-256 variants, and fail back to the AES-128 variants. Once landed, Metasploit's smb_version module will automatically identify when AES-256 can be negotiated.

You need to test this with a fully up to date Windows 11 system. I don't think AES-256 is available for Windows 10. I also double checked that AES-128 negotiation and encryption still works correctly.

Server 2019 uses AES-128, while Windows 11 negotiates AES-256. This can be confirmed using Wireshark and inspecting the negotiate response frame form the server.
```
  : ruby_smb:feat/aes-25610:29:08 ruby_smb ruby examples/read_file.rb --username smcintyre --password "$(getpass)" 192.168.159.70 SMBShare readme.txt
Password: SMB3 : (0x00000000) STATUS_SUCCESS: The operation completed successfully.
Connected to \\192.168.159.70\SMBShare successfully!
Hello from Windows 11!
  : ruby_smb:feat/aes-25610:29:13 ruby_smb ruby examples/read_file.rb --username smcintyre --password "$(getpass)" 192.168.159.96 SMBShare readme.txt
Password: SMB3 : (0x00000000) STATUS_SUCCESS: The operation completed successfully.
Connected to \\192.168.159.96\SMBShare successfully!
Hello from Server 2019!
  : ruby_smb:feat/aes-25610:29:21 rub
```

This may introduce conflicts with 197 that will also need to be updated so the server also supports AES-256.