### PR TITLE
Move the server CLI into a library

### DIFF
--- a/examples/file_server.rb
+++ b/examples/file_server.rb
@@ -10,7 +10,7 @@ Encoding.default_internal = 'UTF-8' if Encoding.default_internal.nil?
 options = RubySMB::Server::Cli.parse(defaults: { share_path: '.' }) do |options, parser|
   parser.banner = "Usage: #{File.basename(__FILE__)} [options]"
 
-  parser.on("--path PATH", "The path to share (default: #{options[:share_path]})") do |path|
+  parser.on("--share-path SHARE_PATH", "The path to share (default: #{options[:share_path]})") do |path|
     options[:share_path] = path
   end
 end

--- a/examples/file_server.rb
+++ b/examples/file_server.rb
@@ -7,7 +7,7 @@ require 'ruby_smb'
 # we just need *a* default encoding to handle the strings from the NTLM messages
 Encoding.default_internal = 'UTF-8' if Encoding.default_internal.nil?
 
-options = RubySMB::Server::Cli.parse!(defaults: { share_path: '.' }) do |options, parser|
+options = RubySMB::Server::Cli.parse(defaults: { share_path: '.' }) do |options, parser|
   parser.banner = "Usage: #{File.basename(__FILE__)} [options]"
 
   parser.on("--path PATH", "The path to share (default: #{options[:share_path]})") do |path|

--- a/examples/file_server.rb
+++ b/examples/file_server.rb
@@ -3,81 +3,19 @@
 require 'bundler/setup'
 require 'optparse'
 require 'ruby_smb'
-require 'ruby_smb/gss/provider/ntlm'
 
 # we just need *a* default encoding to handle the strings from the NTLM messages
 Encoding.default_internal = 'UTF-8' if Encoding.default_internal.nil?
 
-options = {
-  allow_anonymous: true,
-  allow_guests: false,
-  domain: nil,
-  username: 'RubySMB',
-  password: 'password',
-  share_name: 'home',
-  share_path: '.',
-  smbv1: true,
-  smbv2: true,
-  smbv3: true
-}
-OptionParser.new do |opts|
-  opts.banner = "Usage: #{File.basename(__FILE__)} [options]"
-  opts.on("--path PATH", "The path to share (default: #{options[:share_path]})") do |path|
+options = RubySMB::Server::Cli.parse!(defaults: { share_path: '.' }) do |options, parser|
+  parser.banner = "Usage: #{File.basename(__FILE__)} [options]"
+
+  parser.on("--path PATH", "The path to share (default: #{options[:share_path]})") do |path|
     options[:share_path] = path
   end
-  opts.on("--share SHARE", "The share name (default: #{options[:share_name]})") do |share|
-    options[:share_name] = share
-  end
-  opts.on("--[no-]anonymous", "Allow anonymous access (default: #{options[:allow_anonymous]})") do |allow_anonymous|
-    options[:allow_anonymous] = allow_anonymous
-  end
-  opts.on("--[no-]smbv1", "Enable or disable SMBv1 (default: #{options[:smbv1] ? 'Enabled' : 'Disabled'})") do |smbv1|
-    options[:smbv1] = smbv1
-  end
-  opts.on("--[no-]smbv2", "Enable or disable SMBv2 (default: #{options[:smbv2] ? 'Enabled' : 'Disabled'})") do |smbv2|
-    options[:smbv2] = smbv2
-  end
-  opts.on("--[no-]smbv3", "Enable or disable SMBv3 (default: #{options[:smbv3] ? 'Enabled' : 'Disabled'})") do |smbv3|
-    options[:smbv3] = smbv3
-  end
-  opts.on("--[no-]guests", "Allow guest accounts (default: #{options[:allow_guests]})") do |allow_guests|
-    options[:allow_guests] = allow_guests
-  end
-  opts.on("--username USERNAME", "The account's username (default: #{options[:username]})") do |username|
-    if username.include?('\\')
-      options[:domain], options[:username] = username.split('\\', 2)
-    else
-      options[:username] = username
-    end
-  end
-  opts.on("--password PASSWORD", "The account's password (default: #{options[:password]})") do |password|
-    options[:password] = password
-  end
-end.parse!
-
-ntlm_provider = RubySMB::Gss::Provider::NTLM.new(
-  allow_anonymous: options[:allow_anonymous],
-  allow_guests: options[:allow_guests]
-)
-ntlm_provider.put_account(options[:username], options[:password], domain: options[:domain])  # password can also be an NTLM hash
-
-server = RubySMB::Server.new(
-  gss_provider: ntlm_provider,
-  logger: :stdout
-)
-server.dialects.select! { |dialect| RubySMB::Dialect[dialect].family != RubySMB::Dialect::FAMILY_SMB1 } unless options[:smbv1]
-server.dialects.select! { |dialect| RubySMB::Dialect[dialect].family != RubySMB::Dialect::FAMILY_SMB2 } unless options[:smbv2]
-server.dialects.select! { |dialect| RubySMB::Dialect[dialect].family != RubySMB::Dialect::FAMILY_SMB3 } unless options[:smbv3]
-
-if server.dialects.empty?
-  puts "at least one version must be enabled"
-  exit false
 end
 
