### PR TITLE
Fix Windows 11 File Reads From The Server

### DIFF
--- a/lib/ruby_smb/client/encryption.rb
+++ b/lib/ruby_smb/client/encryption.rb
@@ -4,7 +4,7 @@ module RubySMB
     module Encryption
       def smb3_encrypt(data)
         unless @client_encryption_key
-          raise RubySMB::Error::EncryptionError.new('The encryption algorithm has not be set') if @encryption_algorithm.nil?
+          raise RubySMB::Error::EncryptionError.new('The encryption algorithm has not been set') if @encryption_algorithm.nil?
 
           key_bit_len = OpenSSL::Cipher.new(@encryption_algorithm).key_len * 8
 
@@ -39,7 +39,7 @@ module RubySMB
 
       def smb3_decrypt(th)
         unless @server_encryption_key
-          raise RubySMB::Error::EncryptionError.new('The encryption algorithm has not be set') if @encryption_algorithm.nil?
+          raise RubySMB::Error::EncryptionError.new('The encryption algorithm has not been set') if @encryption_algorithm.nil?
 
           key_bit_len = OpenSSL::Cipher.new(@encryption_algorithm).key_len * 8
 

--- a/lib/ruby_smb/server/server_client/encryption.rb
+++ b/lib/ruby_smb/server/server_client/encryption.rb
@@ -5,7 +5,7 @@ module RubySMB
       module Encryption
         def smb3_encrypt(data, session)
           encryption_algorithm = SMB2::EncryptionCapabilities::ENCRYPTION_ALGORITHM_MAP[@cipher_id]
-          raise RubySMB::Error::EncryptionError.new('The encryption algorithm has not be set') if encryption_algorithm.nil?
+          raise RubySMB::Error::EncryptionError.new('The encryption algorithm has not been set') if encryption_algorithm.nil?
 
           key_bit_len = OpenSSL::Cipher.new(encryption_algorithm).key_len * 8
 
@@ -35,7 +35,7 @@ module RubySMB
 
         def smb3_decrypt(encrypted_request, session)
           encryption_algorithm = SMB2::EncryptionCapabilities::ENCRYPTION_ALGORITHM_MAP[@cipher_id]
-          raise RubySMB::Error::EncryptionError.new('The encryption algorithm has not be set') if encryption_algorithm.nil?
+          raise RubySMB::Error::EncryptionError.new('The encryption algorithm has not been set') if encryption_algorithm.nil?
 
           key_bit_len = OpenSSL::Cipher.new(encryption_algorithm).key_len * 8
 

--- a/lib/ruby_smb/server/server_client/encryption.rb
+++ b/lib/ruby_smb/server/server_client/encryption.rb
@@ -4,47 +4,61 @@ module RubySMB
       # Contains the methods for handling encryption / decryption
       module Encryption
         def smb3_encrypt(data, session)
+          encryption_algorithm = SMB2::EncryptionCapabilities::ENCRYPTION_ALGORITHM_MAP[@cipher_id]
+          raise RubySMB::Error::EncryptionError.new('The encryption algorithm has not be set') if encryption_algorithm.nil?
+
+          key_bit_len = OpenSSL::Cipher.new(encryption_algorithm).key_len * 8
+
           case @dialect
           when '0x0300', '0x0302'
             server_encryption_key = RubySMB::Crypto::KDF.counter_mode(
               session.key,
               "SMB2AESCCM\x00",
-              "ServerOut\x00"
+              "ServerOut\x00",
+              length: key_bit_len
             )
           when '0x0311'
             server_encryption_key = RubySMB::Crypto::KDF.counter_mode(
               session.key,
               "SMBS2CCipherKey\x00",
-              @preauth_integrity_hash_value
+              @preauth_integrity_hash_value,
+              length: key_bit_len
             )
           else
             raise RubySMB::Error::EncryptionError.new('Dialect is incompatible with SMBv3 decryption')
           end
 
           th = RubySMB::SMB2::Packet::TransformHeader.new(flags: 1, session_id: session.id)
-          th.encrypt(data, server_encryption_key, algorithm: SMB2::EncryptionCapabilities::ENCRYPTION_ALGORITHM_MAP[@cipher_id])
+          th.encrypt(data, server_encryption_key, algorithm: encryption_algorithm)
           th
         end
 
         def smb3_decrypt(encrypted_request, session)
+          encryption_algorithm = SMB2::EncryptionCapabilities::ENCRYPTION_ALGORITHM_MAP[@cipher_id]
+          raise RubySMB::Error::EncryptionError.new('The encryption algorithm has not be set') if encryption_algorithm.nil?
+
+          key_bit_len = OpenSSL::Cipher.new(encryption_algorithm).key_len * 8
+
           case @dialect
           when '0x0300', '0x0302'
             client_encryption_key = RubySMB::Crypto::KDF.counter_mode(
               session.key,
               "SMB2AESCCM\x00",
-              "ServerIn \x00"
+              "ServerIn \x00",
+              length: key_bit_len
             )
           when '0x0311'
             client_encryption_key = RubySMB::Crypto::KDF.counter_mode(
               session.key,
               "SMBC2SCipherKey\x00",
-              @preauth_integrity_hash_value
+              @preauth_integrity_hash_value,
+              length: key_bit_len
             )
           else
             raise RubySMB::Error::EncryptionError.new('Dialect is incompatible with SMBv3 encryption')
           end
 
