### PR TITLE
Add more Fscc information classes to the server

### DIFF
--- a/lib/ruby_smb/fscc/file_information.rb
+++ b/lib/ruby_smb/fscc/file_information.rb
@@ -51,6 +51,10 @@ module RubySMB
       # Information class used to query or set the mode of the file.
       FILE_MODE_INFORMATION              = 0x10
 
+      # Information class used to query the buffer alignment required by the
+      # underlying device.
+      FILE_ALIGNMENT_INFORMATION         = 0x11
+
       # Information class used to enumerate the data streams of a file or a
       # directory.
       FILE_STREAM_INFORMATION            = 0x16
@@ -118,6 +122,7 @@ module RubySMB
       require 'ruby_smb/fscc/file_information/file_access_information'
       require 'ruby_smb/fscc/file_information/file_position_information'
       require 'ruby_smb/fscc/file_information/file_mode_information'
+      require 'ruby_smb/fscc/file_information/file_alignment_information'
     end
   end
 end

--- a/lib/ruby_smb/fscc/file_information.rb
+++ b/lib/ruby_smb/fscc/file_information.rb
@@ -44,6 +44,10 @@ module RubySMB
       # Information class used to mark a file for deletion.
       FILE_DISPOSITION_INFORMATION       = 0x0D
 
+      # Information class used to query or set the position of the file pointer
+      # within a file.
+      FILE_POSITION_INFORMATION          = 0x0E
+
       # Information class used to enumerate the data streams of a file or a
       # directory.
       FILE_STREAM_INFORMATION            = 0x16
@@ -109,6 +113,7 @@ module RubySMB
       require 'ruby_smb/fscc/file_information/file_standard_information'
       require 'ruby_smb/fscc/file_information/file_internal_information'
       require 'ruby_smb/fscc/file_information/file_access_information'
+      require 'ruby_smb/fscc/file_information/file_position_information'
     end
   end
 end

--- a/lib/ruby_smb/fscc/file_information.rb
+++ b/lib/ruby_smb/fscc/file_information.rb
@@ -20,6 +20,9 @@ module RubySMB
       # Information class used to query or set file information.
       FILE_BASIC_INFORMATION             = 0x04
 
+      # Information class is used to query file information.
+      FILE_STANDARD_INFORMATION          = 0x05
+
       # Information class used to query for the size of the extended attributes
       # (EA) for a file.
       FILE_EA_INFORMATION                = 0x07
@@ -96,6 +99,7 @@ module RubySMB
       require 'ruby_smb/fscc/file_information/file_ea_information'
       require 'ruby_smb/fscc/file_information/file_stream_information'
       require 'ruby_smb/fscc/file_information/file_basic_information'
+      require 'ruby_smb/fscc/file_information/file_standard_information'
     end
   end
 end

--- a/lib/ruby_smb/fscc/file_information.rb
+++ b/lib/ruby_smb/fscc/file_information.rb
@@ -123,6 +123,7 @@ module RubySMB
       require 'ruby_smb/fscc/file_information/file_position_information'
       require 'ruby_smb/fscc/file_information/file_mode_information'
       require 'ruby_smb/fscc/file_information/file_alignment_information'
+      require 'ruby_smb/fscc/file_information/file_all_information'
     end
   end
 end

--- a/lib/ruby_smb/fscc/file_information.rb
+++ b/lib/ruby_smb/fscc/file_information.rb
@@ -23,6 +23,9 @@ module RubySMB
       # Information class is used to query file information.
       FILE_STANDARD_INFORMATION          = 0x05
 
+      # Information class used to query for the file system's 64-bit file ID.
+      FILE_INTERNAL_INFORMATION          = 0x06
+
       # Information class used to query for the size of the extended attributes
       # (EA) for a file.
       FILE_EA_INFORMATION                = 0x07
@@ -100,6 +103,7 @@ module RubySMB
       require 'ruby_smb/fscc/file_information/file_stream_information'
       require 'ruby_smb/fscc/file_information/file_basic_information'
       require 'ruby_smb/fscc/file_information/file_standard_information'
+      require 'ruby_smb/fscc/file_information/file_internal_information'
     end
   end
 end

--- a/lib/ruby_smb/fscc/file_information.rb
+++ b/lib/ruby_smb/fscc/file_information.rb
@@ -34,6 +34,9 @@ module RubySMB
       # granted when the file was opened.
       FILE_ACCESS_INFORMATION            = 0x08
 
+      # Information class is used locally to query the name of a file.
+      FILE_NAME_INFORMATION              = 0x09
+
       # Information class used to rename a file.
       FILE_RENAME_INFORMATION            = 0x0A
 
@@ -97,20 +100,13 @@ module RubySMB
         constants.select { |c| c.upcase == c }.find { |c| const_get(c) == value }
       end
 
-      # The FILE_NAME_INFORMATION type as defined in
-      # https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/20406fb1-605f-4629-ba9a-c67ee25f23d2
-      class FileNameInformation < BinData::Record
-        endian :little
-        uint32           :file_name_length, label: 'File Name Length',  initial_value: -> { file_name.do_num_bytes }
-        string16         :file_name,        label: 'File Name',         read_length: -> { file_name_length }
-      end
-
       require 'ruby_smb/fscc/file_information/file_directory_information'
       require 'ruby_smb/fscc/file_information/file_full_directory_information'
       require 'ruby_smb/fscc/file_information/file_disposition_information'
       require 'ruby_smb/fscc/file_information/file_id_full_directory_information'
       require 'ruby_smb/fscc/file_information/file_both_directory_information'
       require 'ruby_smb/fscc/file_information/file_id_both_directory_information'
+      require 'ruby_smb/fscc/file_information/file_name_information'
       require 'ruby_smb/fscc/file_information/file_names_information'
       require 'ruby_smb/fscc/file_information/file_rename_information'
       require 'ruby_smb/fscc/file_information/file_network_open_information'

--- a/lib/ruby_smb/fscc/file_information.rb
+++ b/lib/ruby_smb/fscc/file_information.rb
@@ -30,6 +30,10 @@ module RubySMB
       # (EA) for a file.
       FILE_EA_INFORMATION                = 0x07
 
+      # Information class used to query the access rights of a file that were
+      # granted when the file was opened.
+      FILE_ACCESS_INFORMATION            = 0x08
+
       # Information class used to rename a file.
       FILE_RENAME_INFORMATION            = 0x0A
 
@@ -104,6 +108,7 @@ module RubySMB
       require 'ruby_smb/fscc/file_information/file_basic_information'
       require 'ruby_smb/fscc/file_information/file_standard_information'
       require 'ruby_smb/fscc/file_information/file_internal_information'
+      require 'ruby_smb/fscc/file_information/file_access_information'
     end
   end
 end

--- a/lib/ruby_smb/fscc/file_information.rb
+++ b/lib/ruby_smb/fscc/file_information.rb
@@ -17,6 +17,9 @@ module RubySMB
       # contents of a directory.
       FILE_BOTH_DIRECTORY_INFORMATION    = 0x03
 
+      # Information class used to query or set file information.
+      FILE_BASIC_INFORMATION             = 0x04
+
       # Information class used to query for the size of the extended attributes
       # (EA) for a file.
       FILE_EA_INFORMATION                = 0x07
@@ -57,6 +60,10 @@ module RubySMB
       FILE_NORMALIZED_NAME_INFORMATION = 0x30
 
 
+      # Information class is used to query a collection of file information
+      # structures.
+      FILE_ALL_INFORMATION = 0x12
+
       # These Information Classes can be used by SMB1 using the pass-through
       # Information Levels when available on the server (CAP_INFOLEVEL_PASSTHRU
       # capability flag in an SMB_COM_NEGOTIATE server response). The constant
@@ -88,6 +95,7 @@ module RubySMB
       require 'ruby_smb/fscc/file_information/file_network_open_information'
       require 'ruby_smb/fscc/file_information/file_ea_information'
       require 'ruby_smb/fscc/file_information/file_stream_information'
+      require 'ruby_smb/fscc/file_information/file_basic_information'
     end
   end
 end

--- a/lib/ruby_smb/fscc/file_information.rb
+++ b/lib/ruby_smb/fscc/file_information.rb
@@ -48,6 +48,9 @@ module RubySMB
       # within a file.
       FILE_POSITION_INFORMATION          = 0x0E
 
+      # Information class used to query or set the mode of the file.
+      FILE_MODE_INFORMATION              = 0x10
+
       # Information class used to enumerate the data streams of a file or a
       # directory.
       FILE_STREAM_INFORMATION            = 0x16
@@ -114,6 +117,7 @@ module RubySMB
       require 'ruby_smb/fscc/file_information/file_internal_information'
       require 'ruby_smb/fscc/file_information/file_access_information'
       require 'ruby_smb/fscc/file_information/file_position_information'
+      require 'ruby_smb/fscc/file_information/file_mode_information'
     end
   end
 end

--- a/lib/ruby_smb/fscc/file_information.rb
+++ b/lib/ruby_smb/fscc/file_information.rb
@@ -108,6 +108,7 @@ module RubySMB
       require 'ruby_smb/fscc/file_information/file_id_both_directory_information'
       require 'ruby_smb/fscc/file_information/file_name_information'
       require 'ruby_smb/fscc/file_information/file_names_information'
+      require 'ruby_smb/fscc/file_information/file_normalized_name_information'
       require 'ruby_smb/fscc/file_information/file_rename_information'
       require 'ruby_smb/fscc/file_information/file_network_open_information'
       require 'ruby_smb/fscc/file_information/file_ea_information'

--- a/lib/ruby_smb/fscc/file_information/file_access_information.rb
+++ b/lib/ruby_smb/fscc/file_information/file_access_information.rb
@@ -1,0 +1,15 @@
+module RubySMB
+  module Fscc
+    module FileInformation
+      # The FileAccessInformation Class as defined in
+      # [2.4.1 FileAccessInformation](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/01cf43d2-deb3-40d3-a39b-9e68693d7c90)
+      class FileAccessInformation < BinData::Record
+        CLASS_LEVEL = FileInformation::FILE_ACCESS_INFORMATION
+
+        endian :little
+
+        uint32  :access_flags, label: 'Access Flags'
+      end
+    end
+  end
+end

--- a/lib/ruby_smb/fscc/file_information/file_alignment_information.rb
+++ b/lib/ruby_smb/fscc/file_information/file_alignment_information.rb
@@ -1,0 +1,15 @@
+module RubySMB
+  module Fscc
+    module FileInformation
+      # The FileAlignmentInformation Class as defined in
+      # [2.4.3 FileAlignmentInformation](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/9b0b9971-85aa-4651-8438-f1c4298bcb0d)
+      class FileAlignmentInformation < BinData::Record
+        CLASS_LEVEL = FileInformation::FILE_ALIGNMENT_INFORMATION
+
+        endian :little
+
+        uint32  :alignment_requirement, label: 'Alignment Requirement'
+      end
+    end
+  end
+end

--- a/lib/ruby_smb/fscc/file_information/file_alignment_information.rb
+++ b/lib/ruby_smb/fscc/file_information/file_alignment_information.rb
@@ -6,9 +6,39 @@ module RubySMB
       class FileAlignmentInformation < BinData::Record
         CLASS_LEVEL = FileInformation::FILE_ALIGNMENT_INFORMATION
 