+server = RubySMB::Server::Cli.build(options)
 server.add_share(RubySMB::Server::Share::Provider::Disk.new(options[:share_name], options[:share_path]))
-puts "server is running"
-server.run do
-  puts "received connection"
-  true
-end
 
+RubySMB::Server::Cli.run(server)

--- a/examples/virtual_file_server.rb
+++ b/examples/virtual_file_server.rb
@@ -31,7 +31,7 @@ MAGIC_8_BALL_ANSWERS = [
   'Very doubtful'
 ]
 
-options = RubySMB::Server::Cli.parse! do |options, parser|
+options = RubySMB::Server::Cli.parse do |options, parser|
   parser.banner = "Usage: #{File.basename(__FILE__)} [options]"
 
   parser.on("--virtual-content CONTENT", "The virtual share contents") do |virtual_content|

--- a/examples/virtual_file_server.rb
+++ b/examples/virtual_file_server.rb
@@ -3,7 +3,6 @@
 require 'bundler/setup'
 require 'optparse'
 require 'ruby_smb'
-require 'ruby_smb/gss/provider/ntlm'
 
 # we just need *a* default encoding to handle the strings from the NTLM messages
 Encoding.default_internal = 'UTF-8' if Encoding.default_internal.nil?
@@ -32,70 +31,23 @@ MAGIC_8_BALL_ANSWERS = [
   'Very doubtful'
 ]
 
-options = {
-  allow_anonymous: true,
-  domain: nil,
-  username: 'RubySMB',
-  password: 'password',
-  share_name: 'home',
-  smbv1: true,
-  smbv2: true,
-  smbv3: true
-}
-OptionParser.new do |opts|
-  opts.banner = "Usage: #{File.basename(__FILE__)} [options]"
-  opts.on("--share SHARE", "The share name (default: #{options[:share_name]})") do |share|
-    options[:share_name] = share
-  end
-  opts.on("--[no-]anonymous", "Allow anonymous access (default: #{options[:allow_anonymous]})") do |allow_anonymous|
-    options[:allow_anonymous] = allow_anonymous
-  end
-  opts.on("--[no-]smbv1", "Enable or disable SMBv1 (default: #{options[:smbv1] ? 'Enabled' : 'Disabled'})") do |smbv1|
-    options[:smbv1] = smbv1
-  end
-  opts.on("--[no-]smbv2", "Enable or disable SMBv2 (default: #{options[:smbv2] ? 'Enabled' : 'Disabled'})") do |smbv2|
-    options[:smbv2] = smbv2
-  end
-  opts.on("--[no-]smbv3", "Enable or disable SMBv3 (default: #{options[:smbv3] ? 'Enabled' : 'Disabled'})") do |smbv3|
-    options[:smbv3] = smbv3
-  end
-  opts.on("--username USERNAME", "The account's username (default: #{options[:username]})") do |username|
-    if username.include?('\\')
-      options[:domain], options[:username] = username.split('\\', 2)
-    else
-      options[:username] = username
-    end
-  end
-  opts.on("--password PASSWORD", "The account's password (default: #{options[:password]})") do |password|
-    options[:password] = password
-  end
-  opts.on("--virtual-content CONTENT", "The virtual share contents") do |virtual_content|
+options = RubySMB::Server::Cli.parse! do |options, parser|
+  parser.banner = "Usage: #{File.basename(__FILE__)} [options]"
+
+  parser.on("--virtual-content CONTENT", "The virtual share contents") do |virtual_content|
     options[:virtual_content] = virtual_content
   end
-  opts.on("--virtual-name NAME", "The virtual share file name") do |virtual_name|
+
+  parser.on("--virtual-name NAME", "The virtual share file name") do |virtual_name|
     options[:virtual_name] = virtual_name
   end
-  opts.on("--virtual-type TYPE", "The virtual share type") do |virtual_type|
+
+  parser.on("--virtual-type TYPE", "The virtual share type") do |virtual_type|
     options[:virtual_type] = virtual_type
   end
