### PR TITLE
Fix the security_blob length

### DIFF
--- a/lib/ruby_smb/smb1/packet/session_setup_request.rb
+++ b/lib/ruby_smb/smb1/packet/session_setup_request.rb
@@ -23,7 +23,7 @@ module RubySMB
         # for the security blob, you must null-terminate the {native_os} and {native_lan_man} fields
         # yourself if you set them away from their defaults.
         class DataBlock < RubySMB::SMB1::DataBlock
-          string      :security_blob,  label: 'Security Blob (GSS-API)', length: -> { parent.parameter_block.security_blob_length }
+          string      :security_blob,  label: 'Security Blob (GSS-API)', read_length: -> { parent.parameter_block.security_blob_length }
           uint8       :pad1,           label: 'Pad 1', onlyif: -> { parent.smb_header.flags2.unicode == 1 && pad1.abs_offset % 2 == 1 }
           choice      :native_os,      label: 'Native OS', selection: -> { parent.smb_header.flags2.unicode } do
             stringz   0, initial_value: 'Windows 7 Ultimate N 7601 Service Pack 1'


### PR DESCRIPTION
This decouples the strong correlation of the `#security_blob` field with it's length parameter in `SMB1::SessionSetupRequest`. The result allows the contents of the `#security_blob` field to be set, while the length is 0. This is helpful in some [exploitation scenarios](https://github.com/zeroSteiner/metasploit-framework/commit/5c84e5951db887b1e1538cfd2e76309e3fe7f62b).

These changes won't have any effect on parsing incoming requests that are correctly formed. You can see the differences between `length` and `read_length` documented in the [BinData wiki](https://github.com/dmendel/bindata/wiki/PrimitiveTypes#sized-strings).

## Testing

- [ ] SMB1 Session Setup support should still work, try using something like psexec or one of the example scripts