+        # If this value is specified, there are no alignment requirements for the device.
+        FILE_BYTE_ALIGNMENT               = 0x00000000 # 0
+
+        # If this value is specified, data MUST be aligned on a 2-byte boundary.
+        FILE_WORD_ALIGNMENT               = 0x00000001 # 1
+
+        # If this value is specified, data MUST be aligned on a 4-byte boundary.
+        FILE_LONG_ALIGNMENT               = 0x00000003 # 3
+
+        # If this value is specified, data MUST be aligned on an 8-byte boundary.
+        FILE_QUAD_ALIGNMENT               = 0x00000007 # 7
+
+        # If this value is specified, data MUST be aligned on a 16-byte boundary.
+        FILE_OCTA_ALIGNMENT               = 0X0000000F # 15
+
+        # If this value is specified, data MUST be aligned on a 32-byte boundary.
+        FILE_32_BYTE_ALIGNMENT            = 0X0000001F # 31
+
+        # If this value is specified, data MUST be aligned on a 64-byte boundary.
+        FILE_64_BYTE_ALIGNMENT            = 0X0000003F # 63
+
+        # If this value is specified, data MUST be aligned on a 128-byte boundary.
+        FILE_128_BYTE_ALIGNMENT           = 0X0000007F # 127
+
+        # If this value is specified, data MUST be aligned on a 256-byte boundary.
+        FILE_256_BYTE_ALIGNMENT           = 0X000000FF # 255
+
+        # If this value is specified, data MUST be aligned on a 512-byte boundary.
+        FILE_512_BYTE_ALIGNMENT           = 0X000001FF # 511
+
         endian :little
 
-        uint32  :alignment_requirement, label: 'Alignment Requirement'
+        uint32  :alignment_requirement, label: 'Alignment Requirement', initial_value: FILE_BYTE_ALIGNMENT
       end
     end
   end

--- a/lib/ruby_smb/fscc/file_information/file_all_information.rb
+++ b/lib/ruby_smb/fscc/file_information/file_all_information.rb
@@ -16,7 +16,7 @@ module RubySMB
         file_position_information   :position_information,  label: 'Position Information'
         file_mode_information       :mode_information,      label: 'Mode Information'
         file_alignment_information  :alignment_information, label: 'Alignment Information'
-        file_name_information       :name_information,      label: 'Label Information'
+        file_name_information       :name_information,      label: 'Name Information'
       end
     end
   end

--- a/lib/ruby_smb/fscc/file_information/file_all_information.rb
+++ b/lib/ruby_smb/fscc/file_information/file_all_information.rb
@@ -1,0 +1,23 @@
+module RubySMB
+  module Fscc
+    module FileInformation
+      # The FileAllInformation Class as defined in
+      # [2.4.2 FileAllInformation](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/95f3056a-ebc1-4f5d-b938-3f68a44677a6)
+      class FileAllInformation < BinData::Record
+        CLASS_LEVEL = FileInformation::FILE_ALL_INFORMATION
+
+        endian :little
+
+        file_basic_information      :basic_information,     label: 'Basic Information'
+        file_standard_information   :standard_information,  label: 'Standard Information'
+        file_internal_information   :internal_information,  label: 'Internal Information'
+        file_ea_information         :ea_information,        label: 'EA Information'
+        file_access_information     :access_information,    label: 'Access Information'
+        file_position_information   :position_information,  label: 'Position Information'
+        file_mode_information       :mode_information,      label: 'Mode Information'
+        file_alignment_information  :alignment_information, label: 'Alignment Information'
+        file_name_information       :name_information,      label: 'Label Information'
+      end
+    end
+  end
+end

--- a/lib/ruby_smb/fscc/file_information/file_basic_information.rb
+++ b/lib/ruby_smb/fscc/file_information/file_basic_information.rb
@@ -1,0 +1,20 @@
+module RubySMB
+  module Fscc
+    module FileInformation
+      # The FileBasicInformation Class as defined in
+      # [2.4.7 FileBasicInformation](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/16023025-8a78-492f-8b96-c873b042ac50)
+      class FileBasicInformation < BinData::Record
+        CLASS_LEVEL = FileInformation::FILE_BASIC_INFORMATION
+
+        endian :little
+
+        file_time       :create_time,     label: 'Create Time'
+        file_time       :last_access,     label: 'Last Accessed Time'
+        file_time       :last_write,      label: 'Last Write Time'
+        file_time       :last_change,     label: 'Last Modified Time'
+        file_attributes :file_attributes, label: 'File Attributes'
+        string          :reserved,        label: 'Reserved', length: 4
+      end
+    end
+  end
+end

--- a/lib/ruby_smb/fscc/file_information/file_both_directory_information.rb
+++ b/lib/ruby_smb/fscc/file_information/file_both_directory_information.rb
@@ -2,7 +2,7 @@ module RubySMB
   module Fscc
     module FileInformation
       # The FileBothDirectoryInformation Class as defined in
-      # [2.4.8 FileBothDirectoryInformation](https://msdn.microsoft.com/en-us/library/cc232095.aspx)
+      # [2.4.8 FileBothDirectoryInformation](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/270df317-9ba5-4ccb-ba00-8d22be139bc5)
       class FileBothDirectoryInformation < BinData::Record
         CLASS_LEVEL = FileInformation::FILE_BOTH_DIRECTORY_INFORMATION
 
@@ -14,8 +14,8 @@ module RubySMB
         file_time        :last_access,        label: 'Last Accessed Time'
         file_time        :last_write,         label: 'Last Write Time'
         file_time        :last_change,        label: 'Last Modified Time'
-        uint64           :end_of_file,        label: 'End of File'
-        uint64           :allocation_size,    label: 'Allocated Size'
+        int64            :end_of_file,        label: 'End of File'
+        int64            :allocation_size,    label: 'Allocated Size'
         file_attributes  :file_attributes,    label: 'File Attributes'
         uint32           :file_name_length,   label: 'File Name Length', initial_value: -> { file_name.do_num_bytes }
         uint32           :ea_size,            label: 'Extended Attributes Size'

--- a/lib/ruby_smb/fscc/file_information/file_directory_information.rb
+++ b/lib/ruby_smb/fscc/file_information/file_directory_information.rb
@@ -2,7 +2,7 @@ module RubySMB
   module Fscc
     module FileInformation
       # The FileDirectoryInformation Class as defined in
-      # [2.4.10 FileDirectoryInformation](https://msdn.microsoft.com/en-us/library/cc232097.aspx)
+      # [2.4.10 FileDirectoryInformation](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/b38bf518-9057-4c88-9ddd-5e2d3976a64b)
       class FileDirectoryInformation < BinData::Record
         CLASS_LEVEL = FileInformation::FILE_DIRECTORY_INFORMATION
 
@@ -14,8 +14,8 @@ module RubySMB
         file_time        :last_access,      label: 'Last Accessed Time'
         file_time        :last_write,       label: 'Last Write Time'
         file_time        :last_change,      label: 'Last Modified Time'
-        uint64           :end_of_file,      label: 'End of File'
-        uint64           :allocation_size,  label: 'Allocated Size'
+        int64            :end_of_file,      label: 'End of File'
+        int64            :allocation_size,  label: 'Allocated Size'
         file_attributes  :file_attributes,  label: 'File Attributes'
         uint32           :file_name_length, label: 'File Name Length',  initial_value: -> { file_name.do_num_bytes }
         string16         :file_name,        label: 'File Name',         read_length: -> { file_name_length }

--- a/lib/ruby_smb/fscc/file_information/file_ea_information.rb
+++ b/lib/ruby_smb/fscc/file_information/file_ea_information.rb
@@ -7,6 +7,7 @@ module RubySMB
         CLASS_LEVEL = FileInformation::FILE_EA_INFORMATION
 
         endian :little
+
         uint32 :ea_size, label: 'Extended Attributes Size'
       end
     end

--- a/lib/ruby_smb/fscc/file_information/file_full_directory_information.rb
+++ b/lib/ruby_smb/fscc/file_information/file_full_directory_information.rb
@@ -2,7 +2,7 @@ module RubySMB
   module Fscc
     module FileInformation
       # The FileFullDirectoryInformation Class as defined in
-      # [2.4.14 FileFullDirectoryInformation](https://msdn.microsoft.com/en-us/library/cc232068.aspx)
+      # [2.4.14 FileFullDirectoryInformation](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/e8d926d1-3a22-4654-be9c-58317a85540b)
       class FileFullDirectoryInformation < BinData::Record
         CLASS_LEVEL = FileInformation::FILE_FULL_DIRECTORY_INFORMATION
 
@@ -14,8 +14,8 @@ module RubySMB
         file_time        :last_access,      label: 'Last Accessed Time'
         file_time        :last_write,       label: 'Last Write Time'
         file_time        :last_change,      label: 'Last Modified Time'
-        uint64           :end_of_file,      label: 'End of File'
-        uint64           :allocation_size,  label: 'Allocated Size'
+        int64            :end_of_file,      label: 'End of File'
+        int64            :allocation_size,  label: 'Allocated Size'
         file_attributes  :file_attributes,  label: 'File Attributes'
         uint32           :file_name_length, label: 'File Name Length', initial_value: -> { file_name.do_num_bytes }
         uint32           :ea_size,          label: 'Extended Attributes Size'

--- a/lib/ruby_smb/fscc/file_information/file_id_both_directory_information.rb
+++ b/lib/ruby_smb/fscc/file_information/file_id_both_directory_information.rb
@@ -14,8 +14,8 @@ module RubySMB
         file_time        :last_access,        label: 'Last Accessed Time'
         file_time        :last_write,         label: 'Last Write Time'
         file_time        :last_change,        label: 'Last Modified Time'
-        uint64           :end_of_file,        label: 'End of File'
-        uint64           :allocation_size,    label: 'Allocated Size'
+        int64            :end_of_file,        label: 'End of File'
+        int64            :allocation_size,    label: 'Allocated Size'
         file_attributes  :file_attributes,    label: 'File Attributes'
         uint32           :file_name_length,   label: 'File Name Length', initial_value: -> { file_name.do_num_bytes }
         uint32           :ea_size,            label: 'Extended Attributes Size'

--- a/lib/ruby_smb/fscc/file_information/file_id_both_directory_information.rb
+++ b/lib/ruby_smb/fscc/file_information/file_id_both_directory_information.rb
@@ -23,7 +23,7 @@ module RubySMB
         uint8            :reserved,           label: 'Reserved Space'
         string16         :short_name,         label: 'File Short Name', length: 24
         uint16           :reserved2,          label: 'Reserved Space'
-        uint64           :file_id,            label: 'File Id'
+        uint64           :file_id,            label: 'File ID'
         string16         :file_name,          label: 'File Name', read_length: -> { file_name_length }
       end
     end

--- a/lib/ruby_smb/fscc/file_information/file_id_full_directory_information.rb
+++ b/lib/ruby_smb/fscc/file_information/file_id_full_directory_information.rb
@@ -2,7 +2,7 @@ module RubySMB
   module Fscc
     module FileInformation
       # The FileIdDirectoryInformation Class as defined in
