### PR TITLE
Always track sequence counter regardless of having a session key present

### DIFF
--- a/lib/ruby_smb/client.rb
+++ b/lib/ruby_smb/client.rb
@@ -462,6 +462,7 @@ module RubySMB
         packet.smb_header.uid = self.user_id if self.user_id
         packet.smb_header.pid_low = self.pid if self.pid
         packet = smb1_sign(packet) if signing_required && !session_key.empty?
+        self.sequence_counter += 1
       when 'SMB2'
         packet = increment_smb_message_id(packet)
         packet.smb2_header.session_id = session_id
@@ -501,7 +502,7 @@ module RubySMB
         break
       end unless version == 'SMB1'
 
-      self.sequence_counter += 1 if signing_required && !session_key.empty?
+      self.sequence_counter += 1
       # update the SMB2 message ID according to the received Credit Charged
       self.smb2_message_id += smb2_header.credit_charge - 1 if smb2_header && self.server_supports_multi_credit
       raw_response

--- a/lib/ruby_smb/signing.rb
+++ b/lib/ruby_smb/signing.rb
@@ -13,7 +13,6 @@ module RubySMB
     # @return [RubySMB::GenericPacket] the signed packet
     def smb1_sign(packet)
       packet = Signing::smb1_sign(packet, @session_key, @sequence_counter)
-      @sequence_counter += 1
 
       packet
     end

--- a/spec/lib/ruby_smb/client_spec.rb
+++ b/spec/lib/ruby_smb/client_spec.rb
@@ -239,6 +239,27 @@ RSpec.describe RubySMB::Client do
     end
 
     context 'with SMB1' do
+      context 'when tracking sequence numbers' do
+        it 'increments the sequence_counter by 2 when successfully sending and receiving a message' do
+          expect { smb1_client.send_recv(smb1_request) }.to change { smb1_client.sequence_counter }.from(0).to(2)
+        end
+
+        it 'increments the sequence_counter by 1 when waiting for the server response' do
+          expect(smb1_client).to receive(:recv_packet)
+          allow(smb1_client).to receive(:recv_packet) do |*args, **kwargs|
+            expect(smb1_client.sequence_counter).to eq(1)
+          end
+          smb1_client.send_recv(smb1_request)
+        end
+
+        it 'does not increment the sequence_counter again if there is a communication error with the server' do
+          expect do
+            allow(smb1_client).to receive(:recv_packet).and_raise RubySMB::Error::CommunicationError
+            smb1_client.send_recv(smb1_request) rescue RubySMB::Error::CommunicationError
+          end.to change { smb1_client.sequence_counter }.from(0).to(1)
+        end
+      end
+
       it 'does not check if it is a STATUS_PENDING response' do
         expect(smb1_client).to_not receive(:is_status_pending?)
         smb1_client.send_recv(smb1_request)


### PR DESCRIPTION
According to the SMB specification, the signing example shows that we should always increment the sequence counter when interacting with the server - regardless of having a session_key present just yet:

https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-smb/8b80e60b-7514-442b-baf4-eb785d0b0e2c

> 3. The client builds an [SMB_COM_SESSION_SETUP_ANDX request](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-smb/a00d0361-3544-4845-96ab-309b4bb7705d) SMB and sends it to the server.
> ...
> At this stage, the SessionKey is not yet available.
> ...
> After the packet is sent by the client, the sequence number is incremented to 1, which is the expected sequence number for the response packet from the server.
> 
> https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-smb/8b80e60b-7514-442b-baf4-eb785d0b0e2c#:~:text=The%20client%20builds%20an%20SMB_COM_SESSION_SETUP_ANDX%20request%20SMB%20and%20sends%20it%20to%20the%20server.