-          encrypted_request.decrypt(client_encryption_key, algorithm: SMB2::EncryptionCapabilities::ENCRYPTION_ALGORITHM_MAP[@cipher_id])
+          encrypted_request.decrypt(client_encryption_key, algorithm: encryption_algorithm)
         end
       end
     end

--- a/lib/ruby_smb/server/server_client/negotiation.rb
+++ b/lib/ruby_smb/server/server_client/negotiation.rb
@@ -119,7 +119,8 @@ module RubySMB
             )
 
             nc = request.find_negotiate_context(SMB2::NegotiateContext::SMB2_ENCRYPTION_CAPABILITIES)
-            if (ciphers = nc&.data&.ciphers)
+            ciphers = nc&.data&.ciphers
+            if ciphers
               cipher = ciphers.find { |cipher| SMB2::EncryptionCapabilities::ENCRYPTION_ALGORITHM_MAP.include?(cipher) }
               @cipher_id = cipher unless cipher.nil?
             end

--- a/lib/ruby_smb/server/server_client/negotiation.rb
+++ b/lib/ruby_smb/server/server_client/negotiation.rb
@@ -119,16 +119,15 @@ module RubySMB
             )
 
             nc = request.find_negotiate_context(SMB2::NegotiateContext::SMB2_ENCRYPTION_CAPABILITIES)
-            cipher = nc&.data&.ciphers&.first
-            if SMB2::EncryptionCapabilities::ENCRYPTION_ALGORITHM_MAP.include? cipher
-              @cipher_id = cipher
-            else
-              cipher = 0
+            if (ciphers = nc&.data&.ciphers)
+              cipher = ciphers.find { |cipher| SMB2::EncryptionCapabilities::ENCRYPTION_ALGORITHM_MAP.include?(cipher) }
+              @cipher_id = cipher unless cipher.nil?
             end
+
             contexts << SMB2::NegotiateContext.new(
               context_type: SMB2::NegotiateContext::SMB2_ENCRYPTION_CAPABILITIES,
               data: {
-                ciphers: [ cipher ]
+                ciphers: [ @cipher_id ]
               }
             )
           elsif dialect == '0x0300' || dialect == '0x0302'

--- a/lib/ruby_smb/smb2/negotiate_context.rb
+++ b/lib/ruby_smb/smb2/negotiate_context.rb
@@ -103,6 +103,10 @@ module RubySMB
       SMB2_NETNAME_NEGOTIATE_CONTEXT_ID    = 0x0005
       # The NegotiateContext Data field contains the transport capabilities, as specified in section 2.2.3.1.5.
       SMB2_TRANSPORT_CAPABILITIES          = 0x0006
+      # The NegotiateContext Data field contains the RDMA transform capabilities, as specified in section 2.2.3.1.6.
+      SMB2_RDMA_TRANSFORM_CAPABILITIES     = 0x0007
+      # The NegotiateContext Data field contains the signing capabilities, as specified in section 2.2.3.1.7.
+      SMB2_SIGNING_CAPABILITIES            = 0x0008
 
       endian  :little
 
@@ -116,6 +120,7 @@ module RubySMB
         compression_capabilities       SMB2_COMPRESSION_CAPABILITIES,       label: 'Compression Capabilities'
         netname_negotiate_context_id   SMB2_NETNAME_NEGOTIATE_CONTEXT_ID,   label: 'Netname Negotiate Context ID', data_length: :data_length
         transport_capabilities         SMB2_TRANSPORT_CAPABILITIES,         label: 'Transport Capabilities'
+        string                         :default,                            label: 'Unsupported Negotiating Context', read_length: :data_length
       end
 
       def pad_length


### PR DESCRIPTION
This fixes a couple of small bugs that were preventing Windows 11 clients from reading files on the SMB server.

The main issue was that the new negotiate contexts could not be parsed. This meant the server couldn't negotiate the connection. The contexts now have a default string file that just consumes the data to keep things aligned but doesn't process it. This allows the negotiation to be complete without needing to be aware of all the negotiate contexts which should make it more future proof.

Additionally, the logic used to negotiate the encryption was improved to select the first mutually supported algorithm instead of only selecting the first algorithm if it's supported. This should also help make things more future-proof should additional encryption algorithms be added.

Finally, AES-256 support was fixed for the server. The key generation needed to be updated to account for the encryption algorithm so the bit length would be set correctly.

## Testing

Use the example file server and a Windows 11 client.

- [x] Start the file server: `ruby examples/file_server.rb --path /var/public --share public --username MSFLAB\\smcintyre --password Password1!`
    * This assumes there are some readable files in `/var/public`, shares them using the share name "public", and adds an account with which to access them
- [x] Go to Windows 11 and read the file from the server: `type \\192.168.159.128\public\test.txt`
    * Without these changes, this would fail. The server would stack trace on negotiate because of the unsupported contexts. With these changes, assuming that the account was set up correctly, the Windows 11 client should be able to read the `test.txt` file just fine.
    * The observant user may note that Windows 11 appears to prefer the AES-128 encryption algorithms, meaning that the AES-256 changes are not actually tested.
- [x] Somehow force the server to negotiate AES-256 (edit the code, use a breakpoint, etc) and verify it in Wireshark, look at the negotiate response and see what the server selected
- [x] Read a file again, using AES-256 and see that it's read just fine.

Fixes #205 