-      # [2.4.18 FileIdFullDirectoryInformation](https://msdn.microsoft.com/en-us/library/cc232071.aspx)
+      # [2.4.18 FileIdFullDirectoryInformation](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/ab8e7558-899c-4be1-a7c5-3a9ae8ab76a0)
       class FileIdFullDirectoryInformation < BinData::Record
         CLASS_LEVEL = FileInformation::FILE_ID_FULL_DIRECTORY_INFORMATION
 
@@ -14,8 +14,8 @@ module RubySMB
         file_time        :last_access,      label: 'Last Accessed Time'
         file_time        :last_write,       label: 'Last Write Time'
         file_time        :last_change,      label: 'Last Modified Time'
-        uint64           :end_of_file,      label: 'End of File'
-        uint64           :allocation_size,  label: 'Allocated Size'
+        int64            :end_of_file,      label: 'End of File'
+        int64            :allocation_size,  label: 'Allocated Size'
         file_attributes  :file_attributes,  label: 'File Attributes'
         uint32           :file_name_length, label: 'File Name Length', initial_value: -> { file_name.do_num_bytes }
         uint32           :ea_size,          label: 'Extended Attributes Size'

--- a/lib/ruby_smb/fscc/file_information/file_internal_information.rb
+++ b/lib/ruby_smb/fscc/file_information/file_internal_information.rb
@@ -1,0 +1,15 @@
+module RubySMB
+  module Fscc
+    module FileInformation
+      # The FileInternalInformation Class as defined in
+      # [2.4.22 FileInternalInformation](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/7d796611-2fa5-41ac-8178-b6fea3a017b3)
+      class FileInternalInformation < BinData::Record
+        CLASS_LEVEL = FileInformation::FILE_ID_FULL_DIRECTORY_INFORMATION
+
+        endian :little
+
+        uint64 :file_id, label: 'File ID'
+      end
+    end
+  end
+end

--- a/lib/ruby_smb/fscc/file_information/file_internal_information.rb
+++ b/lib/ruby_smb/fscc/file_information/file_internal_information.rb
@@ -4,7 +4,7 @@ module RubySMB
       # The FileInternalInformation Class as defined in
       # [2.4.22 FileInternalInformation](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/7d796611-2fa5-41ac-8178-b6fea3a017b3)
       class FileInternalInformation < BinData::Record
-        CLASS_LEVEL = FileInformation::FILE_ID_FULL_DIRECTORY_INFORMATION
+        CLASS_LEVEL = FileInformation::FILE_INTERNAL_INFORMATION
 
         endian :little
 

--- a/lib/ruby_smb/fscc/file_information/file_mode_information.rb
+++ b/lib/ruby_smb/fscc/file_information/file_mode_information.rb
@@ -1,0 +1,29 @@
+module RubySMB
+  module Fscc
+    module FileInformation
+      # The FileModeInformation Class as defined in
+      # [2.4.26 FileModeInformation](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/52df7798-8330-474b-ac31-9afe8075640c)
+      class FileModeInformation < BinData::Record
+        CLASS_LEVEL = FileInformation::FILE_MODE_INFORMATION
+
+        endian :little
+
+        struct  :flags do
+          bit2   :reserved
+          bit1   :file_synchronous_io_nonalert,   label: 'File Synchronous IO Nonalert'
+          bit1   :file_synchronous_io_alert,      label: 'File Synchronous IO Alert'
+          bit1   :file_no_intermediate_buffering, label: 'File No Intermediate Buffering'
+          bit1   :file_sequential_only,           label: 'File Sequential Only'
+          bit1   :file_write_through,             label: 'File Write Through'
+          bit1   :reserved2
+          # byte boundary
+          bit3   :reserved3
+          bit1   :file_delete_on_close,           label: 'File Delete On Close'
+          bit4   :reserved4
+          # byte boundary
+          bit16  :reserved5
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby_smb/fscc/file_information/file_name_information.rb
+++ b/lib/ruby_smb/fscc/file_information/file_name_information.rb
@@ -1,0 +1,16 @@
+module RubySMB
+  module Fscc
+    module FileInformation
+      # The FileNameInformation Class as defined in
+      # [2.4.27 FileNameInformation](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/cb30e415-54c5-4483-a346-822ea90e1e89)
+      class FileNameInformation < BinData::Record
+        CLASS_LEVEL = FileInformation::FILE_NAME_INFORMATION
+
+        endian :little
+
+        uint32           :file_name_length, label: 'File Name Length',  initial_value: -> { file_name.do_num_bytes }
+        string16         :file_name,        label: 'File Name',         read_length: -> { file_name_length }
+      end
+    end
+  end
+end

--- a/lib/ruby_smb/fscc/file_information/file_names_information.rb
+++ b/lib/ruby_smb/fscc/file_information/file_names_information.rb
@@ -2,7 +2,7 @@ module RubySMB
   module Fscc
     module FileInformation
       # The FileNamesInformation Class as defined in
-      # [2.4.26 FileNamesInformation](https://msdn.microsoft.com/en-us/library/cc232077.aspx)
+      # [2.4.28 FileNamesInformation](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/a289f7a8-83d2-4927-8c88-b2d328dde5a5)
       class FileNamesInformation < BinData::Record
         CLASS_LEVEL = FileInformation::FILE_NAMES_INFORMATION
 

--- a/lib/ruby_smb/fscc/file_information/file_normalized_name_information.rb
+++ b/lib/ruby_smb/fscc/file_information/file_normalized_name_information.rb
@@ -1,0 +1,16 @@
+module RubySMB
+  module Fscc
+    module FileInformation
+      # The FileNormalizedNameInformation Class as defined in
+      # [2.4.30 FileNormalizedNameInformation](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/20bcadba-808c-4880-b757-4af93e41edf6)
+      class FileNormalizedNameInformation < BinData::Record
+        CLASS_LEVEL = FileInformation::FILE_NORMALIZED_NAME_INFORMATION
+
+        endian :little
+
+        uint32           :file_name_length, label: 'File Name Length',  initial_value: -> { file_name.do_num_bytes }
+        string16         :file_name,        label: 'File Name',         read_length: -> { file_name_length }
+      end
+    end
+  end
+end

--- a/lib/ruby_smb/fscc/file_information/file_position_information.rb
+++ b/lib/ruby_smb/fscc/file_information/file_position_information.rb
@@ -1,0 +1,15 @@
+module RubySMB
+  module Fscc
+    module FileInformation
+      # The FilePositionInformation Class as defined in
+      # [2.4.35 FilePositionInformation](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/e3ce4a39-327e-495c-99b6-6b61606b6f16)
+      class FilePositionInformation < BinData::Record
+        CLASS_LEVEL = FileInformation::FILE_POSITION_INFORMATION
+
+        endian :little
+
+        int64  :current_byte_offset, label: 'Current Byte Offset'
+      end
+    end
+  end
+end

--- a/lib/ruby_smb/fscc/file_information/file_rename_information.rb
+++ b/lib/ruby_smb/fscc/file_information/file_rename_information.rb
@@ -4,7 +4,7 @@ module RubySMB
       # The FileRenameInformation Class as defined in
       # [2.4.34.2 FileRenameInformation](https://msdn.microsoft.com/en-us/library/cc704597.aspx)
       class FileRenameInformation < BinData::Record
-        CLASS_LEVEL = FileInformation::FILE_ID_FULL_DIRECTORY_INFORMATION
+        CLASS_LEVEL = FileInformation::FILE_RENAME_INFORMATION
 
         endian :little
 

--- a/lib/ruby_smb/fscc/file_information/file_standard_information.rb
+++ b/lib/ruby_smb/fscc/file_information/file_standard_information.rb
@@ -1,0 +1,20 @@
+module RubySMB
+  module Fscc
+    module FileInformation
+      # The FileStandardInformation Class as defined in
+      # [2.4.41 FileStandardInformation](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/5afa7f66-619c-48f3-955f-68c4ece704ae)
+      class FileStandardInformation < BinData::Record
+        CLASS_LEVEL = FileInformation::FILE_STANDARD_INFORMATION
+
+        endian :little
+
+        int64  :allocation_size, label: 'Allocation Size'
+        int64  :end_of_file,     label: 'End of File'
+        uint32 :number_of_links, label: 'Number of Links'
+        int8   :delete_pending,  label: 'Delete Pending'
+        int8   :directory,       label: 'Directory'
+        string :reserved,        label: 'Reserved', length: 2
+      end
+    end
+  end
+end

--- a/lib/ruby_smb/fscc/file_information/file_stream_information.rb
+++ b/lib/ruby_smb/fscc/file_information/file_stream_information.rb
@@ -4,7 +4,10 @@ module RubySMB
       # The FileStreamInformation
       # [2.4.43 FileStreamInformation](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/f8762be6-3ab9-411e-a7d6-5cc68f70c78d)
       class FileStreamInformation < BinData::Record
+        CLASS_LEVEL = Fscc::FileInformation::FILE_STREAM_INFORMATION
+
         endian :little
+
         uint32   :next_entry_offset,      label: 'Next Entry Offset'
         uint32   :stream_name_length,     label: 'Stream Name Length', initial_value: -> { stream_name.do_num_bytes }
         int64    :stream_size,            label: 'Stream Size'

--- a/lib/ruby_smb/fscc/file_system_information.rb
+++ b/lib/ruby_smb/fscc/file_system_information.rb
@@ -15,6 +15,10 @@ module RubySMB
       FILE_FS_VOLUME_FLAGS_INFORMATION = 10
       FILE_FS_SECTOR_SIZE_INFORMATION  = 11
 
+      def self.name(value)
+        constants.select { |c| c.upcase == c }.find { |c| const_get(c) == value }
+      end
+
       require 'ruby_smb/fscc/file_system_information/file_fs_attribute_information'
       require 'ruby_smb/fscc/file_system_information/file_fs_volume_information'
     end

--- a/lib/ruby_smb/fscc/file_system_information/file_fs_attribute_information.rb
+++ b/lib/ruby_smb/fscc/file_system_information/file_fs_attribute_information.rb
@@ -7,6 +7,7 @@ module RubySMB
         CLASS_LEVEL = FileSystemInformation::FILE_FS_ATTRIBUTE_INFORMATION
 
         endian :little
+
         struct   :file_system_attributes,            label: 'File System Attributes' do
           bit1   :file_supports_reparse_points,      label: 'FS Supports Reparse Points'
           bit1   :file_supports_sparse_files,        label: 'FS Supports Sparse Files'

--- a/lib/ruby_smb/fscc/file_system_information/file_fs_volume_information.rb
+++ b/lib/ruby_smb/fscc/file_system_information/file_fs_volume_information.rb
@@ -7,6 +7,7 @@ module RubySMB
         CLASS_LEVEL = FileSystemInformation::FILE_FS_VOLUME_INFORMATION
 
         endian :little
+
         file_time :volume_creation_time, label: 'Volume Creation Time'
         uint32    :volume_serial_number, label: 'Volume Serial Number'
         uint32    :volume_label_length,  label: 'Volume Label Length', initial_value: -> { volume_label.do_num_bytes }

--- a/lib/ruby_smb/server/share/provider/disk/processor.rb
+++ b/lib/ruby_smb/server/share/provider/disk/processor.rb
@@ -31,6 +31,11 @@ module RubySMB
               )
             end
 
