### PR TITLE
Track negotiation security buffer

### DIFF
--- a/lib/ruby_smb/client.rb
+++ b/lib/ruby_smb/client.rb
@@ -295,6 +295,12 @@ module RubySMB
     #   false otherwise
     attr_accessor :server_supports_multi_credit
 
+    # The negotiated security buffer. This is nil until the negotiation process
+    # has finished.
+    # @!attribute [rw] negotiation_security_buffer
+    #   @return [String] The raw security buffer bytes
+    attr_accessor :negotiation_security_buffer
+
     # @param dispatcher [RubySMB::Dispatcher::Socket] the packet dispatcher to use
     # @param smb1 [Boolean] whether or not to enable SMB1 support
     # @param smb2 [Boolean] whether or not to enable SMB2 support

--- a/lib/ruby_smb/client/authentication.rb
+++ b/lib/ruby_smb/client/authentication.rb
@@ -146,7 +146,7 @@ module RubySMB
       end
 
       # Takes the raw binary string and returns a {RubySMB::SMB1::Packet::SessionSetupResponse}
-      def smb1_ntlmssp_final_packet(raw_response)
+      def smb1_session_setup_response(raw_response)
         packet = RubySMB::SMB1::Packet::SessionSetupResponse.read(raw_response)
 
         unless packet.valid?
@@ -157,6 +157,11 @@ module RubySMB
           )
         end
         packet
+      end
+
+      # Takes the raw binary string and returns a {RubySMB::SMB1::Packet::SessionSetupResponse}
+      def smb1_ntlmssp_final_packet(raw_response)
+        smb1_session_setup_response(raw_response)
       end
 
       # Takes the raw binary string and returns a {RubySMB::SMB1::Packet::SessionSetupResponse}
@@ -235,7 +240,7 @@ module RubySMB
       end
 
       # Takes the raw binary string and returns a {RubySMB::SMB2::Packet::SessionSetupResponse}
-      def smb2_ntlmssp_final_packet(raw_response)
+      def smb2_session_setup_response(raw_response)
         packet = RubySMB::SMB2::Packet::SessionSetupResponse.read(raw_response)
         unless packet.valid?
           raise RubySMB::Error::InvalidPacket.new(
@@ -246,6 +251,11 @@ module RubySMB
         end
 
         packet
+      end
+
+      # Takes the raw binary string and returns a {RubySMB::SMB2::Packet::SessionSetupResponse}
+      def smb2_ntlmssp_final_packet(raw_response)
+        smb2_session_setup_response(raw_response)
       end
 
       # Takes the raw binary string and returns a {RubySMB::SMB2::Packet::SessionSetupResponse}

--- a/lib/ruby_smb/client/negotiation.rb
+++ b/lib/ruby_smb/client/negotiation.rb
@@ -118,6 +118,7 @@ module RubySMB
           self.server_max_buffer_size = packet.parameter_block.max_buffer_size - 260
           self.negotiated_smb_version = 1
           self.session_encrypt_data = false
+          self.negotiation_security_buffer = packet.data_block.security_blob
           'SMB1'
         when RubySMB::SMB2::Packet::NegotiateResponse
           self.smb1 = false
@@ -137,6 +138,7 @@ module RubySMB
           self.server_start_time = packet.server_start_time.to_time if packet.server_start_time != 0
           self.server_system_time = packet.system_time.to_time if packet.system_time != 0
           self.server_supports_multi_credit = self.dialect != '0x0202' && packet&.capabilities&.large_mtu == 1
+          self.negotiation_security_buffer = packet.security_buffer
           case self.dialect
           when '0x02ff'
           when '0x0300', '0x0302'

--- a/lib/ruby_smb/error.rb
+++ b/lib/ruby_smb/error.rb
@@ -99,6 +99,10 @@ module RubySMB
     # unsupported protocol.
     class NegotiationFailure < RubySMBError; end
 
+    # Raised when Authentication fails, possibly due to an
+    # unsupported GSS mechanism type.
+    class AuthenticationFailure < RubySMBError; end
+
     # Raised when trying to parse raw binary into a BitField and the data
     # is invalid.
     class InvalidBitField < RubySMBError; end

--- a/lib/ruby_smb/gss.rb
+++ b/lib/ruby_smb/gss.rb
@@ -14,6 +14,7 @@ module RubySMB
     # @param asn The ASN object to apply the traversal path on.
     # @param [Array] path The path to traverse, each element is passed to the
     #   ASN object's #value's #[] operator.
+    # @return [OpenSSL::ASN1::Sequence, nil]
     def self.asn1dig(asn, *path)
       path.each do |part|
         return nil unless asn&.value

--- a/lib/ruby_smb/smb1/packet/session_setup_request.rb
+++ b/lib/ruby_smb/smb1/packet/session_setup_request.rb
@@ -40,6 +40,17 @@ module RubySMB
         parameter_block   :parameter_block
         data_block        :data_block
 
+        # Takes the specified security buffer string and sets it in the {RubySMB::SMB1::Packet::SessionSetupRequest::DataBlock#security_blob}
+        # field. It also automatically sets the length in
+        # {RubySMB::SMB1::Packet::SessionSetupRequest::ParameterBlock#security_blob_length}
+        #
+        # @param buffer [String] the security buffer
+        # @return [void]
+        def set_security_buffer(buffer)
+          parameter_block.security_blob_length = buffer.length
+          data_block.security_blob = buffer
+        end
+
         # Takes an NTLM Type 1 Message and creates the GSS Security Blob
         # for it and sets it in the {RubySMB::SMB1::Packet::SessionSetupRequest::DataBlock#security_blob}
         # field. It also automatically sets the length in


### PR DESCRIPTION
ruby_smb does not currently track the negotiation security buffer, which is required for validating the remote server's GSS Mech types - i.e. if it supports Kerberos/NTLMSSP auth etc.