-end.parse!
-
-ntlm_provider = RubySMB::Gss::Provider::NTLM.new(allow_anonymous: options[:allow_anonymous])
-ntlm_provider.put_account(options[:username], options[:password], domain: options[:domain])  # password can also be an NTLM hash
-
-server = RubySMB::Server.new(
-  gss_provider: ntlm_provider,
-  logger: :stdout
-)
-server.dialects.select! { |dialect| RubySMB::Dialect[dialect].family != RubySMB::Dialect::FAMILY_SMB1 } unless options[:smbv1]
-server.dialects.select! { |dialect| RubySMB::Dialect[dialect].family != RubySMB::Dialect::FAMILY_SMB2 } unless options[:smbv2]
-server.dialects.select! { |dialect| RubySMB::Dialect[dialect].family != RubySMB::Dialect::FAMILY_SMB3 } unless options[:smbv3]
-
-if server.dialects.empty?
-  puts "at least one version must be enabled"
-  exit false
 end
 
+server = RubySMB::Server::Cli.build(options)
 virtual_disk = RubySMB::Server::Share::Provider::VirtualDisk.new(options[:share_name])
 
 # greeting is a static text file
@@ -135,9 +87,5 @@ elsif options[:virtual_content] || options[:virtual_name] || options[:virtual_ty
 end
 
 server.add_share(virtual_disk)
-puts "server is running"
-server.run do |server_client|
-  puts "received connection"
-  true
-end
 
+RubySMB::Server::Cli.run(server)

--- a/lib/ruby_smb/server.rb
+++ b/lib/ruby_smb/server.rb
@@ -6,6 +6,7 @@ module RubySMB
   # Currently, the server only supports negotiating and authenticating requests. No other server functionality is
   # available at this time. The negotiating and authentication is supported for SMB versions 1 through 3.1.1.
   class Server
+    require 'ruby_smb/server/cli'
     require 'ruby_smb/server/server_client'
     require 'ruby_smb/server/session'
     require 'ruby_smb/server/share'

--- a/lib/ruby_smb/server/cli.rb
+++ b/lib/ruby_smb/server/cli.rb
@@ -31,7 +31,7 @@ module RubySMB
       #   * :smbv2 [Boolean] Whether or not to enable SMBv2 dialects.
       #   * :smbv3 [Boolean] Whether or not to enable SMBv3 dialects.
       #   * :share_name [String] The name of the share to add.
-      def self.parse!(defaults: {}, &block)
+      def self.parse(defaults: {}, &block)
         defaults = DEFAULT_OPTIONS.merge(defaults)
         options = defaults.clone
         OptionParser.new do |parser|

--- a/lib/ruby_smb/server/cli.rb
+++ b/lib/ruby_smb/server/cli.rb
@@ -35,7 +35,7 @@ module RubySMB
         defaults = DEFAULT_OPTIONS.merge(defaults)
         options = defaults.clone
         OptionParser.new do |parser|
-          parser.on("--share SHARE", "The share name (default: #{defaults[:share_name]})") do |share|
+          parser.on("--share-name SHARE_NAME", "The share name (default: #{defaults[:share_name]})") do |share|
             options[:share_name] = share
           end
 
@@ -92,9 +92,9 @@ module RubySMB
           gss_provider: ntlm_provider,
           logger: :stdout
         )
-        server.dialects.select! { |dialect| RubySMB::Dialect[dialect].family != RubySMB::Dialect::FAMILY_SMB1 } unless options[:smbv1]
-        server.dialects.select! { |dialect| RubySMB::Dialect[dialect].family != RubySMB::Dialect::FAMILY_SMB2 } unless options[:smbv2]
-        server.dialects.select! { |dialect| RubySMB::Dialect[dialect].family != RubySMB::Dialect::FAMILY_SMB3 } unless options[:smbv3]
+        server.dialects.filter! { |dialect| RubySMB::Dialect[dialect].family != RubySMB::Dialect::FAMILY_SMB1 } unless options[:smbv1]
+        server.dialects.filter! { |dialect| RubySMB::Dialect[dialect].family != RubySMB::Dialect::FAMILY_SMB2 } unless options[:smbv2]
+        server.dialects.filter! { |dialect| RubySMB::Dialect[dialect].family != RubySMB::Dialect::FAMILY_SMB3 } unless options[:smbv3]
 
         server
       end