+            # Build an access mask bit field for the specified path. The return type is a DirectoryAccessMask if path
+            # is a directory, otherwise it's a FileAccessMask.
+            #
+            # @param Pathname path the path to build an access mask for
+            # @return [DirectoryAccessMask, FileAccessMask] the access mask
             def smb2_access_mask(path)
               # see: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/b3af3aaf-9271-4419-b326-eba0341df7d2
               if path.directory?
@@ -61,7 +66,10 @@ module RubySMB
               case info_class
               when Fscc::FileInformation::FILE_ACCESS_INFORMATION
                 info = Fscc::FileInformation::FileAccessInformation.new
-                info.access_flags = smb2_access_mask(path).to_binary_s.unpack1('V')
+                # smb2_access_mask returns back either file or directory access mask depending on what path is,
+                # FileAccessInformation however isn't defined to account for this context so set it from the binary
+                # value
+                info.access_flags.read(smb2_access_mask(path).to_binary_s)
               when Fscc::FileInformation::FILE_ALIGNMENT_INFORMATION
                 info = Fscc::FileInformation::FileAlignmentInformation.new
               when Fscc::FileInformation::FILE_ALL_INFORMATION

--- a/lib/ruby_smb/server/share/provider/disk/processor.rb
+++ b/lib/ruby_smb/server/share/provider/disk/processor.rb
@@ -131,7 +131,8 @@ module RubySMB
                   stream_name: '::$DATA'
                 )
               else
-                raise NotImplementedError, "Unsupported FSCC file information class: #{info_class} (#{Fscc::FileInformation.name(info_class)})"
+                logger.warn("Unsupported FSCC file information class: #{info_class} (#{Fscc::FileInformation.name(info_class)})")
+                raise NotImplementedError
               end
 
               # some have a next offset field that needs to be set accordingly

--- a/lib/ruby_smb/server/share/provider/disk/processor.rb
+++ b/lib/ruby_smb/server/share/provider/disk/processor.rb
@@ -89,6 +89,10 @@ module RubySMB
                 info = Fscc::FileInformation::FileIdBothDirectoryInformation.new
                 set_common_info(info, path)
                 info.file_name = rename || path.basename.to_s
+              when Fscc::FileInformation::FILE_ID_FULL_DIRECTORY_INFORMATION
+                info = Fscc::FileInformation::FileIdFullDirectoryInformation.new
+                set_common_info(info, path)
+                info.file_name = rename || path.basename.to_s
               when Fscc::FileInformation::FILE_INTERNAL_INFORMATION
                 info = Fscc::FileInformation::FileInternalInformation.new
                 info.file_id = Zlib::crc32(path.to_s)

--- a/lib/ruby_smb/server/share/provider/disk/processor.rb
+++ b/lib/ruby_smb/server/share/provider/disk/processor.rb
@@ -44,6 +44,21 @@ module RubySMB
 
             def build_fscc_file_information(path, info_class, rename: nil)
               case info_class
+              when Fscc::FileInformation::FILE_ALL_INFORMATION
+                info = Fscc::FileInformation::FileAllInformation.new
+                info.basic_information = build_fscc_file_information(path, Fscc::FileInformation::FILE_BASIC_INFORMATION, rename: rename)
+                info.standard_information = build_fscc_file_information(path, Fscc::FileInformation::FILE_STANDARD_INFORMATION, rename: rename)
+                info.internal_information = build_fscc_file_information(path, Fscc::FileInformation::FILE_INTERNAL_INFORMATION, rename: rename)
+                info.ea_information = build_fscc_file_information(path, Fscc::FileInformation::FILE_EA_INFORMATION, rename: rename)
+                info.access_information = build_fscc_file_information(path, Fscc::FileInformation::FILE_ACCESS_INFORMATION, rename: rename)
+                info.position_information = build_fscc_file_information(path, Fscc::FileInformation::FILE_POSITION_INFORMATION, rename: rename)
+                info.mode_information = build_fscc_file_information(path, Fscc::FileInformation::FILE_MODE_INFORMATION, rename: rename)
+                info.alignment_information = build_fscc_file_information(path, Fscc::FileInformation::FILE_ALIGNMENT_INFORMATION, rename: rename)
+                info.name_information = build_fscc_file_information(path, Fscc::FileInformation::FILE_NAMES_INFORMATION, rename: rename)
+              when Fscc::FileInformation::FILE_BASIC_INFORMATION
+                info = Fscc::FileInformation::FileBasicInformation.new
+                set_common_timestamps(info, path)
+                info.file_attributes = build_fscc_file_attributes(path)
               when Fscc::FileInformation::FILE_EA_INFORMATION
                 info = Fscc::FileInformation::FileEaInformation.new
               when Fscc::FileInformation::FILE_FULL_DIRECTORY_INFORMATION
@@ -57,16 +72,20 @@ module RubySMB
               when Fscc::FileInformation::FILE_NETWORK_OPEN_INFORMATION
                 info = Fscc::FileInformation::FileNetworkOpenInformation.new
                 set_common_info(info, path)
+              when Fscc::FileInformation::FILE_STANDARD_INFORMATION
+                info = Fscc::FileInformation::FileStandardInformation.new
+                info.allocation_size = get_allocation_size(path)
+                info.directory = path.directory? ? 1 : 0
               when Fscc::FileInformation::FILE_STREAM_INFORMATION
-                  unless path.file?
-                    raise NotImplementedError, 'Can only generate FILE_STREAM_INFORMATION for files'
-                  end
+                unless path.file?
+                  raise NotImplementedError, 'Can only generate FILE_STREAM_INFORMATION for files'
+                end
 
-                  info = Fscc::FileInformation::FileStreamInformation.new(
-                    stream_size: path.size,
-                    stream_allocation_size: get_allocation_size(path),
-                    stream_name: '::$DATA'
-                  )
+                info = Fscc::FileInformation::FileStreamInformation.new(
+                  stream_size: path.size,
+                  stream_allocation_size: get_allocation_size(path),
+                  stream_name: '::$DATA'
+                )
               else
                 raise NotImplementedError, "Unsupported FSCC file information class: #{info_class} (#{Fscc::FileInformation.name(info_class)})"
               end

--- a/lib/ruby_smb/server/share/provider/disk/processor.rb
+++ b/lib/ruby_smb/server/share/provider/disk/processor.rb
@@ -1,3 +1,4 @@
+require 'zlib'
 require 'ruby_smb/server/share/provider/processor'
 
 module RubySMB
@@ -30,6 +31,20 @@ module RubySMB
               )
             end
 
+            def smb2_access_mask(path)
+              # see: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/b3af3aaf-9271-4419-b326-eba0341df7d2
+              if path.directory?
+                am = SMB2::BitField::DirectoryAccessMask.new
+                am.traverse = true
+                am.list = true
+              else
+                am = SMB2::BitField::FileAccessMask.new
+                am.read_data = true
+              end
+              am.read_attr = true
+              am
+            end
+
             private
 
             def build_fscc_file_attributes(path)
@@ -44,6 +59,11 @@ module RubySMB
 
             def build_fscc_file_information(path, info_class, rename: nil)
               case info_class
+              when Fscc::FileInformation::FILE_ACCESS_INFORMATION
+                info = Fscc::FileInformation::FileAccessInformation.new
+                info.access_flags = smb2_access_mask(path).to_binary_s.unpack1('V')
+              when Fscc::FileInformation::FILE_ALIGNMENT_INFORMATION
+                info = Fscc::FileInformation::FileAlignmentInformation.new
               when Fscc::FileInformation::FILE_ALL_INFORMATION
                 info = Fscc::FileInformation::FileAllInformation.new
                 info.basic_information = build_fscc_file_information(path, Fscc::FileInformation::FILE_BASIC_INFORMATION, rename: rename)
@@ -54,7 +74,7 @@ module RubySMB
                 info.position_information = build_fscc_file_information(path, Fscc::FileInformation::FILE_POSITION_INFORMATION, rename: rename)
                 info.mode_information = build_fscc_file_information(path, Fscc::FileInformation::FILE_MODE_INFORMATION, rename: rename)
                 info.alignment_information = build_fscc_file_information(path, Fscc::FileInformation::FILE_ALIGNMENT_INFORMATION, rename: rename)
-                info.name_information = build_fscc_file_information(path, Fscc::FileInformation::FILE_NAMES_INFORMATION, rename: rename)
+                info.name_information = build_fscc_file_information(path, Fscc::FileInformation::FILE_NAME_INFORMATION, rename: rename)
               when Fscc::FileInformation::FILE_BASIC_INFORMATION
                 info = Fscc::FileInformation::FileBasicInformation.new
                 set_common_timestamps(info, path)
@@ -69,12 +89,24 @@ module RubySMB
                 info = Fscc::FileInformation::FileIdBothDirectoryInformation.new
                 set_common_info(info, path)
                 info.file_name = rename || path.basename.to_s
+              when Fscc::FileInformation::FILE_INTERNAL_INFORMATION
+                info = Fscc::FileInformation::FileInternalInformation.new
+                info.file_id = Zlib::crc32(path.to_s)
+              when Fscc::FileInformation::FILE_MODE_INFORMATION
+                info = Fscc::FileInformation::FileModeInformation.new
+              when Fscc::FileInformation::FILE_NAME_INFORMATION
+                info = Fscc::FileInformation::FileNameInformation.new
+                info.file_name = rename || path.basename.to_s
               when Fscc::FileInformation::FILE_NETWORK_OPEN_INFORMATION
                 info = Fscc::FileInformation::FileNetworkOpenInformation.new
                 set_common_info(info, path)
+              when Fscc::FileInformation::FILE_POSITION_INFORMATION
+                info = Fscc::FileInformation::FilePositionInformation.new
+                info.current_byte_offset = path.size
               when Fscc::FileInformation::FILE_STANDARD_INFORMATION
                 info = Fscc::FileInformation::FileStandardInformation.new
                 info.allocation_size = get_allocation_size(path)
+                info.end_of_file = path.size
                 info.directory = path.directory? ? 1 : 0
               when Fscc::FileInformation::FILE_STREAM_INFORMATION
                 unless path.file?

--- a/lib/ruby_smb/server/share/provider/disk/processor/query.rb
+++ b/lib/ruby_smb/server/share/provider/disk/processor/query.rb
@@ -315,7 +315,7 @@ module RubySMB
 
                 case request.file_information_class
                 when Fscc::FileInformation::FILE_NORMALIZED_NAME_INFORMATION
-                  info = Fscc::FileInformation::FileNameInformation.new(file_name: @handles[request.file_id.to_binary_s].remote_path)
+                  info = Fscc::FileInformation::FileNormalizedNameInformation.new(file_name: @handles[request.file_id.to_binary_s].remote_path)
                 else
                   info = build_fscc_file_information(local_path, request.file_information_class)
                 end

--- a/lib/ruby_smb/server/share/provider/disk/processor/query.rb
+++ b/lib/ruby_smb/server/share/provider/disk/processor/query.rb
@@ -344,7 +344,7 @@ module RubySMB
                     volume_label: provider.name
                   )
                 else
-                  logger.warn("Can not handle QUERY_INFO request for type: #{request.info_type}, class: #{request.file_information_class}")
+                  logger.warn("Can not handle QUERY_INFO request for type: #{request.info_type}, class: #{request.file_information_class} (#{Fscc::FileSystemInformation.name(request.file_information_class)})")
                   raise NotImplementedError
                 end
 

