### PR TITLE
Set the extended security flag when necessary

### DIFF
--- a/lib/ruby_smb/gss/provider/ntlm.rb
+++ b/lib/ruby_smb/gss/provider/ntlm.rb
@@ -78,6 +78,10 @@ module RubySMB
                 msg.flag |= NTLM::NEGOTIATE_FLAGS.fetch(flag)
               end
 
+              if type1_msg.flag & NTLM::NEGOTIATE_FLAGS[:EXTENDED_SECURITY] == NTLM::NEGOTIATE_FLAGS[:EXTENDED_SECURITY]
+                msg.flag |= NTLM::NEGOTIATE_FLAGS[:EXTENDED_SECURITY]
+              end
+
               @server_challenge = @provider.generate_server_challenge
               msg.challenge = @server_challenge.unpack1('Q<') # 64-bit unsigned, little endian (uint64_t)
               target_info = Net::NTLM::TargetInfo.new('')


### PR DESCRIPTION
Set the extended security flag when generating the NTLM challenge and it was set by the client in the type 1 message. This fixes the issue affecting smbclient version 4.3.11 as seen on Ubuntu 16.04 and reported in #201. With this in place, smbclient is able to authenticate to the server as intended.

## Testing

- [x] Use docker to start an Ubuntu instance: `docker run --rm -it ubuntu:16.04 /bin/bash`
- [x] Install smbclient: `apt-get update; apt-get install smbclient`
- [x] Start the SMB server (the supported server versions don't matter): `ruby examples/file_server.rb --path /var/public --share public --username MSFLAB\\smcintyre --password Password1!`
- [x] Connect to the server using smbclient: `smbclient //192.168.159.128/public -U MSFLAB\\smcintyre`, see it work, run `dir` and see output.
    * Without this change, an error from smbclient would be thrown complaining that a possible downgrade was detected.

<details>
<summary>Before the patch</summary>

```
root@4b11077b8eef:/# smbclient //192.168.159.128/public -U MSFLAB\\smcintyre
WARNING: The "syslog" option is deprecated
Enter MSFLAB\smcintyre's password: 
Connection to 192.168.159.128 failed (Error NT_STATUS_CONNECTION_REFUSED)
root@4b11077b8eef:/# smbclient //192.168.159.128/public -U MSFLAB\\smcintyre
WARNING: The "syslog" option is deprecated
Enter MSFLAB\smcintyre's password: 
ntlmssp_handle_neg_flags: Got challenge flags[0xe2800001] - possible downgrade detected! missing_flags[0x00080000] - NT code 0x80090302
  NTLMSSP_NEGOTIATE_EXTENDED_SESSIONSECURITY
SPNEGO(ntlmssp) login failed: NT code 0x80090302
session setup failed: NT code 0x80090302
root@4b11077b8eef:/# 
```
</details>

<details>
<summary>After the patch</summary>

```
root@4b11077b8eef:/# smbclient //192.168.159.128/public -U MSFLAB\\smcintyre
WARNING: The "syslog" option is deprecated
Enter MSFLAB\smcintyre's password: 
Domain=[LOCALHOST] OS=[] Server=[]
smb: \> dir
  cmd.x64.dll                         N     5120  Fri Mar 18 12:34:37 2022
  cmd.x86.dll                         N     5120  Fri Mar 18 12:34:48 2022
  meterpreter.x64.exe                 N     7168  Tue Jan 18 14:53:04 2022
  meterpreter.x86.exe                 N    73802  Tue Jan 18 14:53:21 2022
  payload.x64.dll                     N     8704  Fri Oct  1 22:00:02 2021
  reverse_tcp.1.x64.dll               R     8704  Mon Nov 29 20:37:22 2021
  reverse_tcp.x64.dll                 N     8704  Fri Dec 17 18:01:24 2021
  test                                D        0  Tue Mar 29 21:01:57 2022
  test.txt                            N       13  Wed Dec  1 15:12:34 2021
Error in dskattr: NT_STATUS_NOT_SUPPORTED
smb: \> exit

```
</details>

Closes #201