### PR TITLE
Expose Socket Information

### DIFF
--- a/lib/ruby_smb/server/server_client.rb
+++ b/lib/ruby_smb/server/server_client.rb
@@ -19,7 +19,7 @@ module RubySMB
       include RubySMB::Server::ServerClient::ShareIO
       include RubySMB::Server::ServerClient::TreeConnect
 
-      attr_reader :dialect, :session_table
+      attr_reader :dialect, :dispatcher, :session_table
 
       # @param [Server] server the server that accepted this connection
       # @param [Dispatcher::Socket] dispatcher the connection's socket dispatcher
@@ -55,6 +55,14 @@ module RubySMB
       # @return [String]
       def getpeername
         @dispatcher.tcp_socket.getpeername
+      end
+
+      def peerhost
+        ::Socket::unpack_sockaddr_in(getpeername)[1]
+      end
+
+      def peerport
+        ::Socket::unpack_sockaddr_in(getpeername)[0]
       end
 
       #

--- a/spec/lib/ruby_smb/server/server_client_spec.rb
+++ b/spec/lib/ruby_smb/server/server_client_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe RubySMB::Server::ServerClient do
   subject(:server_client) { described_class.new(server, dispatcher) }
 
   it { is_expected.to respond_to :dialect }
+  it { is_expected.to respond_to :dispatcher }
   it { is_expected.to respond_to :session_table }
 
   describe '#disconnect!' do
@@ -28,6 +29,20 @@ RSpec.describe RubySMB::Server::ServerClient do
     it 'creates a new authenticator instance' do
       expect(server.gss_provider).to receive(:new_authenticator).and_call_original
       described_class.new(server, dispatcher)
+    end
+  end
+
+  describe '#peerhost' do
+    it 'returns the peer IP address' do
+      expect(server_client).to receive(:getpeername).and_return(Socket.sockaddr_in(4444, '127.0.0.1'))
+      expect(server_client.peerhost).to eq '127.0.0.1'
+    end
+  end
+
+  describe '#peerport' do
+    it 'returns the peer IP port' do
+      expect(server_client).to receive(:getpeername).and_return(Socket.sockaddr_in(4444, '127.0.0.1'))
+      expect(server_client.peerport).to eq 4444
     end
   end
 


### PR DESCRIPTION
This updates the ServerClient class to expose some additional information like the peer host and port. This can be used by something like Metasploit to more easily identify the client connection.