--- a/lib/ruby_smb/smb2/tree.rb
+++ b/lib/ruby_smb/smb2/tree.rb
@@ -237,6 +237,7 @@ module RubySMB
 
         if read
           create_request.share_access.read_access = 1
+          create_request.desired_access.read_attr = 1
           create_request.desired_access.read_data = 1
         end
 

--- a/spec/lib/ruby_smb/fscc/file_information/file_access_information_spec.rb
+++ b/spec/lib/ruby_smb/fscc/file_information/file_access_information_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+RSpec.describe RubySMB::Fscc::FileInformation::FileAccessInformation do
+  it 'references the correct class level' do
+    expect(described_class).to be_const_defined(:CLASS_LEVEL)
+    expect(described_class::CLASS_LEVEL).to be RubySMB::Fscc::FileInformation::FILE_ACCESS_INFORMATION
+  end
+
+  subject(:struct) { described_class.new }
+
+  it { should respond_to :access_flags }
+
+  it 'is little endian' do
+    expect(described_class.fields.instance_variable_get(:@hints)[:endian]).to eq :little
+  end
+
+  it 'tracks the access flags in a Uint32 field' do
+    expect(struct.access_flags).to be_a BinData::Uint32le
+  end
+
+end

--- a/spec/lib/ruby_smb/fscc/file_information/file_alignment_information_spec.rb
+++ b/spec/lib/ruby_smb/fscc/file_information/file_alignment_information_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+RSpec.describe RubySMB::Fscc::FileInformation::FileAlignmentInformation do
+  it 'references the correct class level' do
+    expect(described_class).to be_const_defined(:CLASS_LEVEL)
+    expect(described_class::CLASS_LEVEL).to be RubySMB::Fscc::FileInformation::FILE_ALIGNMENT_INFORMATION
+  end
+
+  subject(:struct) { described_class.new }
+
+  it { should respond_to :alignment_requirement }
+
+  it 'is little endian' do
+    expect(described_class.fields.instance_variable_get(:@hints)[:endian]).to eq :little
+  end
+
+  it 'tracks the alignment requirement in a Uint32 field' do
+    expect(struct.alignment_requirement).to be_a BinData::Uint32le
+  end
+
+end

--- a/spec/lib/ruby_smb/fscc/file_information/file_all_information_spec.rb
+++ b/spec/lib/ruby_smb/fscc/file_information/file_all_information_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+
+RSpec.describe RubySMB::Fscc::FileInformation::FileAllInformation do
+  it 'references the correct class level' do
+    expect(described_class).to be_const_defined(:CLASS_LEVEL)
+    expect(described_class::CLASS_LEVEL).to be RubySMB::Fscc::FileInformation::FILE_ALL_INFORMATION
+  end
+
+  subject(:struct) { described_class.new }
+
+ it { should respond_to :basic_information }
+ it { should respond_to :standard_information }
+ it { should respond_to :internal_information }
+ it { should respond_to :ea_information }
+ it { should respond_to :access_information }
+ it { should respond_to :position_information }
+ it { should respond_to :mode_information }
+ it { should respond_to :alignment_information }
+ it { should respond_to :name_information }
+
+  it 'is little endian' do
+    expect(described_class.fields.instance_variable_get(:@hints)[:endian]).to eq :little
+  end
+
+  it 'tracks the basic information in a FileBasicInformation field' do
+    expect(struct.basic_information).to be_a RubySMB::Fscc::FileInformation::FileBasicInformation
+  end
+
+  it 'tracks the standard information in a FileStandardInformation field' do
+    expect(struct.standard_information).to be_a RubySMB::Fscc::FileInformation::FileStandardInformation
+  end
+
+  it 'tracks the internal information in a FileInternalInformation field' do
+    expect(struct.internal_information).to be_a RubySMB::Fscc::FileInformation::FileInternalInformation
+  end
+
+  it 'tracks the ea information in a FileEaInformation field' do
+    expect(struct.ea_information).to be_a RubySMB::Fscc::FileInformation::FileEaInformation
+  end
+
+  it 'tracks the access information in a FileAccessInformation field' do
+    expect(struct.access_information).to be_a RubySMB::Fscc::FileInformation::FileAccessInformation
+  end
+
+  it 'tracks the position information in a FilePositionInformation field' do
+    expect(struct.position_information).to be_a RubySMB::Fscc::FileInformation::FilePositionInformation
+  end
+
+  it 'tracks the mode information in a FileModeInformation field' do
+    expect(struct.mode_information).to be_a RubySMB::Fscc::FileInformation::FileModeInformation
+  end
+
+  it 'tracks the alignment information in a FileAlignmentInformation field' do
+    expect(struct.alignment_information).to be_a RubySMB::Fscc::FileInformation::FileAlignmentInformation
+  end
+
+  it 'tracks the name information in a FileNameInformation field' do
+    expect(struct.name_information).to be_a RubySMB::Fscc::FileInformation::FileNameInformation
+  end
+end
+

--- a/spec/lib/ruby_smb/fscc/file_information/file_basic_information_spec.rb
+++ b/spec/lib/ruby_smb/fscc/file_information/file_basic_information_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+RSpec.describe RubySMB::Fscc::FileInformation::FileBasicInformation do
+  it 'references the correct class level' do
+    expect(described_class).to be_const_defined(:CLASS_LEVEL)
+    expect(described_class::CLASS_LEVEL).to be RubySMB::Fscc::FileInformation::FILE_BASIC_INFORMATION
+  end
+
+  subject(:struct) { described_class.new }
+
+  it { should respond_to :create_time }
+  it { should respond_to :last_access }
+  it { should respond_to :last_write }
+  it { should respond_to :last_change }
+  it { should respond_to :file_attributes }
+
+  it 'is little endian' do
+    expect(described_class.fields.instance_variable_get(:@hints)[:endian]).to eq :little
+  end
+
+  it 'tracks the create time in a FileTime field' do
+    expect(struct.create_time).to be_a RubySMB::Field::FileTime
+  end
+
+  it 'tracks the last access time in a FileTime field' do
+    expect(struct.last_access).to be_a RubySMB::Field::FileTime
+  end
+
+  it 'tracks the last write time in a FileTime field' do
+    expect(struct.last_write).to be_a RubySMB::Field::FileTime
+  end
+
+  it 'tracks the last modified time in a FileTime field' do
+    expect(struct.last_change).to be_a RubySMB::Field::FileTime
+  end
+
+  it 'tracks the file attributes in a FileAttributes field' do
+    expect(struct.file_attributes).to be_a RubySMB::Fscc::FileAttributes
+  end
+
+end

--- a/spec/lib/ruby_smb/fscc/file_information/file_both_directory_information_spec.rb
+++ b/spec/lib/ruby_smb/fscc/file_information/file_both_directory_information_spec.rb
@@ -43,6 +43,14 @@ RSpec.describe RubySMB::Fscc::FileInformation::FileBothDirectoryInformation do
     expect(struct.last_change).to be_a RubySMB::Field::FileTime
   end
 
+  it 'tracks the file size in a Int64 field' do
+    expect(struct.end_of_file).to be_a BinData::Int64le
+  end
+
+  it 'tracks the allocation size in a Int64 field' do
+    expect(struct.allocation_size).to be_a BinData::Int64le
+  end
+
   it 'contains the file attributes of the file' do
     expect(struct.file_attributes).to be_a RubySMB::Fscc::FileAttributes
   end

--- a/spec/lib/ruby_smb/fscc/file_information/file_both_directory_information_spec.rb
+++ b/spec/lib/ruby_smb/fscc/file_information/file_both_directory_information_spec.rb
@@ -27,6 +27,14 @@ RSpec.describe RubySMB::Fscc::FileInformation::FileBothDirectoryInformation do
     expect(described_class.fields.instance_variable_get(:@hints)[:endian]).to eq :little
   end
 
+  it 'tracks the next offset in a Uint32 field' do
+    expect(struct.next_offset).to be_a BinData::Uint32le
+  end
+
+  it 'tracks the file index in a Uint32 field' do
+    expect(struct.file_index).to be_a BinData::Uint32le
+  end
+
   it 'tracks the creation time in a Filetime field' do
     expect(struct.create_time).to be_a RubySMB::Field::FileTime
   end
@@ -60,20 +68,53 @@ RSpec.describe RubySMB::Fscc::FileInformation::FileBothDirectoryInformation do
     expect(struct.file_name_length).to eq struct.file_name.do_num_bytes
   end
 
-  it 'automatically encodes the file name in UTF-16LE' do
-    name = 'Hello_world.txt'
-    struct.file_name = name
-    expect(struct.file_name.force_encoding('utf-16le')).to eq name.encode('utf-16le')
+  it 'tracks the extended attributes size in a Uint32 field' do
+    expect(struct.ea_size).to be_a BinData::Uint32le
   end
 
-  describe 'reading in from a blob' do
-    it 'uses the file_name_length to know when to stop reading' do
+  it 'tracks the short name length in a Uint8 field' do
+    expect(struct.short_name_length).to be_a BinData::Uint8
+  end
+
+  it 'tracks the short name in a String16 field' do
+    expect(struct.short_name).to be_a RubySMB::Field::String16
+  end
+
+  it 'tracks the file name in a String16 field' do
+    expect(struct.file_name).to be_a RubySMB::Field::String16
+  end
+
+  describe '#short_name' do
+    it 'automatically encodes the short name in UTF-16LE' do
+      name = 'Hello_world.'
+      struct.short_name = name
+      expect(struct.short_name.force_encoding('utf-16le')).to eq name.encode('utf-16le')
+    end
+
+    it 'is always exactly 24 bytes in length' do
+      struct.short_name = ''
+      expect(struct.short_name.num_bytes).to eq 24
+      struct.short_name = 'Hello_world.'
+      expect(struct.short_name.num_bytes).to eq 24
+    end
+  end
+
+  describe '#file_name' do
+    it 'automatically encodes the file name in UTF-16LE' do
       name = 'Hello_world.txt'
       struct.file_name = name
-      blob = struct.to_binary_s
-      blob << 'AAAA'
-      new_from_blob = described_class.read(blob)
-      expect(new_from_blob.file_name.force_encoding('utf-16le')).to eq name.encode('utf-16le')
+      expect(struct.file_name.force_encoding('utf-16le')).to eq name.encode('utf-16le')
+    end
+
+    describe 'reading in from a blob' do
+      it 'uses the file_name_length to know when to stop reading' do
+        name = 'Hello_world.txt'
+        struct.file_name = name
+        blob = struct.to_binary_s
+        blob << 'AAAA'
+        new_from_blob = described_class.read(blob)
+        expect(new_from_blob.file_name.force_encoding('utf-16le')).to eq name.encode('utf-16le')
+      end
     end
   end
 end

--- a/spec/lib/ruby_smb/fscc/file_information/file_directory_information_spec.rb
+++ b/spec/lib/ruby_smb/fscc/file_information/file_directory_information_spec.rb
@@ -24,6 +24,14 @@ RSpec.describe RubySMB::Fscc::FileInformation::FileDirectoryInformation do
     expect(described_class.fields.instance_variable_get(:@hints)[:endian]).to eq :little
   end
 