--- a/lib/ruby_smb/server/cli.rb
+++ b/lib/ruby_smb/server/cli.rb
@@ -1,0 +1,121 @@
+require 'optparse'
+
+module RubySMB
+  class Server
+    module Cli
+      DEFAULT_OPTIONS = {
+        allow_anonymous: true,
+        allow_guests: false,
+        domain: nil,
+        username: 'RubySMB',
+        password: 'password',
+        share_name: 'home',
+        smbv1: true,
+        smbv2: true,
+        smbv3: true
+      }.freeze
+
+      # Parse options from the command line. The resulting option hash is suitable for passing to {build}.
+      #
+      # @yield [options, parser] A block that can be used to update the built option parser.
+      # @yieldparam [Hash<Symbol => >] options The options hash that should be assigned to.
+      # @yieldparam [OptionParser] parser The built option parser.
+      # @param [Hash] defaults Default option values to use.
+      # @return [Hash<Symbol => >] The options hash.
+      #   * :allow_anonymous [Boolean] Whether or not to allow anonymous authentication.
+      #   * :allow_guest [Boolean] Whether or not to allow guest authentication.
+      #   * :username [String] The username of the account to add for authentication.
+      #   * :password [String] The password of the account to add for authentication.
+      #   * :domain [String] The domain of the account to add for authentication.
+      #   * :smbv1 [Boolean] Whether or not to enable SMBv1 dialects.
+      #   * :smbv2 [Boolean] Whether or not to enable SMBv2 dialects.
+      #   * :smbv3 [Boolean] Whether or not to enable SMBv3 dialects.
+      #   * :share_name [String] The name of the share to add.
+      def self.parse!(defaults: {}, &block)
+        defaults = DEFAULT_OPTIONS.merge(defaults)
+        options = defaults.clone
+        OptionParser.new do |parser|
+          parser.on("--share SHARE", "The share name (default: #{defaults[:share_name]})") do |share|
+            options[:share_name] = share
+          end
+
+          parser.on("--[no-]anonymous", "Allow anonymous access (default: #{defaults[:allow_anonymous]})") do |allow_anonymous|
+            options[:allow_anonymous] = allow_anonymous
+          end
+
+          parser.on("--[no-]guests", "Allow guest accounts (default: #{defaults[:allow_guests]})") do |allow_guests|
+            options[:allow_guests] = allow_guests
+          end
+
+          parser.on("--[no-]smbv1", "Enable or disable SMBv1 (default: #{defaults[:smbv1] ? 'Enabled' : 'Disabled'})") do |smbv1|
+            options[:smbv1] = smbv1
+          end
+
+          parser.on("--[no-]smbv2", "Enable or disable SMBv2 (default: #{defaults[:smbv2] ? 'Enabled' : 'Disabled'})") do |smbv2|
+            options[:smbv2] = smbv2
+          end
+
+          parser.on("--[no-]smbv3", "Enable or disable SMBv3 (default: #{defaults[:smbv3] ? 'Enabled' : 'Disabled'})") do |smbv3|
+            options[:smbv3] = smbv3
+          end
+
+          parser.on("--username USERNAME", "The account's username (default: #{defaults[:username]})") do |username|
+            if username.include?('\\')
+              options[:domain], options[:username] = username.split('\\', 2)
+            else
+              options[:username] = username
+            end
+          end
+
+          parser.on("--password PASSWORD", "The account's password (default: #{defaults[:password]})") do |password|
+            options[:password] = password
+          end
+
+          block.call(options, parser) if block_given?
+        end.parse!
+
+        options
+      end
+
+      # Build a server instance from the specified options. The NTLM provider will be used for authentication.
+      #
+      # @param [Hash] options the options to use while building the server. See the return value of {parse} for a
+      #   comprehensive list of keys.
+      def self.build(options)
+        ntlm_provider = RubySMB::Gss::Provider::NTLM.new(
+          allow_anonymous: options[:allow_anonymous],
+          allow_guests: options[:allow_guests]
+        )
+        ntlm_provider.put_account(options[:username], options[:password], domain: options[:domain])  # password can also be an NTLM hash
+
+        server = RubySMB::Server.new(
+          gss_provider: ntlm_provider,
+          logger: :stdout
+        )
+        server.dialects.select! { |dialect| RubySMB::Dialect[dialect].family != RubySMB::Dialect::FAMILY_SMB1 } unless options[:smbv1]
+        server.dialects.select! { |dialect| RubySMB::Dialect[dialect].family != RubySMB::Dialect::FAMILY_SMB2 } unless options[:smbv2]
+        server.dialects.select! { |dialect| RubySMB::Dialect[dialect].family != RubySMB::Dialect::FAMILY_SMB3 } unless options[:smbv3]
+
+        server
+      end
+
+      # Run the server forever. At least 1 SMB dialect must be enabled.
+      #
+      # @param [RubySMB::Server] server The server instance to run.
+      # @param [#puts] out The stream to write standard output messages to.
+      # @param [#puts] err The stream to write error messages to.
+      def self.run(server, out: $stdout, err: $stderr)
+        if server.dialects.empty?
+          err.puts 'at least one version must be enabled'
+          return
+        end
+
+        out.puts 'server is running'
+        server.run do |server_client|
+          out.puts 'received connection'
+          true
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds the `RubySMB::Server::Cli` module with the code necessary to start a server from the command line interface. It consolidates all the duplicate options in the examples and will make it easy to add and smb server tool to metasploit in the future without a ton of duplicated code.

# Testing
- [ ] Run `examples/file_server.rb` with various options and configurations, see it start and honor the settings specified on the command line
- [ ] Do the same thing for `examples/virtual_file_server.rb`
- [ ] Read the docs, make sure they make sense