### PR TITLE
Fix negotiation for SMB v2.0.2

### DIFF
--- a/lib/ruby_smb/client/negotiation.rb
+++ b/lib/ruby_smb/client/negotiation.rb
@@ -5,7 +5,7 @@ module RubySMB
     module Negotiation
       # Handles the entire SMB Multi-Protocol Negotiation from the
       # Client to the Server. It sets state on the client appropriate
-      # to the protocol and capabilites negotiated during the exchange.
+      # to the protocol and capabilities negotiated during the exchange.
       # It also keeps track of the negotiated dialect.
       #
       # @return [void]
@@ -23,13 +23,13 @@ module RubySMB
           update_preauth_hash(response_packet)
         end
 
-        # If the response contains the SMB2 wildcard revision number dialect;
-        # it indicates that the server implements SMB 2.1 or future dialect
-        # revisions and expects the client to send a subsequent SMB2 Negotiate
+        # If the response contains an SMB2 dialect and the request was SMB1;
+        # it indicates that the server SMB2 and wants to upgrade the connection,
+        # the server expects the client to send a subsequent SMB2 Negotiate
         # request to negotiate the actual SMB 2 Protocol revision to be used.
         # The wildcard revision number is sent only in response to a
         # multi-protocol negotiate request with the "SMB 2.???" dialect string.
-        if @dialect == '0x02ff'
+        if request_packet.packet_smb_version == 'SMB1' && RubySMB::Dialect[@dialect].order == RubySMB::Dialect::ORDER_SMB2
           self.smb2_message_id += 1
           version = negotiate
         end

--- a/lib/ruby_smb/client/negotiation.rb
+++ b/lib/ruby_smb/client/negotiation.rb
@@ -29,7 +29,7 @@ module RubySMB
         # request to negotiate the actual SMB 2 Protocol revision to be used.
         # The wildcard revision number is sent only in response to a
         # multi-protocol negotiate request with the "SMB 2.???" dialect string.
-        if request_packet.packet_smb_version == 'SMB1' && RubySMB::Dialect[@dialect].order == RubySMB::Dialect::ORDER_SMB2
+        if request_packet.packet_smb_version == 'SMB1' && RubySMB::Dialect[@dialect]&.order == RubySMB::Dialect::ORDER_SMB2
           self.smb2_message_id += 1
           version = negotiate
         end

--- a/lib/ruby_smb/client/negotiation.rb
+++ b/lib/ruby_smb/client/negotiation.rb
@@ -24,10 +24,10 @@ module RubySMB
         end
 
         # If the response contains an SMB2 dialect and the request was SMB1;
-        # it indicates that the server SMB2 and wants to upgrade the connection,
-        # the server expects the client to send a subsequent SMB2 Negotiate
-        # request to negotiate the actual SMB 2 Protocol revision to be used.
-        # The wildcard revision number is sent only in response to a
+        # it indicates that the server supports SMB2 and wants to upgrade the
+        # connection. The server expects the client to send a subsequent SMB2
+        # Negotiate request to negotiate the actual SMB 2 Protocol revision to
+        # be used. The wildcard revision number is sent only in response to a
         # multi-protocol negotiate request with the "SMB 2.???" dialect string.
         if request_packet.packet_smb_version == 'SMB1' && RubySMB::Dialect[@dialect]&.order == RubySMB::Dialect::ORDER_SMB2
           self.smb2_message_id += 1

--- a/spec/lib/ruby_smb/client_spec.rb
+++ b/spec/lib/ruby_smb/client_spec.rb
@@ -1279,13 +1279,13 @@ RSpec.describe RubySMB::Client do
       end
 
       it 'calls the backing methods' do
-        expect(client).to receive(:negotiate_request).twice.and_call_original
+        request_packet = double('Request packet')
+        allow(client).to receive(:negotiate_request).and_return(request_packet)
+        allow(request_packet).to receive(:packet_smb_version)
+        expect(client).to receive(:negotiate_request)
         expect(client).to receive(:send_recv)
         expect(client).to receive(:negotiate_response)
-        expect(client).to receive(:parse_negotiate_response).twice do
-          client.dialect = '0x02ff'
-          client.smb1 = false
-        end
+        expect(client).to receive(:parse_negotiate_response)
         client.negotiate
       end
 

--- a/spec/lib/ruby_smb/client_spec.rb
+++ b/spec/lib/ruby_smb/client_spec.rb
@@ -1279,10 +1279,13 @@ RSpec.describe RubySMB::Client do
       end
 
       it 'calls the backing methods' do
-        expect(client).to receive(:negotiate_request)
+        expect(client).to receive(:negotiate_request).twice.and_call_original
         expect(client).to receive(:send_recv)
         expect(client).to receive(:negotiate_response)
-        expect(client).to receive(:parse_negotiate_response)
+        expect(client).to receive(:parse_negotiate_response).twice do
+          client.dialect = '0x02ff'
+          client.smb1 = false
+        end
         client.negotiate
       end
 
@@ -1319,14 +1322,20 @@ RSpec.describe RubySMB::Client do
 
         it 'increments the message ID' do
           expect(client).to receive(:smb2_message_id=).with(1)
+          expect(client).to receive(:negotiate_request).twice.and_call_original
+          expect(client).to receive(:parse_negotiate_response).twice do
+            client.smb1 = false
+          end
           client.negotiate
         end
 
         it 're-negotiates' do
-          expect(client).to receive(:negotiate_request).twice
+          expect(client).to receive(:negotiate_request).twice.and_call_original
           expect(client).to receive(:send_recv).twice
           expect(client).to receive(:negotiate_response).twice
-          expect(client).to receive(:parse_negotiate_response).twice
+          expect(client).to receive(:parse_negotiate_response).twice do
+            client.smb1 = false
+          end
           client.negotiate
         end
       end


### PR DESCRIPTION
Some older Windows servers will respond back to an SMB 1 negotiate request with a dialect of 2.0.2 instead of the wildcard dialect. When that occurs, the client doesn't increment the message ID correctly which causes the subsequent session negotiation request to be rejected.

This issue can be reproduced with older versions of Server 2008. Once the issue is patched, the session setup should proceed correctly.

I opted to update the logic from doing an explicit check for the wildcard dialect (which was failing) to checking if an SMB2/3 response was received to an SMB1 request. This is a bit more flexible. I then tested it with servers running 2.0.2 (fixed), 2.1 and 3.1.1.