+  it 'tracks the next offset in a Uint32 field' do
+    expect(struct.next_offset).to be_a BinData::Uint32le
+  end
+
+  it 'tracks the file index in a Uint32 field' do
+    expect(struct.file_index).to be_a BinData::Uint32le
+  end
+
   it 'tracks the creation time in a Filetime field' do
     expect(struct.create_time).to be_a RubySMB::Field::FileTime
   end
@@ -40,6 +48,14 @@ RSpec.describe RubySMB::Fscc::FileInformation::FileDirectoryInformation do
     expect(struct.last_change).to be_a RubySMB::Field::FileTime
   end
 
+  it 'tracks the file size in a Int64 field' do
+    expect(struct.end_of_file).to be_a BinData::Int64le
+  end
+
+  it 'tracks the allocation size in a Int64 field' do
+    expect(struct.allocation_size).to be_a BinData::Int64le
+  end
+
   it 'contains the file attributes of the file' do
     expect(struct.file_attributes).to be_a RubySMB::Fscc::FileAttributes
   end
@@ -49,20 +65,22 @@ RSpec.describe RubySMB::Fscc::FileInformation::FileDirectoryInformation do
     expect(struct.file_name_length).to eq struct.file_name.do_num_bytes
   end
 
-  it 'automatically encodes the file name in UTF-16LE' do
-    name = 'Hello_world.txt'
-    struct.file_name = name
-    expect(struct.file_name.force_encoding('utf-16le')).to eq name.encode('utf-16le')
-  end
-
-  describe 'reading in from a blob' do
-    it 'uses the file_name_length to know when to stop reading' do
+  describe '#file_name' do
+    it 'automatically encodes the file name in UTF-16LE' do
       name = 'Hello_world.txt'
       struct.file_name = name
-      blob = struct.to_binary_s
-      blob << 'AAAA'
-      new_from_blob = described_class.read(blob)
-      expect(new_from_blob.file_name.force_encoding('utf-16le')).to eq name.encode('utf-16le')
+      expect(struct.file_name.force_encoding('utf-16le')).to eq name.encode('utf-16le')
+    end
+
+    describe 'reading in from a blob' do
+      it 'uses the file_name_length to know when to stop reading' do
+        name = 'Hello_world.txt'
+        struct.file_name = name
+        blob = struct.to_binary_s
+        blob << 'AAAA'
+        new_from_blob = described_class.read(blob)
+        expect(new_from_blob.file_name.force_encoding('utf-16le')).to eq name.encode('utf-16le')
+      end
     end
   end
 end

--- a/spec/lib/ruby_smb/fscc/file_information/file_ea_information_spec.rb
+++ b/spec/lib/ruby_smb/fscc/file_information/file_ea_information_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+RSpec.describe RubySMB::Fscc::FileInformation::FileEaInformation do
+  it 'references the correct class level' do
+    expect(described_class).to be_const_defined(:CLASS_LEVEL)
+    expect(described_class::CLASS_LEVEL).to be RubySMB::Fscc::FileInformation::FILE_EA_INFORMATION
+  end
+
+  subject(:struct) { described_class.new }
+
+  it { should respond_to :ea_size }
+
+  it 'is little endian' do
+    expect(described_class.fields.instance_variable_get(:@hints)[:endian]).to eq :little
+  end
+
+  it 'tracks the extended attributes size in a Uint32 field' do
+    expect(struct.ea_size).to be_a BinData::Uint32le
+  end
+
+end

--- a/spec/lib/ruby_smb/fscc/file_information/file_full_directory_information_spec.rb
+++ b/spec/lib/ruby_smb/fscc/file_information/file_full_directory_information_spec.rb
@@ -25,6 +25,14 @@ RSpec.describe RubySMB::Fscc::FileInformation::FileFullDirectoryInformation do
     expect(described_class.fields.instance_variable_get(:@hints)[:endian]).to eq :little
   end
 
+  it 'tracks the next offset in a Uint32 field' do
+    expect(struct.next_offset).to be_a BinData::Uint32le
+  end
+
+  it 'tracks the file index in a Uint32 field' do
+    expect(struct.file_index).to be_a BinData::Uint32le
+  end
+
   it 'tracks the creation time in a Filetime field' do
     expect(struct.create_time).to be_a RubySMB::Field::FileTime
   end
@@ -41,6 +49,14 @@ RSpec.describe RubySMB::Fscc::FileInformation::FileFullDirectoryInformation do
     expect(struct.last_change).to be_a RubySMB::Field::FileTime
   end
 
+  it 'tracks the file size in a Int64 field' do
+    expect(struct.end_of_file).to be_a BinData::Int64le
+  end
+
+  it 'tracks the allocation size in a Int64 field' do
+    expect(struct.allocation_size).to be_a BinData::Int64le
+  end
+
   it 'contains the file attributes of the file' do
     expect(struct.file_attributes).to be_a RubySMB::Fscc::FileAttributes
   end
@@ -50,20 +66,22 @@ RSpec.describe RubySMB::Fscc::FileInformation::FileFullDirectoryInformation do
     expect(struct.file_name_length).to eq struct.file_name.do_num_bytes
   end
 
-  it 'automatically encodes the file name in UTF-16LE' do
-    name = 'Hello_world.txt'
-    struct.file_name = name
-    expect(struct.file_name.force_encoding('utf-16le')).to eq name.encode('utf-16le')
-  end
-
-  describe 'reading in from a blob' do
-    it 'uses the file_name_length to know when to stop reading' do
+  describe '#file_name' do
+    it 'automatically encodes the file name in UTF-16LE' do
       name = 'Hello_world.txt'
       struct.file_name = name
-      blob = struct.to_binary_s
-      blob << 'AAAA'
-      new_from_blob = described_class.read(blob)
-      expect(new_from_blob.file_name.force_encoding('utf-16le')).to eq name.encode('utf-16le')
+      expect(struct.file_name.force_encoding('utf-16le')).to eq name.encode('utf-16le')
+    end
+
+    describe 'reading in from a blob' do
+      it 'uses the file_name_length to know when to stop reading' do
+        name = 'Hello_world.txt'
+        struct.file_name = name
+        blob = struct.to_binary_s
+        blob << 'AAAA'
+        new_from_blob = described_class.read(blob)
+        expect(new_from_blob.file_name.force_encoding('utf-16le')).to eq name.encode('utf-16le')
+      end
     end
   end
 end

--- a/spec/lib/ruby_smb/fscc/file_information/file_id_full_directory_information_spec.rb
+++ b/spec/lib/ruby_smb/fscc/file_information/file_id_full_directory_information_spec.rb
@@ -26,6 +26,14 @@ RSpec.describe RubySMB::Fscc::FileInformation::FileIdFullDirectoryInformation do
     expect(described_class.fields.instance_variable_get(:@hints)[:endian]).to eq :little
   end
 
+  it 'tracks the next offset in a Uint32 field' do
+    expect(struct.next_offset).to be_a BinData::Uint32le
+  end
+
+  it 'tracks the file index in a Uint32 field' do
+    expect(struct.file_index).to be_a BinData::Uint32le
+  end
+
   it 'tracks the creation time in a Filetime field' do
     expect(struct.create_time).to be_a RubySMB::Field::FileTime
   end
@@ -42,6 +50,14 @@ RSpec.describe RubySMB::Fscc::FileInformation::FileIdFullDirectoryInformation do
     expect(struct.last_change).to be_a RubySMB::Field::FileTime
   end
 
+  it 'tracks the file size in a Int64 field' do
+    expect(struct.end_of_file).to be_a BinData::Int64le
+  end
+
+  it 'tracks the allocation size in a Int64 field' do
+    expect(struct.allocation_size).to be_a BinData::Int64le
+  end
+
   it 'contains the file attributes of the file' do
     expect(struct.file_attributes).to be_a RubySMB::Fscc::FileAttributes
   end
@@ -51,20 +67,22 @@ RSpec.describe RubySMB::Fscc::FileInformation::FileIdFullDirectoryInformation do
     expect(struct.file_name_length).to eq struct.file_name.do_num_bytes
   end
 
-  it 'automatically encodes the file name in UTF-16LE' do
-    name = 'Hello_world.txt'
-    struct.file_name = name
-    expect(struct.file_name.force_encoding('utf-16le')).to eq name.encode('utf-16le')
-  end
-
-  describe 'reading in from a blob' do
-    it 'uses the file_name_length to know when to stop reading' do
+  describe '#file_name' do
+    it 'automatically encodes the file name in UTF-16LE' do
       name = 'Hello_world.txt'
       struct.file_name = name
-      blob = struct.to_binary_s
-      blob << 'AAAA'
-      new_from_blob = described_class.read(blob)
-      expect(new_from_blob.file_name.force_encoding('utf-16le')).to eq name.encode('utf-16le')
+      expect(struct.file_name.force_encoding('utf-16le')).to eq name.encode('utf-16le')
+    end
+
+    describe 'reading in from a blob' do
+      it 'uses the file_name_length to know when to stop reading' do
+        name = 'Hello_world.txt'
+        struct.file_name = name
+        blob = struct.to_binary_s
+        blob << 'AAAA'
+        new_from_blob = described_class.read(blob)
+        expect(new_from_blob.file_name.force_encoding('utf-16le')).to eq name.encode('utf-16le')
+      end
     end
   end
 end

--- a/spec/lib/ruby_smb/fscc/file_information/file_internal_information_spec.rb
+++ b/spec/lib/ruby_smb/fscc/file_information/file_internal_information_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+RSpec.describe RubySMB::Fscc::FileInformation::FileInternalInformation do
+  it 'references the correct class level' do
+    expect(described_class).to be_const_defined(:CLASS_LEVEL)
+    expect(described_class::CLASS_LEVEL).to be RubySMB::Fscc::FileInformation::FILE_INTERNAL_INFORMATION
+  end
+
+  subject(:struct) { described_class.new }
+
+  it { should respond_to :file_id }
+
+  it 'is little endian' do
+    expect(described_class.fields.instance_variable_get(:@hints)[:endian]).to eq :little
+  end
+
+  it 'tracks the file ID in a Uint64 field' do
+    expect(struct.file_id).to be_a BinData::Uint64le
+  end
+
+end

--- a/spec/lib/ruby_smb/fscc/file_information/file_mode_information_spec.rb
+++ b/spec/lib/ruby_smb/fscc/file_information/file_mode_information_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+RSpec.describe RubySMB::Fscc::FileInformation::FileModeInformation do
+  it 'references the correct class level' do
+    expect(described_class).to be_const_defined(:CLASS_LEVEL)
+    expect(described_class::CLASS_LEVEL).to be RubySMB::Fscc::FileInformation::FILE_MODE_INFORMATION
+  end
+
+  subject(:struct) { described_class.new }
+
+  it { should respond_to :flags }
+
+  it 'is little endian' do
+    expect(described_class.fields.instance_variable_get(:@hints)[:endian]).to eq :little
+  end
+
+  it 'tracks the flags in a struct field' do
+    expect(struct.flags).to be_a BinData::Struct
+  end
+
+end

--- a/spec/lib/ruby_smb/fscc/file_information/file_name_information_spec.rb
+++ b/spec/lib/ruby_smb/fscc/file_information/file_name_information_spec.rb
@@ -1,15 +1,13 @@
 require 'spec_helper'
 
