### PR TITLE
Support guest authentication

### DIFF
--- a/examples/file_server.rb
+++ b/examples/file_server.rb
@@ -10,6 +10,7 @@ Encoding.default_internal = 'UTF-8' if Encoding.default_internal.nil?
 
 options = {
   allow_anonymous: true,
+  allow_guests: false,
   domain: nil,
   username: 'RubySMB',
   password: 'password',
@@ -39,6 +40,9 @@ OptionParser.new do |opts|
   opts.on("--[no-]smbv3", "Enable or disable SMBv3 (default: #{options[:smbv3] ? 'Enabled' : 'Disabled'})") do |smbv3|
     options[:smbv3] = smbv3
   end
+  opts.on("--[no-]guests", "Allow guest accounts (default: #{options[:allow_guests]})") do |allow_guests|
+    options[:allow_guests] = allow_guests
+  end
   opts.on("--username USERNAME", "The account's username (default: #{options[:username]})") do |username|
     if username.include?('\\')
       options[:domain], options[:username] = username.split('\\', 2)
@@ -51,7 +55,10 @@ OptionParser.new do |opts|
   end
 end.parse!
 
-ntlm_provider = RubySMB::Gss::Provider::NTLM.new(allow_anonymous: options[:allow_anonymous])
+ntlm_provider = RubySMB::Gss::Provider::NTLM.new(
+  allow_anonymous: options[:allow_anonymous],
+  allow_guests: options[:allow_guests]
+)
 ntlm_provider.put_account(options[:username], options[:password], domain: options[:domain])  # password can also be an NTLM hash
 
 server = RubySMB::Server.new(

--- a/lib/ruby_smb/gss/provider.rb
+++ b/lib/ruby_smb/gss/provider.rb
@@ -7,7 +7,11 @@ module RubySMB
       # A special constant implying that the authenticated user is anonymous.
       IDENTITY_ANONYMOUS = :anonymous
       # The result of a processed GSS request.
-      Result = Struct.new(:buffer, :nt_status, :identity)
+      Result = Struct.new(:buffer, :nt_status, :identity, :is_guest) do
+        def is_anonymous
+          identity == Gss::Provider::IDENTITY_ANONYMOUS
+        end
+      end
 
       #
       # The base class for a GSS authentication provider. This class defines a common interface and is not usable as a
@@ -26,6 +30,11 @@ module RubySMB
         # Whether or not anonymous authentication attempts should be permitted.
         #
         attr_accessor :allow_anonymous
+
+        #
+        # Whether or not unknown users should be allowed to authenticate as guests.
+        #
+        attr_accessor :allow_guests
       end
     end
   end

--- a/lib/ruby_smb/gss/provider/ntlm.rb
+++ b/lib/ruby_smb/gss/provider/ntlm.rb
@@ -109,6 +109,7 @@ module RubySMB
           def process_ntlm_type3(type3_msg)
             if type3_msg.user == '' && type3_msg.domain == ''
               if @provider.allow_anonymous
+                @session_key = "\x00".b * 16 # see MS-NLMP section 3.4
                 return WindowsError::NTStatus::STATUS_SUCCESS
               end
 
@@ -122,6 +123,12 @@ module RubySMB
               domain: type3_msg.domain
             )
             if account.nil?
+              if @provider.allow_guests
+                logger.info("NTLM authentication request succeeded for #{dbg_string} (guest)")
+                @session_key = "\x00".b * 16 # see MS-NLMP section 3.4
+                return WindowsError::NTStatus::STATUS_SUCCESS
+              end
+
               logger.info("NTLM authentication request failed for #{dbg_string} (no account)")
               return WindowsError::NTStatus::STATUS_LOGON_FAILURE
             end
@@ -229,25 +236,31 @@ module RubySMB
                 domain: type3_msg.domain
               )
               if account.nil?
-                if @provider.allow_anonymous
+                if type3_msg.user == ''
+                  is_guest = false
                   identity = IDENTITY_ANONYMOUS
+                else
+                  is_guest = true
+                  identity = Account.new(type3_msg.user.encode(''.encoding), '', type3_msg.domain.encode(''.encoding)).to_s
                 end
               else
+                is_guest = false
                 identity = account.to_s
               end
             end
 
-            Result.new(buffer, nt_status, identity)
+            Result.new(buffer, nt_status, identity, is_guest)
           end
         end
 
         # @param [Boolean] allow_anonymous whether or not to allow anonymous authentication attempts
         # @param [String] default_domain the default domain to use for authentication, unless specified 'WORKGROUP' will
         #   be used
-        def initialize(allow_anonymous: false, default_domain: 'WORKGROUP')
+        def initialize(allow_anonymous: false, allow_guests: false, default_domain: 'WORKGROUP')
           raise ArgumentError, 'Must specify a default domain' unless default_domain
 
           @allow_anonymous = allow_anonymous
+          @allow_guests = allow_guests
           @default_domain = default_domain
           @accounts = []
           @generate_server_challenge = -> { SecureRandom.bytes(8) }

--- a/lib/ruby_smb/server/session.rb
+++ b/lib/ruby_smb/server/session.rb
@@ -64,7 +64,7 @@ module RubySMB
       attr_accessor :tree_connect_table
 
       # Untyped hash for storing additional arbitrary metadata about the current session
-      # @!attribute [rw] metadaa
+      # @!attribute [rw] metadata
       #   @return [Hash]
       attr_accessor :metadata
 
@@ -72,6 +72,10 @@ module RubySMB
       # @!attribute [r] creation_time
       #   @return [Time]
       attr_reader   :creation_time
+
+      # Whether or not the authenticated user is a guest.
+      # @!attribute [rw] is_guest
+      attr_accessor :is_guest
     end
   end
 end


### PR DESCRIPTION
Support guest authentication. Per the specs a guest user is implementation-specific. This effectively allows incoming connections to authenticate when the user doesn't exist in the database. It's necessary to disable encryption in this case for SMB3 unfortunately.

> Otherwise, if the returned src_name corresponds to an implementation-specific guest user,[<270>](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/a64e55aa-1152-48e4-8206-edd96444e7f7#Appendix_A_270) the server MUST set the SMB2_SESSION_FLAG_IS_GUEST in the SessionFlags field of the SMB2 SESSION_SETUP Response and MUST set Session.IsGuest to TRUE.

See: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/5ed93f06-a1d2-4837-8954-fa8b833c2654

This setting is disabled by default. In the future it'll be necessary to support Metasploit hosting files for incoming requests which may be coming from an authenticated context.

# Testing

The example file server now has a `--guests` option. When enabled, incoming users will be authenticated using the guest context. Turn that option on, and do not add an explicit account.

- [ ] Run: `ruby examples/file_server.rb --path /var/public --share public --guest`
- [ ] Request a file from a Windows system: `type \\192.168.159.128\public\test.txt`
- [ ] See in the logging output that the NTLM authentication succeeded for a user and that it was marked as a guest as noted with the ` (guest)` suffix