-RSpec.describe RubySMB::Fscc::FileInformation::FileNamesInformation do
+RSpec.describe RubySMB::Fscc::FileInformation::FileNameInformation do
   it 'references the correct class level' do
     expect(described_class).to be_const_defined(:CLASS_LEVEL)
-    expect(described_class::CLASS_LEVEL).to be RubySMB::Fscc::FileInformation::FILE_NAMES_INFORMATION
+    expect(described_class::CLASS_LEVEL).to be RubySMB::Fscc::FileInformation::FILE_NAME_INFORMATION
   end
 
   subject(:struct) { described_class.new }
 
-  it { should respond_to :next_offset }
-  it { should respond_to :file_index }
   it { should respond_to :file_name_length }
   it { should respond_to :file_name }
 
@@ -23,11 +21,6 @@ RSpec.describe RubySMB::Fscc::FileInformation::FileNamesInformation do
 
   it 'tracks the file name in a String16 field' do
     expect(struct.file_name).to be_a RubySMB::Field::String16
-  end
-
-  it 'tracks the length of the file_name field' do
-    struct.file_name = 'Hello.txt'
-    expect(struct.file_name_length).to eq struct.file_name.do_num_bytes
   end
 
   it 'automatically encodes the file name in UTF-16LE' do

--- a/spec/lib/ruby_smb/fscc/file_information/file_name_information_spec.rb
+++ b/spec/lib/ruby_smb/fscc/file_information/file_name_information_spec.rb
@@ -23,20 +23,22 @@ RSpec.describe RubySMB::Fscc::FileInformation::FileNameInformation do
     expect(struct.file_name).to be_a RubySMB::Field::String16
   end
 
-  it 'automatically encodes the file name in UTF-16LE' do
-    name = 'Hello_world.txt'
-    struct.file_name = name
-    expect(struct.file_name.force_encoding('utf-16le')).to eq name.encode('utf-16le')
-  end
-
-  describe 'reading in from a blob' do
-    it 'uses the file_name_length to know when to stop reading' do
+  describe '#file_name' do
+    it 'automatically encodes the file name in UTF-16LE' do
       name = 'Hello_world.txt'
       struct.file_name = name
-      blob = struct.to_binary_s
-      blob << 'AAAA'
-      new_from_blob = described_class.read(blob)
-      expect(new_from_blob.file_name.force_encoding('utf-16le')).to eq name.encode('utf-16le')
+      expect(struct.file_name.force_encoding('utf-16le')).to eq name.encode('utf-16le')
+    end
+
+    describe 'reading in from a blob' do
+      it 'uses the file_name_length to know when to stop reading' do
+        name = 'Hello_world.txt'
+        struct.file_name = name
+        blob = struct.to_binary_s
+        blob << 'AAAA'
+        new_from_blob = described_class.read(blob)
+        expect(new_from_blob.file_name.force_encoding('utf-16le')).to eq name.encode('utf-16le')
+      end
     end
   end
 end

--- a/spec/lib/ruby_smb/fscc/file_information/file_names_information_spec.rb
+++ b/spec/lib/ruby_smb/fscc/file_information/file_names_information_spec.rb
@@ -17,6 +17,14 @@ RSpec.describe RubySMB::Fscc::FileInformation::FileNamesInformation do
     expect(described_class.fields.instance_variable_get(:@hints)[:endian]).to eq :little
   end
 
+  it 'tracks the next offset in a Uint32 field' do
+    expect(struct.next_offset).to be_a BinData::Uint32le
+  end
+
+  it 'tracks the file index in a Uint32 field' do
+    expect(struct.file_index).to be_a BinData::Uint32le
+  end
+
   it 'tracks the file name length in a Uint32 field' do
     expect(struct.file_name_length).to be_a BinData::Uint32le
   end
@@ -30,20 +38,22 @@ RSpec.describe RubySMB::Fscc::FileInformation::FileNamesInformation do
     expect(struct.file_name_length).to eq struct.file_name.do_num_bytes
   end
 
-  it 'automatically encodes the file name in UTF-16LE' do
-    name = 'Hello_world.txt'
-    struct.file_name = name
-    expect(struct.file_name.force_encoding('utf-16le')).to eq name.encode('utf-16le')
-  end
-
-  describe 'reading in from a blob' do
-    it 'uses the file_name_length to know when to stop reading' do
+  describe '#file_name' do
+    it 'automatically encodes the file name in UTF-16LE' do
       name = 'Hello_world.txt'
       struct.file_name = name
-      blob = struct.to_binary_s
-      blob << 'AAAA'
-      new_from_blob = described_class.read(blob)
-      expect(new_from_blob.file_name.force_encoding('utf-16le')).to eq name.encode('utf-16le')
+      expect(struct.file_name.force_encoding('utf-16le')).to eq name.encode('utf-16le')
+    end
+
+    describe 'reading in from a blob' do
+      it 'uses the file_name_length to know when to stop reading' do
+        name = 'Hello_world.txt'
+        struct.file_name = name
+        blob = struct.to_binary_s
+        blob << 'AAAA'
+        new_from_blob = described_class.read(blob)
+        expect(new_from_blob.file_name.force_encoding('utf-16le')).to eq name.encode('utf-16le')
+      end
     end
   end
 end

--- a/spec/lib/ruby_smb/fscc/file_information/file_network_open_information_spec.rb
+++ b/spec/lib/ruby_smb/fscc/file_information/file_network_open_information_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+RSpec.describe RubySMB::Fscc::FileInformation::FileNetworkOpenInformation do
+  it 'references the correct class level' do
+    expect(described_class).to be_const_defined(:CLASS_LEVEL)
+    expect(described_class::CLASS_LEVEL).to be RubySMB::Fscc::FileInformation::FILE_NETWORK_OPEN_INFORMATION
+  end
+
+  subject(:struct) { described_class.new }
+
+  it { should respond_to :create_time }
+  it { should respond_to :last_access }
+  it { should respond_to :last_write }
+  it { should respond_to :last_change }
+  it { should respond_to :allocation_size }
+  it { should respond_to :end_of_file }
+  it { should respond_to :file_attributes }
+
+  it 'is little endian' do
+    expect(described_class.fields.instance_variable_get(:@hints)[:endian]).to eq :little
+  end
+
+  it 'tracks the create time in a FileTime field' do
+    expect(struct.create_time).to be_a RubySMB::Field::FileTime
+  end
+
+  it 'tracks the last access time in a FileTime field' do
+    expect(struct.last_access).to be_a RubySMB::Field::FileTime
+  end
+
+  it 'tracks the last write time in a FileTime field' do
+    expect(struct.last_write).to be_a RubySMB::Field::FileTime
+  end
+
+  it 'tracks the last modified time in a FileTime field' do
+    expect(struct.last_change).to be_a RubySMB::Field::FileTime
+  end
+
+  it 'tracks the file size in a Int64 field' do
+    expect(struct.end_of_file).to be_a BinData::Int64le
+  end
+
+  it 'tracks the allocation size in a Int64 field' do
+    expect(struct.allocation_size).to be_a BinData::Int64le
+  end
+
+  it 'tracks the file attributes in a FileAttributes field' do
+    expect(struct.file_attributes).to be_a RubySMB::Fscc::FileAttributes
+  end
+
+end

--- a/spec/lib/ruby_smb/fscc/file_information/file_normalized_name_information_spec.rb
+++ b/spec/lib/ruby_smb/fscc/file_information/file_normalized_name_information_spec.rb
@@ -23,20 +23,22 @@ RSpec.describe RubySMB::Fscc::FileInformation::FileNormalizedNameInformation do
     expect(struct.file_name).to be_a RubySMB::Field::String16
   end
 
-  it 'automatically encodes the file name in UTF-16LE' do
-    name = 'Hello_world.txt'
-    struct.file_name = name
-    expect(struct.file_name.force_encoding('utf-16le')).to eq name.encode('utf-16le')
-  end
-
-  describe 'reading in from a blob' do
-    it 'uses the file_name_length to know when to stop reading' do
+  describe '#file_name' do
+    it 'automatically encodes the file name in UTF-16LE' do
       name = 'Hello_world.txt'
       struct.file_name = name
-      blob = struct.to_binary_s
-      blob << 'AAAA'
-      new_from_blob = described_class.read(blob)
-      expect(new_from_blob.file_name.force_encoding('utf-16le')).to eq name.encode('utf-16le')
+      expect(struct.file_name.force_encoding('utf-16le')).to eq name.encode('utf-16le')
+    end
+
+    describe 'reading in from a blob' do
+      it 'uses the file_name_length to know when to stop reading' do
+        name = 'Hello_world.txt'
+        struct.file_name = name
+        blob = struct.to_binary_s
+        blob << 'AAAA'
+        new_from_blob = described_class.read(blob)
+        expect(new_from_blob.file_name.force_encoding('utf-16le')).to eq name.encode('utf-16le')
+      end
     end
   end
 end

--- a/spec/lib/ruby_smb/fscc/file_information/file_normalized_name_information_spec.rb
+++ b/spec/lib/ruby_smb/fscc/file_information/file_normalized_name_information_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+RSpec.describe RubySMB::Fscc::FileInformation::FileNormalizedNameInformation do
+  it 'references the correct class level' do
+    expect(described_class).to be_const_defined(:CLASS_LEVEL)
+    expect(described_class::CLASS_LEVEL).to be RubySMB::Fscc::FileInformation::FILE_NORMALIZED_NAME_INFORMATION
+  end
+
+  subject(:struct) { described_class.new }
+
+  it { should respond_to :file_name_length }
+  it { should respond_to :file_name }
+
+  it 'is little endian' do
+    expect(described_class.fields.instance_variable_get(:@hints)[:endian]).to eq :little
+  end
+
+  it 'tracks the file name length in a Uint32 field' do
+    expect(struct.file_name_length).to be_a BinData::Uint32le
+  end
+
+  it 'tracks the file name in a String16 field' do
+    expect(struct.file_name).to be_a RubySMB::Field::String16
+  end
+
+  it 'automatically encodes the file name in UTF-16LE' do
+    name = 'Hello_world.txt'
+    struct.file_name = name
+    expect(struct.file_name.force_encoding('utf-16le')).to eq name.encode('utf-16le')
+  end
+
+  describe 'reading in from a blob' do
+    it 'uses the file_name_length to know when to stop reading' do
+      name = 'Hello_world.txt'
+      struct.file_name = name
+      blob = struct.to_binary_s
+      blob << 'AAAA'
+      new_from_blob = described_class.read(blob)
+      expect(new_from_blob.file_name.force_encoding('utf-16le')).to eq name.encode('utf-16le')
+    end
+  end
+end

--- a/spec/lib/ruby_smb/fscc/file_information/file_position_information_spec.rb
+++ b/spec/lib/ruby_smb/fscc/file_information/file_position_information_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+RSpec.describe RubySMB::Fscc::FileInformation::FilePositionInformation do
+  it 'references the correct class level' do
+    expect(described_class).to be_const_defined(:CLASS_LEVEL)
+    expect(described_class::CLASS_LEVEL).to be RubySMB::Fscc::FileInformation::FILE_POSITION_INFORMATION
+  end
+
+  subject(:struct) { described_class.new }
+
+  it { should respond_to :current_byte_offset }
+
+  it 'is little endian' do
+    expect(described_class.fields.instance_variable_get(:@hints)[:endian]).to eq :little
+  end
+
+  it 'tracks the current byte offset in a Int64 field' do
+    expect(struct.current_byte_offset).to be_a BinData::Int64le
+  end
+
+end

--- a/spec/lib/ruby_smb/fscc/file_information/file_rename_information_spec.rb
+++ b/spec/lib/ruby_smb/fscc/file_information/file_rename_information_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 RSpec.describe RubySMB::Fscc::FileInformation::FileRenameInformation do
   it 'references the correct class level' do
     expect(described_class).to be_const_defined(:CLASS_LEVEL)
-    expect(described_class::CLASS_LEVEL).to be RubySMB::Fscc::FileInformation::FILE_ID_FULL_DIRECTORY_INFORMATION
+    expect(described_class::CLASS_LEVEL).to be RubySMB::Fscc::FileInformation::FILE_RENAME_INFORMATION
   end
 
   subject(:struct) { described_class.new }

--- a/spec/lib/ruby_smb/fscc/file_information/file_standard_information_spec.rb
+++ b/spec/lib/ruby_smb/fscc/file_information/file_standard_information_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+RSpec.describe RubySMB::Fscc::FileInformation::FileStandardInformation do
+  it 'references the correct class level' do
+    expect(described_class).to be_const_defined(:CLASS_LEVEL)
+    expect(described_class::CLASS_LEVEL).to be RubySMB::Fscc::FileInformation::FILE_STANDARD_INFORMATION
+  end
+
+  subject(:struct) { described_class.new }
+
+  it { should respond_to :allocation_size }
+  it { should respond_to :end_of_file }
+  it { should respond_to :number_of_links }
+  it { should respond_to :delete_pending }
+  it { should respond_to :directory }
+
+  it 'is little endian' do
+    expect(described_class.fields.instance_variable_get(:@hints)[:endian]).to eq :little
+  end
+
+  it 'tracks the allocation size in a Int64 field' do
+    expect(struct.allocation_size).to be_a BinData::Int64le
+  end
+
+  it 'tracks the file size in a Int64 field' do
+    expect(struct.end_of_file).to be_a BinData::Int64le
+  end
+
+  it 'tracks the number of links in a Uint32 field' do
+    expect(struct.number_of_links).to be_a BinData::Uint32le
+  end
+
+  it 'tracks if a delete is pending in a Int8 field' do
+    expect(struct.delete_pending).to be_a BinData::Int8
+  end
+
+  it 'tracks if it is a directory in a Int8 field' do
+    expect(struct.directory).to be_a BinData::Int8
+  end
+
+end

--- a/spec/lib/ruby_smb/fscc/file_information/file_stream_information_spec.rb
+++ b/spec/lib/ruby_smb/fscc/file_information/file_stream_information_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+RSpec.describe RubySMB::Fscc::FileInformation::FileStreamInformation do
+  it 'references the correct class level' do
+    expect(described_class).to be_const_defined(:CLASS_LEVEL)
+    expect(described_class::CLASS_LEVEL).to be RubySMB::Fscc::FileInformation::FILE_STREAM_INFORMATION
+  end
+
+  subject(:struct) { described_class.new }
+
+  it { should respond_to :next_entry_offset }
+  it { should respond_to :stream_name_length }
+  it { should respond_to :stream_size }
+  it { should respond_to :stream_allocation_size }
+  it { should respond_to :stream_name }
+
+  it 'is little endian' do
+    expect(described_class.fields.instance_variable_get(:@hints)[:endian]).to eq :little
+  end
+
+  it 'tracks the next entry offset in a Uint32 field' do
+    expect(struct.next_entry_offset).to be_a BinData::Uint32le
+  end
+
+  it 'tracks the stream name length in a Uint32 field' do
+    expect(struct.stream_name_length).to be_a BinData::Uint32le
+  end
+
+  it 'tracks the stream size in a Int64 field' do
+    expect(struct.stream_size).to be_a BinData::Int64le
+  end
+
+  it 'tracks the stream allocation size in a Int64 field' do
+    expect(struct.stream_allocation_size).to be_a BinData::Int64le
+  end
+
+  it 'tracks the stream name in a String16 field' do
+    expect(struct.stream_name).to be_a RubySMB::Field::String16
+  end
+
+  it 'tracks the length of the stream_name field' do
+    struct.stream_name = 'Hello.txt'
+    expect(struct.stream_name_length).to eq struct.stream_name.do_num_bytes
+  end
+
+  it 'automatically encodes the stream name in UTF-16LE' do
+    name = 'Hello_world.txt'
+    struct.stream_name = name
+    expect(struct.stream_name.force_encoding('utf-16le')).to eq name.encode('utf-16le')
+  end
+end

--- a/spec/lib/ruby_smb/fscc/file_information_spec.rb
+++ b/spec/lib/ruby_smb/fscc/file_information_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+RSpec.describe RubySMB::Fscc::FileInformation do
+
+  describe '#name' do
+    it 'maps constant names to their value' do
+      expect(described_class.name(RubySMB::Fscc::FileInformation::FILE_DIRECTORY_INFORMATION)).to eq :FILE_DIRECTORY_INFORMATION
+    end
+
+    it 'returns nil for values that do not exist' do
+      expect(described_class.name(-1)).to be_nil
+    end
+  end
+end

--- a/spec/lib/ruby_smb/fscc/file_system_information/file_fs_attribute_information_spec.rb
+++ b/spec/lib/ruby_smb/fscc/file_system_information/file_fs_attribute_information_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+RSpec.describe RubySMB::Fscc::FileSystemInformation::FileFsAttributeInformation do
+  it 'references the correct class level' do
+    expect(described_class).to be_const_defined(:CLASS_LEVEL)
+    expect(described_class::CLASS_LEVEL).to be RubySMB::Fscc::FileSystemInformation::FILE_FS_ATTRIBUTE_INFORMATION
+  end
+
+  subject(:struct) { described_class.new }
+
+  it { should respond_to :file_system_attributes }
+  it { should respond_to :maximum_component_name_length }
+  it { should respond_to :file_system_name_length }
+  it { should respond_to :file_system_name }
+
+  it 'is little endian' do
+    expect(described_class.fields.instance_variable_get(:@hints)[:endian]).to eq :little
+  end
+
+  it 'tracks the file system attributes in a struct field' do
+    expect(struct.file_system_attributes).to be_a BinData::Struct
+  end
+
+  it 'tracks the maximum component name length in a Int32 field' do
+    expect(struct.maximum_component_name_length).to be_a BinData::Int32le
+  end
+
+  it 'tracks the file system name length in a Uint32 field' do
+    expect(struct.file_system_name_length).to be_a BinData::Uint32le
+  end
+
+  it 'tracks the file system name in a String16 field' do
+    expect(struct.file_system_name).to be_a RubySMB::Field::String16
+  end
+
+  it 'tracks the length of the file_system_name field' do
+    struct.file_system_name = 'NTFS'
+    expect(struct.file_system_name_length).to eq struct.file_system_name.do_num_bytes
+  end
+
+  it 'automatically encodes the file system name in UTF-16LE' do
+    name = 'NTFS'
+    struct.file_system_name = name
+    expect(struct.file_system_name.force_encoding('utf-16le')).to eq name.encode('utf-16le')
+  end
+end

--- a/spec/lib/ruby_smb/fscc/file_system_information/file_fs_volume_information_spec.rb
+++ b/spec/lib/ruby_smb/fscc/file_system_information/file_fs_volume_information_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+RSpec.describe RubySMB::Fscc::FileSystemInformation::FileFsVolumeInformation do
+  it 'references the correct class level' do
+    expect(described_class).to be_const_defined(:CLASS_LEVEL)
+    expect(described_class::CLASS_LEVEL).to be RubySMB::Fscc::FileSystemInformation::FILE_FS_VOLUME_INFORMATION
+  end
+
+  subject(:struct) { described_class.new }
+
+  it { should respond_to :volume_creation_time }
+  it { should respond_to :volume_serial_number }
+  it { should respond_to :volume_label_length }
+  it { should respond_to :supports_objects }
+  it { should respond_to :volume_label }
+
+  it 'is little endian' do
+    expect(described_class.fields.instance_variable_get(:@hints)[:endian]).to eq :little
+  end
+
+  it 'tracks the volume creation time in a FileTime field' do
+    expect(struct.volume_creation_time).to be_a RubySMB::Field::FileTime
+  end
+
+  it 'tracks the volume serial number in a Uint32 field' do
+    expect(struct.volume_serial_number).to be_a BinData::Uint32le
+  end
+
+  it 'tracks the volume label length in a Uint32 field' do
+    expect(struct.volume_label_length).to be_a BinData::Uint32le
+  end
+
+  it 'tracks if it supports objects in a Uint8 field' do
+    expect(struct.supports_objects).to be_a BinData::Uint8
+  end
+
+  it 'tracks the volume label in a String16 field' do
+    expect(struct.volume_label).to be_a RubySMB::Field::String16
+  end
+
+  it 'tracks the length of the volume_label field' do
+    struct.volume_label = 'NTFS'
+    expect(struct.volume_label_length).to eq struct.volume_label.do_num_bytes
+  end
+
+  it 'automatically encodes the file system name in UTF-16LE' do
+    name = 'NTFS'
+    struct.volume_label = name
+    expect(struct.volume_label.force_encoding('utf-16le')).to eq name.encode('utf-16le')
+  end
+end

--- a/spec/lib/ruby_smb/fscc/file_system_information_spec.rb
+++ b/spec/lib/ruby_smb/fscc/file_system_information_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+RSpec.describe RubySMB::Fscc::FileSystemInformation do
+
+  describe '#name' do
+    it 'maps constant names to their value' do
+      expect(described_class.name(RubySMB::Fscc::FileSystemInformation::FILE_FS_VOLUME_INFORMATION)).to eq :FILE_FS_VOLUME_INFORMATION
+    end
+
+    it 'returns nil for values that do not exist' do
+      expect(described_class.name(-1)).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
This adds server support for two new Fscc information classes `FILE_ID_FULL_DIRECTORY_INFORMATION` and `FILE_ALL_INFORMATION`. `FILE_ALL_INFORMATION` is actually a compound field that is composed of a whole bunch of others that have also all been added. `FILE_ALL_INFORMATION` support fixes trying to read files using `smbclient` and `FILE_ID_FULL_DIRECTORY_INFORMATION` fixes trying to list directories on the server using RubySMB's own `example/list_directory.rb` script (thus closing #208).

# Testing
- [ ] Make sure the new unit tests pass'
- [ ] Start the example file server using `examples/file_server.rb` and the necessary arguments to share a directory with some files
- [ ] Test FILE_ALL_INFORMATION
- [ ] Use `smbclient` to connect to the server, then use the `get` command to download a file. This would result in NotImplemented error prior to this patch.
- [ ] Test FILE_ID_FULL_DIRECTORY_INFORMATION
- [ ] Use the `examples/list_directory.rb` script to list the directory. This would result in a server-side NotImplemented error and a client side stack-trace prior to this patch.
    