### PR TITLE
Add more MS-SAMR definitions and functions

### DIFF
--- a/lib/ruby_smb/client.rb
+++ b/lib/ruby_smb/client.rb
@@ -54,6 +54,8 @@ module RubySMB
     # The default maximum size of a SMB message that the Server accepts (in bytes)
     SERVER_MAX_BUFFER_SIZE = 4356
 
+    attr_accessor :application_key
+
     # The dispatcher responsible for sending packets
     # @!attribute [rw] dispatcher
     #   @return [RubySMB::Dispatcher::Socket]
@@ -288,7 +290,7 @@ module RubySMB
     attr_accessor :negotiated_smb_version
 
     # Whether or not the server supports multi-credit operations. It is
-    # reported by the LARGE_MTU capabiliy as part of the negotiation process
+    # reported by the LARGE_MTU capability as part of the negotiation process
     # (SMB 2.x and 3.x).
     # @!attribute [rw] server_supports_multi_credit
     #   @return [Boolean] true if the server supports multi-credit operations,
@@ -313,6 +315,7 @@ module RubySMB
       @sequence_counter  = 0
       @session_id        = 0x00
       @session_key       = ''
+      @application_key   = ''
       @session_is_guest  = false
       @signing_required  = false
       @smb1              = smb1
@@ -617,6 +620,7 @@ module RubySMB
     def wipe_state!
       self.session_id       = 0x00
       self.user_id          = 0x00
+      self.application_key  = ''
       self.session_key      = ''
       self.session_is_guest = false
       self.sequence_counter = 0

--- a/lib/ruby_smb/client/authentication.rb
+++ b/lib/ruby_smb/client/authentication.rb
@@ -222,6 +222,21 @@ module RubySMB
             # disable encryption when necessary
             @session_encrypt_data = false
           end
+
+          # see: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/7fd079ca-17e6-4f02-8449-46b606ea289c
+          if @dialect == '0x0300' || @dialect == '0x0302'
+            @application_key = RubySMB::Crypto::KDF.counter_mode(
+              @session_key,
+              "SMB2APP\x00",
+              "SmbRpc\x00"
+            )
+          else
+            @application_key = RubySMB::Crypto::KDF.counter_mode(
+              @session_key,
+              "SMBAppKey\x00",
+              @preauth_integrity_hash_value
+            )
+          end
           # otherwise, leave encryption to the default value that it was initialized to
         end
         ######

--- a/lib/ruby_smb/dcerpc/ndr.rb
+++ b/lib/ruby_smb/dcerpc/ndr.rb
@@ -652,7 +652,7 @@ module RubySMB::Dcerpc::Ndr
     include ConstructedTypePlugin
 
     def should_process_max_count?
-      # According to the NDR defintion for Structures Containing a Conformant
+      # According to the NDR definition for Structures Containing a Conformant
       # Array:
       #
       # "In the NDR representation of a structure that contains a
@@ -763,13 +763,13 @@ module RubySMB::Dcerpc::Ndr
         return (4 - (rel_offset % 4)) % 4
       end
       if obj.is_a?(ConfPlugin)
-        # `max_count` should have been handled at the begining of the structure
+        # `max_count` should have been handled at the beginning of the structure
         # already. We need to fix `rel_offset` since it includes the
         # `max_count` 4 bytes, plus the possible padding bytes needed to align
         # the structure. This is required because BinData Struct is not
-        # aware of `max_count` and considere the first field to be the begining
+        # aware of `max_count` and consider the first field to be the beginning
         # of the structure instead. We have to make sure the alignment is
-        # calculated from the begining of the structure.
+        # calculated from the beginning of the structure.
         align = eval_parameter(:byte_align)
         pad_length = (align - (4 % align)) % align
         rel_offset += (4 + pad_length)
@@ -778,7 +778,7 @@ module RubySMB::Dcerpc::Ndr
         # (not Varying). The size information (max_count) has been place in
         # from of the structure and no other size information is present before
         # the actual elements of the array. Therefore, the alignment must be
-        # done accroding to th rules of the elements. Since a NdrArray has its
+        # done according to the rules of the elements. Since a NdrArray has its
         # default :byte_align value set to 4 (:max_count size), we have to make
         # sure the element size is used instead.
         unless obj.is_a?(VarPlugin)
@@ -839,6 +839,10 @@ module RubySMB::Dcerpc::Ndr
       extend StructPlugin
     end
   end
+
+  #
+  # [Unions](https://pubs.opengroup.org/onlinepubs/9629399/chap14.htm#tagcjh_19_03_08)
+  #
 
   # TODO: Unions
   # TODO: Pipes

--- a/lib/ruby_smb/dcerpc/ndr.rb
+++ b/lib/ruby_smb/dcerpc/ndr.rb
@@ -312,29 +312,31 @@ module RubySMB::Dcerpc::Ndr
     def initialize_instance
       @read_until_index = 0
       @max_count = 0
+      @max_count_set = false
       super
     end
 
     def insert(index, *objs)
       obj = super
-      @max_count = length
+      @max_count = length unless @max_count_set
       obj
     end
 
     def slice_index(index)
       obj = super
-      @max_count = length
+      @max_count = length unless @max_count_set
       obj
     end
 
     def []=(index, value)
       obj = super
-      @max_count = length
+      @max_count = length unless @max_count_set
       obj
     end
 
     def set_max_count(val)
       @max_count = @read_until_index = val
+      @max_count_set = true
     end
   end
 

--- a/lib/ruby_smb/dcerpc/ndr.rb
+++ b/lib/ruby_smb/dcerpc/ndr.rb
@@ -1213,6 +1213,11 @@ module RubySMB::Dcerpc::Ndr
     extend PointerClassPlugin
   end
 
+  class NdrUint16ArrayPtr < NdrConfVarArray
+    default_parameters type: :ndr_uint16
+    extend PointerClassPlugin
+  end
+
   class NdrFileTimePtr < NdrFileTime
     extend PointerClassPlugin
   end

--- a/lib/ruby_smb/dcerpc/request.rb
+++ b/lib/ruby_smb/dcerpc/request.rb
@@ -72,6 +72,7 @@ module RubySMB
           samr_enumerate_domains_in_sam_server_request Samr::SAMR_ENUMERATE_DOMAINS_IN_SAM_SERVER
           samr_lookup_names_in_domain_request          Samr::SAMR_LOOKUP_NAMES_IN_DOMAIN
           samr_create_user2_in_domain_request          Samr::SAMR_CREATE_USER2_IN_DOMAIN
+          samr_set_information_user2_request           Samr::SAMR_SET_INFORMATION_USER2
           string                                       :default
         end
         choice 'Wkssvc', selection: -> { opnum } do

--- a/lib/ruby_smb/dcerpc/request.rb
+++ b/lib/ruby_smb/dcerpc/request.rb
@@ -70,6 +70,7 @@ module RubySMB
           samr_open_user_request                       Samr::SAMR_OPEN_USER
           samr_get_groups_for_user_request             Samr::SAMR_GET_GROUPS_FOR_USER
           samr_enumerate_domains_in_sam_server_request Samr::SAMR_ENUMERATE_DOMAINS_IN_SAM_SERVER
+          samr_lookup_names_in_domain_request          Samr::SAMR_LOOKUP_NAMES_IN_DOMAIN
           string                                       :default
         end
         choice 'Wkssvc', selection: -> { opnum } do

--- a/lib/ruby_smb/dcerpc/request.rb
+++ b/lib/ruby_smb/dcerpc/request.rb
@@ -73,6 +73,7 @@ module RubySMB
           samr_lookup_names_in_domain_request          Samr::SAMR_LOOKUP_NAMES_IN_DOMAIN
           samr_create_user2_in_domain_request          Samr::SAMR_CREATE_USER2_IN_DOMAIN
           samr_set_information_user2_request           Samr::SAMR_SET_INFORMATION_USER2
+          samr_delete_user_request                     Samr::SAMR_DELETE_USER
           string                                       :default
         end
         choice 'Wkssvc', selection: -> { opnum } do

--- a/lib/ruby_smb/dcerpc/request.rb
+++ b/lib/ruby_smb/dcerpc/request.rb
@@ -60,16 +60,17 @@ module RubySMB
           string                          :default
         end
         choice 'Samr', selection: -> { opnum } do
-          samr_connect_request                     Samr::SAMR_CONNECT
-          samr_lookup_domain_in_sam_server_request Samr::SAMR_LOOKUP_DOMAIN_IN_SAM_SERVER
-          samr_open_domain_request                 Samr::SAMR_OPEN_DOMAIN
-          samr_enumerate_users_in_domain_request   Samr::SAMR_ENUMERATE_USERS_IN_DOMAIN
-          samr_rid_to_sid_request                  Samr::SAMR_RID_TO_SID
-          samr_close_handle_request                Samr::SAMR_CLOSE_HANDLE
-          samr_get_alias_membership_request        Samr::SAMR_GET_ALIAS_MEMBERSHIP
-          samr_open_user_request                   Samr::SAMR_OPEN_USER
-          samr_get_groups_for_user_request         Samr::SAMR_GET_GROUPS_FOR_USER
-          string                                   :default
+          samr_connect_request                         Samr::SAMR_CONNECT
+          samr_lookup_domain_in_sam_server_request     Samr::SAMR_LOOKUP_DOMAIN_IN_SAM_SERVER
+          samr_open_domain_request                     Samr::SAMR_OPEN_DOMAIN
+          samr_enumerate_users_in_domain_request       Samr::SAMR_ENUMERATE_USERS_IN_DOMAIN
+          samr_rid_to_sid_request                      Samr::SAMR_RID_TO_SID
+          samr_close_handle_request                    Samr::SAMR_CLOSE_HANDLE
+          samr_get_alias_membership_request            Samr::SAMR_GET_ALIAS_MEMBERSHIP
+          samr_open_user_request                       Samr::SAMR_OPEN_USER
+          samr_get_groups_for_user_request             Samr::SAMR_GET_GROUPS_FOR_USER
+          samr_enumerate_domains_in_sam_server_request Samr::SAMR_ENUMERATE_DOMAINS_IN_SAM_SERVER
+          string                                       :default
         end
         choice 'Wkssvc', selection: -> { opnum } do
           netr_wksta_get_info_request Wkssvc::NETR_WKSTA_GET_INFO

--- a/lib/ruby_smb/dcerpc/request.rb
+++ b/lib/ruby_smb/dcerpc/request.rb
@@ -71,6 +71,7 @@ module RubySMB
           samr_get_groups_for_user_request             Samr::SAMR_GET_GROUPS_FOR_USER
           samr_enumerate_domains_in_sam_server_request Samr::SAMR_ENUMERATE_DOMAINS_IN_SAM_SERVER
           samr_lookup_names_in_domain_request          Samr::SAMR_LOOKUP_NAMES_IN_DOMAIN
+          samr_create_user2_in_domain_request          Samr::SAMR_CREATE_USER2_IN_DOMAIN
           string                                       :default
         end
         choice 'Wkssvc', selection: -> { opnum } do

--- a/lib/ruby_smb/dcerpc/rrp_rpc_unicode_string.rb
+++ b/lib/ruby_smb/dcerpc/rrp_rpc_unicode_string.rb
@@ -109,6 +109,11 @@ module RubySMB
       end
     end
 
+    class RpcUnicodeStringConfVarArray < Ndr::NdrConfVarArray
+      extend Ndr::ArrayClassPlugin
+      default_parameters type: :rpc_unicode_string
+    end
+
     # A pointer to a RPC_UNICODE_STRING structure
     class PrpcUnicodeString < RpcUnicodeString
       extend Ndr::PointerClassPlugin

--- a/lib/ruby_smb/dcerpc/samr.rb
+++ b/lib/ruby_smb/dcerpc/samr.rb
@@ -303,7 +303,7 @@ module RubySMB
       class SamprUlongArray < Ndr::NdrStruct
         default_parameter byte_align: 4
 
-        ndr_uint32   :elem_count, initial_value: -> { elements.size }
+        ndr_uint32   :element_count, initial_value: -> { elements.size }
         pulong_array :elements
       end
 
@@ -901,7 +901,7 @@ module RubySMB
             "Error returned while getting alias membership: "\
             "#{WindowsError::NTStatus.find_by_retval(samr_get_alias_membership_reponse.error_status.value).join(',')}"
         end
-        return [] if samr_get_alias_membership_reponse.membership.elem_count == 0
+        return [] if samr_get_alias_membership_reponse.membership.element_count == 0
         samr_get_alias_membership_reponse.membership.elements.to_ary
       end
 

--- a/lib/ruby_smb/dcerpc/samr.rb
+++ b/lib/ruby_smb/dcerpc/samr.rb
@@ -68,6 +68,80 @@ module RubySMB
         pulong_array :elements
       end
 
+      # [2.2.2.4 RPC_SHORT_BLOB](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/77dbfdbb-6627-4871-ab12-5333929347dc)
+      class RpcShortBlob < BinData::Record
+        ndr_uint16           :buffer_length, initial_value: -> { buffer.length }
+        ndr_uint16           :max_length, initial_value: -> { buffer.length }
+        ndr_uint16_array_ptr :buffer
+      end
+
+      # [2.2.6.22 SAMPR_ENCRYPTED_USER_PASSWORD_NEW](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/112ecc94-1cbe-41cd-b669-377402c20786)
+      class SamprEncryptedUserPasswordNew < BinData::Record
+        ndr_fixed_byte_array :buffer, initial_length: 532
+      end
+
+      # [2.2.6.5 SAMPR_LOGON_HOURS](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/d83c356b-7dda-4096-8270-5c581f84a4d9)
+      class SamprLogonHours < BinData::Record
+        ndr_uint32         :units_per_week
+        ndr_byte_array_ptr :logon_hours
+      end
+
+      # [2.2.7.11 SAMPR_SR_SECURITY_DESCRIPTOR](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/675e37d9-bb97-4f14-bba2-be081c87cd5d)
+      class SamprSrSecurityDescriptor < BinData::Record
+        ndr_uint32         :buffer_length, initial_value: -> { buffer.length }
+        ndr_byte_array_ptr :buffer
+      end
+
+      # [2.2.6.6 SAMPR_USER_ALL_INFORMATION](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/dc966b81-da27-4dae-a28c-ec16534f1cb9)
+      class SamprUserAllInformation < BinData::Record
+        ndr_uint64                   :last_logon
+        ndr_uint64                   :last_logoff
+        ndr_uint64                   :password_last_set
+        ndr_uint64                   :account_expires
+        ndr_uint64                   :password_can_change
+        ndr_uint64                   :password_must_change
+        rpc_unicode_string           :user_name
+        rpc_unicode_string           :full_name
+        rpc_unicode_string           :home_directory
+        rpc_unicode_string           :home_directory_drive
+        rpc_unicode_string           :script_path
+        rpc_unicode_string           :profile_path
+        rpc_unicode_string           :admin_comment
+        rpc_unicode_string           :work_stations
+        rpc_unicode_string           :user_comment
+        rpc_unicode_string           :parameters
+        rpc_short_blob               :lm_owf_password
+        rpc_short_blob               :nt_owf_password
+        rpc_unicode_string           :private_data
+        sampr_sr_security_descriptor :security_descriptor
+        ndr_uint32                   :user_id
+        ndr_uint32                   :primary_group_id
+        ndr_uint32                   :user_account_control
+        ndr_uint32                   :which_fields
+        sampr_logon_hours            :logon_hours
+        ndr_uint16                   :bad_password_count
+        ndr_uint16                   :logon_count
+        ndr_uint16                   :country_code
+        ndr_uint16                   :code_page
+        ndr_uint8                    :lm_password_present
+        ndr_uint8                    :nt_password_present
+        ndr_uint8                    :password_expired
+        ndr_uint8                    :private_data_sensitive
+      end
+
+      class SamprUserInternal4InformationNew < BinData::Record
+        sampr_user_all_information        :i1
+        sampr_encrypted_user_password_new :user_password
+      end
+
+      # [2.2.6.29 SAMPR_USER_INFO_BUFFER](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/9496c26e-490b-4e76-827f-2695fc216f35)
+      class SamprUserInfoBuffer < BinData::Record
+        ndr_uint16 :tag
+        choice     :member, selection: :tag do
+          sampr_user_internal4_information_new USER_INTERNAL4_INFORMATION_NEW
+        end
+      end
+
       # [2.2.10.2 USER_PROPERTY](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/7c0f2eca-1783-450b-b5a0-754cf11f22c9)
       class UserProperty < BinData::Record
         endian   :little
@@ -252,6 +326,33 @@ module RubySMB
       USER_ALL_PASSWORDEXPIRED     = 0x08000000
       USER_ALL_SECURITYDESCRIPTOR  = 0x10000000
       USER_ALL_UNDEFINED_MASK      = 0xC0000000
+
+      # [2.2.6.28 USER_INFORMATION_CLASS Values](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/6b0dff90-5ac0-429a-93aa-150334adabf6)
+      USER_GENERAL_INFORMATION       = 1
+      USER_PREFERENCES_INFORMATION   = 2
+      USER_LOGON_INFORMATION         = 3
+      USER_LOGON_HOURS_INFORMATION   = 4
+      USER_ACCOUNT_INFORMATION       = 5
+      USER_NAME_INFORMATION          = 6
+      USER_ACCOUNT_NAME_INFORMATION  = 7
+      USER_FULL_NAME_INFORMATION     = 8
+      USER_PRIMARY_GROUP_INFORMATION = 9
+      USER_HOME_INFORMATION          = 10
+      USER_SCRIPT_INFORMATION        = 11
+      USER_PROFILE_INFORMATION       = 12
+      USER_ADMIN_COMMENT_INFORMATION = 13
+      USER_WORK_STATIONS_INFORMATION = 14
+      USER_CONTROL_INFORMATION       = 16
+      USER_EXPIRES_INFORMATION       = 17
+      USER_INTERNAL1_INFORMATION     = 18
+      USER_PARAMETERS_INFORMATION    = 20
+      USER_ALL_INFORMATION           = 21
+      USER_INTERNAL4_INFORMATION     = 23
+      USER_INTERNAL5_INFORMATION     = 24
+      USER_INTERNAL4_INFORMATION_NEW = 25
+      USER_INTERNAL5_INFORMATION_NEW = 26
+      USER_INTERNAL7_INFORMATION     = 31
+      USER_INTERNAL8_INFORMATION     = 32
 
       # [2.2.1.9 ACCOUNT_TYPE Values](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/e742be45-665d-4576-b872-0bc99d1e1fbe)
       SAM_DOMAIN_OBJECT             = 0x00000000

--- a/lib/ruby_smb/dcerpc/samr.rb
+++ b/lib/ruby_smb/dcerpc/samr.rb
@@ -453,6 +453,17 @@ module RubySMB
         samr_open_domain_response.domain_handle
       end
 
+      # Enumerates all domains on the remote server.
+      #
+      # @param server_handle [RubySMB::Dcerpc::Samr::SamprHandle] RPC context
+      #   handle representing the server object
+      # @param enumeration_context [Integer] a cookie used by the server to
+      #   resume an enumeration
+      # @return [Array<String>] an array containing the domain names
+      # @raise [RubySMB::Dcerpc::Error::InvalidPacket] if the response is not a
+      #   SamrEnumerateDomainsInSamServerResponse packet
+      # @raise [RubySMB::Dcerpc::Error::SamrError] if the response error status
+      #   is not STATUS_SUCCESS
       def samr_enumerate_domains_in_sam_server(server_handle:, enumeration_context: 0)
         samr_enum_domains_request = SamrEnumerateDomainsInSamServerRequest.new(
           server_handle: server_handle,
@@ -487,7 +498,11 @@ module RubySMB
       #
       # @param domain_handle [RubySMB::Dcerpc::Samr::SamprHandle] RPC context
       #   handle representing the domain object
-      # @return [Hash] hash mapping RID and username
+      # @param enumeration_context [Integer] a cookie used by the server to
+      #   resume an enumeration
+      # @param user_account_control [Integer] a value to use for filtering on
+      #   the userAccountControl attribute
+      # @return [Hash<Integer, String>] hash mapping RID and username
       # @raise [RubySMB::Dcerpc::Error::InvalidPacket] if the response is not a
       #   SamrEnumerateUsersInDomainResponse packet
       # @raise [RubySMB::Dcerpc::Error::SamrError] if the response error status

--- a/lib/ruby_smb/dcerpc/samr.rb
+++ b/lib/ruby_smb/dcerpc/samr.rb
@@ -606,7 +606,7 @@ module RubySMB
       #   handle representing the domain object
       # @param name [Array<String>] An array of string account names to
       #   translate to RIDs.
-      # @return [Hash<String, Hash<Symbol, Integer>, Nil] Returns a hash mapping
+      # @return [Hash<String, Hash<Symbol, Integer>>, Nil] Returns a hash mapping
       #   the requested names to their information. Nil is returned if one or
       #   more names could not be found.
       # @raise [RubySMB::Dcerpc::Error::SamrError] if the response error status

--- a/lib/ruby_smb/dcerpc/samr.rb
+++ b/lib/ruby_smb/dcerpc/samr.rb
@@ -6,6 +6,10 @@ module RubySMB
       VER_MAJOR = 1
       VER_MINOR = 0
 
+      #################################
+      #           Constants           #
+      #################################
+
       # Operation numbers
       SAMR_CONNECT                         = 0x0000
       SAMR_CLOSE_HANDLE                    = 0x0001
@@ -22,198 +26,6 @@ module RubySMB
       SAMR_SET_INFORMATION_USER2           = 0x003a
       SAMR_CONNECT5                        = 0x0040
       SAMR_RID_TO_SID                      = 0x0041
-
-      # [2.2.3.9 SAMPR_RID_ENUMERATION](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/5c94a35a-e7f2-4675-af34-741f5a8ee1a2)
-      class SamprRidEnumeration < Ndr::NdrStruct
-        default_parameters byte_align: 4
-        endian :little
-
-        ndr_uint32         :relative_id
-        rpc_unicode_string :name
-      end
-
-      class SamprRidEnumerationArray < Ndr::NdrConfArray
-        default_parameter type: :sampr_rid_enumeration
-      end
-
-      class PsamprRidEnumerationArray < SamprRidEnumerationArray
-        extend Ndr::PointerClassPlugin
-      end
-
-      # [2.2.3.10 SAMPR_ENUMERATION_BUFFER](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/c53161a4-38e8-4a28-a33e-0d378fce03dd)
-      class SamprEnumerationBuffer < Ndr::NdrStruct
-        default_parameters byte_align: 4
-        endian :little
-
-        ndr_uint32                   :entries_read
-        psampr_rid_enumeration_array :buffer
-      end
-
-      class PsamprEnumerationBuffer < SamprEnumerationBuffer
-        extend Ndr::PointerClassPlugin
-      end
-
-      class SamprHandle < Ndr::NdrContextHandle; end
-
-      class PulongArray < Ndr::NdrConfArray
-        default_parameter type: :ndr_uint32
-        extend Ndr::PointerClassPlugin
-      end
-
-      # [2.2.7.4 SAMPR_ULONG_ARRAY](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/2feb3806-4db2-45b7-90d2-86c8336a31ba)
-      class SamprUlongArray < Ndr::NdrStruct
-        default_parameter byte_align: 4
-
-        ndr_uint32   :elem_count, initial_value: -> { elements.size }
-        pulong_array :elements
-      end
-
-      # [2.2.2.4 RPC_SHORT_BLOB](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/77dbfdbb-6627-4871-ab12-5333929347dc)
-      class RpcShortBlob < BinData::Record
-        ndr_uint16           :buffer_length, initial_value: -> { buffer.length }
-        ndr_uint16           :max_length, initial_value: -> { buffer.length }
-        ndr_uint16_array_ptr :buffer
-      end
-
-      # [2.2.6.22 SAMPR_ENCRYPTED_USER_PASSWORD_NEW](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/112ecc94-1cbe-41cd-b669-377402c20786)
-      class SamprEncryptedUserPasswordNew < BinData::Record
-        ndr_fixed_byte_array :buffer, initial_length: 532
-      end
-
-      # [2.2.6.5 SAMPR_LOGON_HOURS](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/d83c356b-7dda-4096-8270-5c581f84a4d9)
-      class SamprLogonHours < BinData::Record
-        ndr_uint32         :units_per_week
-        ndr_byte_array_ptr :logon_hours
-      end
-
-      # [2.2.7.11 SAMPR_SR_SECURITY_DESCRIPTOR](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/675e37d9-bb97-4f14-bba2-be081c87cd5d)
-      class SamprSrSecurityDescriptor < BinData::Record
-        ndr_uint32         :buffer_length, initial_value: -> { buffer.length }
-        ndr_byte_array_ptr :buffer
-      end
-
-      # [2.2.6.6 SAMPR_USER_ALL_INFORMATION](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/dc966b81-da27-4dae-a28c-ec16534f1cb9)
-      class SamprUserAllInformation < BinData::Record
-        ndr_uint64                   :last_logon
-        ndr_uint64                   :last_logoff
-        ndr_uint64                   :password_last_set
-        ndr_uint64                   :account_expires
-        ndr_uint64                   :password_can_change
-        ndr_uint64                   :password_must_change
-        rpc_unicode_string           :user_name
-        rpc_unicode_string           :full_name
-        rpc_unicode_string           :home_directory
-        rpc_unicode_string           :home_directory_drive
-        rpc_unicode_string           :script_path
-        rpc_unicode_string           :profile_path
-        rpc_unicode_string           :admin_comment
-        rpc_unicode_string           :work_stations
-        rpc_unicode_string           :user_comment
-        rpc_unicode_string           :parameters
-        rpc_short_blob               :lm_owf_password
-        rpc_short_blob               :nt_owf_password
-        rpc_unicode_string           :private_data
-        sampr_sr_security_descriptor :security_descriptor
-        ndr_uint32                   :user_id
-        ndr_uint32                   :primary_group_id
-        ndr_uint32                   :user_account_control
-        ndr_uint32                   :which_fields
-        sampr_logon_hours            :logon_hours
-        ndr_uint16                   :bad_password_count
-        ndr_uint16                   :logon_count
-        ndr_uint16                   :country_code
-        ndr_uint16                   :code_page
-        ndr_uint8                    :lm_password_present
-        ndr_uint8                    :nt_password_present
-        ndr_uint8                    :password_expired
-        ndr_uint8                    :private_data_sensitive
-      end
-
-      class SamprUserInternal4InformationNew < BinData::Record
-        sampr_user_all_information        :i1
-        sampr_encrypted_user_password_new :user_password
-      end
-
-      # [2.2.6.29 SAMPR_USER_INFO_BUFFER](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/9496c26e-490b-4e76-827f-2695fc216f35)
-      class SamprUserInfoBuffer < BinData::Record
-        ndr_uint16 :tag
-        choice     :member, selection: :tag do
-          sampr_user_internal4_information_new USER_INTERNAL4_INFORMATION_NEW
-        end
-      end
-
-      # [2.2.10.2 USER_PROPERTY](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/7c0f2eca-1783-450b-b5a0-754cf11f22c9)
-      class UserProperty < BinData::Record
-        endian   :little
-
-        uint16   :name_length, initial_value: -> { property_name.num_bytes }
-        uint16   :value_length, initial_value: -> { property_value.num_bytes }
-        uint16   :reserved
-        string16 :property_name, read_length: :name_length
-        string   :property_value, read_length: :value_length
-      end
-
-      # [2.2.10.1 USER_PROPERTIES](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/8263e7ab-aba9-43d2-8a36-3a9cb2dd3dad)
-      class UserProperties < BinData::Record
-        endian :little
-
-        uint32 :reserved1
-        uint32 :struct_length, initial_value: -> { num_bytes - 12 }
-        uint16 :reserved2
-        uint16 :reserved3
-        string :reserved4, length: 96
-        uint16 :property_signature, initial_value: 0x50
-        uint16 :property_count, initial_value: -> { user_properties.size }
-        array  :user_properties, type: :user_property, initial_length: :property_count
-        uint8  :reserved5
-      end
-
-      class KerbKeyDataNew < BinData::Record
-        endian :little
-
-        uint16 :reserved1
-        uint16 :reserved2
-        uint32 :reserved3
-        uint32 :iteration_count
-        uint32 :key_type
-        uint32 :key_length
-        uint32 :key_offset
-      end
-
-      # [2.2.10.6 Primary:Kerberos-Newer-Keys - KERB_STORED_CREDENTIAL_NEW](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/08cb3ca7-954b-45e3-902e-77512fe3ba8e)
-      class KerbStoredCredentialNew < BinData::Record
-        endian :little
-
-        uint16 :revision
-        uint16 :flags
-        uint16 :credential_count
-        uint16 :service_credential_count
-        uint16 :old_credential_count
-        uint16 :older_credential_count
-        uint16 :default_salt_length
-        uint16 :default_salt_maximum_length
-        uint32 :default_salt_offset
-        uint32 :default_iteration_count
-        array  :credentials, type: :kerb_key_data_new, initial_length: :credential_count
-        array  :service_credentials, type: :kerb_key_data_new, initial_length: :service_credential_count
-        array  :old_credentials, type: :kerb_key_data_new, initial_length: :old_credential_count
-        array  :older_credentials, type: :kerb_key_data_new, initial_length: :older_credential_count
-        string :default_salt, read_length: -> { credentials.map { |e| e.key_offset }.min - @obj.abs_offset }
-        string :key_values, read_length: -> { credentials.map { |e| e.key_length }.sum }
-
-        def get_key_values
-          credentials.map do |credential|
-            offset = credential.key_offset - key_values.abs_offset
-            key_values[offset, credential.key_length]
-          end
-        end
-      end
-
-
-      #################################
-      #           Constants           #
-      #################################
-
 
       ################
       # ACCESS_MASK Values
@@ -450,6 +262,213 @@ module RubySMB
         0xffffff74 => 'rc4_hmac'
       }
 
+      # [2.2.3.9 SAMPR_RID_ENUMERATION](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/5c94a35a-e7f2-4675-af34-741f5a8ee1a2)
+      class SamprRidEnumeration < Ndr::NdrStruct
+        default_parameters byte_align: 4
+        endian :little
+
+        ndr_uint32         :relative_id
+        rpc_unicode_string :name
+      end
+
+      class SamprRidEnumerationArray < Ndr::NdrConfArray
+        default_parameter type: :sampr_rid_enumeration
+      end
+
+      class PsamprRidEnumerationArray < SamprRidEnumerationArray
+        extend Ndr::PointerClassPlugin
+      end
+
+      # [2.2.3.10 SAMPR_ENUMERATION_BUFFER](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/c53161a4-38e8-4a28-a33e-0d378fce03dd)
+      class SamprEnumerationBuffer < Ndr::NdrStruct
+        default_parameters byte_align: 4
+        endian :little
+
+        ndr_uint32                   :entries_read
+        psampr_rid_enumeration_array :buffer
+      end
+
+      class PsamprEnumerationBuffer < SamprEnumerationBuffer
+        extend Ndr::PointerClassPlugin
+      end
+
+      class SamprHandle < Ndr::NdrContextHandle; end
+
+      class PulongArray < Ndr::NdrConfArray
+        default_parameter type: :ndr_uint32
+        extend Ndr::PointerClassPlugin
+      end
+
+      # [2.2.7.4 SAMPR_ULONG_ARRAY](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/2feb3806-4db2-45b7-90d2-86c8336a31ba)
+      class SamprUlongArray < Ndr::NdrStruct
+        default_parameter byte_align: 4
+
+        ndr_uint32   :elem_count, initial_value: -> { elements.size }
+        pulong_array :elements
+      end
+
+      # [2.2.2.4 RPC_SHORT_BLOB](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/77dbfdbb-6627-4871-ab12-5333929347dc)
+      class RpcShortBlob < BinData::Record
+        ndr_uint16           :buffer_length, initial_value: -> { buffer.length }
+        ndr_uint16           :max_length, initial_value: -> { buffer.length }
+        ndr_uint16_array_ptr :buffer
+      end
+
+      # [2.2.6.22 SAMPR_ENCRYPTED_USER_PASSWORD_NEW](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/112ecc94-1cbe-41cd-b669-377402c20786)
+      class SamprEncryptedUserPasswordNew < BinData::Record
+        ndr_fixed_byte_array :buffer, initial_length: 532
+
+        def self.encrypt_password(password, key)
+          # see: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/5fe3c4c4-e71b-440d-b2fd-8448bfaf6e04
+          password = password.encode('UTF-16LE').force_encoding('ASCII-8bit')
+          buffer = password.rjust(512, "\x00") + [ password.length ].pack('V')
+          salt = SecureRandom.random_bytes(16)
+          key = OpenSSL::Digest::MD5.new(salt + key).digest
+          cipher = OpenSSL::Cipher.new('RC4').tap do |cipher|
+            cipher.encrypt
+            cipher.key = key
+          end
+          cipher.update(buffer) + salt
+        end
+      end
+
+      # [2.2.6.5 SAMPR_LOGON_HOURS](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/d83c356b-7dda-4096-8270-5c581f84a4d9)
+      class SamprLogonHours < BinData::Record
+        ndr_uint32         :units_per_week
+        ndr_byte_array_ptr :logon_hours
+      end
+
+      # [2.2.7.11 SAMPR_SR_SECURITY_DESCRIPTOR](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/675e37d9-bb97-4f14-bba2-be081c87cd5d)
+      class SamprSrSecurityDescriptor < BinData::Record
+        ndr_uint32         :buffer_length, initial_value: -> { buffer.length }
+        ndr_byte_array_ptr :buffer
+      end
+
+      # [2.2.6.6 SAMPR_USER_ALL_INFORMATION](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/dc966b81-da27-4dae-a28c-ec16534f1cb9)
+      class SamprUserAllInformation < BinData::Record
+        ndr_uint64                   :last_logon
+        ndr_uint64                   :last_logoff
+        ndr_uint64                   :password_last_set
+        ndr_uint64                   :account_expires
+        ndr_uint64                   :password_can_change
+        ndr_uint64                   :password_must_change
+        rpc_unicode_string           :user_name
+        rpc_unicode_string           :full_name
+        rpc_unicode_string           :home_directory
+        rpc_unicode_string           :home_directory_drive
+        rpc_unicode_string           :script_path
+        rpc_unicode_string           :profile_path
+        rpc_unicode_string           :admin_comment
+        rpc_unicode_string           :work_stations
+        rpc_unicode_string           :user_comment
+        rpc_unicode_string           :parameters
+        rpc_short_blob               :lm_owf_password
+        rpc_short_blob               :nt_owf_password
+        rpc_unicode_string           :private_data
+        sampr_sr_security_descriptor :security_descriptor
+        ndr_uint32                   :user_id
+        ndr_uint32                   :primary_group_id
+        ndr_uint32                   :user_account_control
+        ndr_uint32                   :which_fields
+        sampr_logon_hours            :logon_hours
+        ndr_uint16                   :bad_password_count
+        ndr_uint16                   :logon_count
+        ndr_uint16                   :country_code
+        ndr_uint16                   :code_page
+        ndr_uint8                    :lm_password_present
+        ndr_uint8                    :nt_password_present
+        ndr_uint8                    :password_expired
+        ndr_uint8                    :private_data_sensitive
+      end
+
+      class SamprUserInternal4InformationNew < BinData::Record
+        sampr_user_all_information        :i1
+        sampr_encrypted_user_password_new :user_password
+      end
+
+      # [2.2.6.3 USER_CONTROL_INFORMATION](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/eb5f1508-ede1-4ff1-be82-55f3e2ef1633)
+      class UserControlInformation < BinData::Record
+        endian     :little
+
+        ndr_uint32 :user_account_control
+      end
+
+      # [2.2.6.29 SAMPR_USER_INFO_BUFFER](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/9496c26e-490b-4e76-827f-2695fc216f35)
+      class SamprUserInfoBuffer < BinData::Record
+        ndr_uint16 :tag
+        choice     :member, selection: :tag do
+          user_control_information             USER_CONTROL_INFORMATION
+          sampr_user_internal4_information_new USER_INTERNAL4_INFORMATION_NEW
+        end
+      end
+
+      # [2.2.10.2 USER_PROPERTY](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/7c0f2eca-1783-450b-b5a0-754cf11f22c9)
+      class UserProperty < BinData::Record
+        endian   :little
+
+        uint16   :name_length, initial_value: -> { property_name.num_bytes }
+        uint16   :value_length, initial_value: -> { property_value.num_bytes }
+        uint16   :reserved
+        string16 :property_name, read_length: :name_length
+        string   :property_value, read_length: :value_length
+      end
+
+      # [2.2.10.1 USER_PROPERTIES](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/8263e7ab-aba9-43d2-8a36-3a9cb2dd3dad)
+      class UserProperties < BinData::Record
+        endian :little
+
+        uint32 :reserved1
+        uint32 :struct_length, initial_value: -> { num_bytes - 12 }
+        uint16 :reserved2
+        uint16 :reserved3
+        string :reserved4, length: 96
+        uint16 :property_signature, initial_value: 0x50
+        uint16 :property_count, initial_value: -> { user_properties.size }
+        array  :user_properties, type: :user_property, initial_length: :property_count
+        uint8  :reserved5
+      end
+
+      class KerbKeyDataNew < BinData::Record
+        endian :little
+
+        uint16 :reserved1
+        uint16 :reserved2
+        uint32 :reserved3
+        uint32 :iteration_count
+        uint32 :key_type
+        uint32 :key_length
+        uint32 :key_offset
+      end
+
+      # [2.2.10.6 Primary:Kerberos-Newer-Keys - KERB_STORED_CREDENTIAL_NEW](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/08cb3ca7-954b-45e3-902e-77512fe3ba8e)
+      class KerbStoredCredentialNew < BinData::Record
+        endian :little
+
+        uint16 :revision
+        uint16 :flags
+        uint16 :credential_count
+        uint16 :service_credential_count
+        uint16 :old_credential_count
+        uint16 :older_credential_count
+        uint16 :default_salt_length
+        uint16 :default_salt_maximum_length
+        uint32 :default_salt_offset
+        uint32 :default_iteration_count
+        array  :credentials, type: :kerb_key_data_new, initial_length: :credential_count
+        array  :service_credentials, type: :kerb_key_data_new, initial_length: :service_credential_count
+        array  :old_credentials, type: :kerb_key_data_new, initial_length: :old_credential_count
+        array  :older_credentials, type: :kerb_key_data_new, initial_length: :older_credential_count
+        string :default_salt, read_length: -> { credentials.map { |e| e.key_offset }.min - @obj.abs_offset }
+        string :key_values, read_length: -> { credentials.map { |e| e.key_length }.sum }
+
+        def get_key_values
+          credentials.map do |credential|
+            offset = credential.key_offset - key_values.abs_offset
+            key_values[offset, credential.key_length]
+          end
+        end
+      end
+
       require 'ruby_smb/dcerpc/samr/rpc_sid'
 
       require 'ruby_smb/dcerpc/samr/samr_connect_request'
@@ -476,6 +495,8 @@ module RubySMB
       require 'ruby_smb/dcerpc/samr/samr_open_user_response'
       require 'ruby_smb/dcerpc/samr/samr_get_groups_for_user_request'
       require 'ruby_smb/dcerpc/samr/samr_get_groups_for_user_response'
+      require 'ruby_smb/dcerpc/samr/samr_set_information_user2_request'
+      require 'ruby_smb/dcerpc/samr/samr_set_information_user2_response'
 
       # Returns a handle to a server object.
       #
@@ -692,8 +713,10 @@ module RubySMB
             array << entry.name.buffer
           end
           break unless samr_enum_domains_reponse.error_status == WindowsError::NTStatus::STATUS_MORE_ENTRIES
+
           enumeration_context = samr_enum_domains_reponse.enumeration_context
         end
+
         res
       end
 
@@ -770,6 +793,35 @@ module RubySMB
             "#{WindowsError::NTStatus.find_by_retval(samr_rid_to_sid_response.error_status.value).join(',')}"
         end
         samr_rid_to_sid_response.sid
+      end
+
+      # Update attributes on a user object.
+      #
+      # @param user_handle [RubySMB::Dcerpc::Samr::SamprHandle] An RPC context
+      #   representing a user object.
+      # @param user_info: [RubySMB::Dcerpc::Samr::SamprUserInfoBuffer] the user
+      #   information to set.
+      # @return nothing is returned on success
+      # @raise [RubySMB::Dcerpc::Error::SamrError] if the response error status
+      #   is not STATUS_SUCCESS
+      def samr_set_information_user2(user_handle:, user_info:)
+        samr_set_information_user2_request = SamrSetInformationUser2Request.new(
+          user_handle: user_handle,
+          buffer: user_info
+        )
+        response = dcerpc_request(samr_set_information_user2_request)
+        begin
+          samr_set_information_user2_response = SamrSetInformationUser2Response.read(response)
+        rescue IOError
+          raise RubySMB::Dcerpc::Error::InvalidPacket, 'Error reading SamrSetInformationUser2Response'
+        end
+        unless samr_set_information_user2_response.error_status == WindowsError::NTStatus::STATUS_SUCCESS
+          raise RubySMB::Dcerpc::Error::SamrError,
+            "Error returned while setting user information: "\
+            "#{WindowsError::NTStatus.find_by_retval(samr_set_information_user2_response.error_status.value).join(',')}"
+        end
+
+        nil
       end
 
       # Closes (that is, releases server-side resources used by) any context

--- a/lib/ruby_smb/dcerpc/samr/samr_create_user2_in_domain_request.rb
+++ b/lib/ruby_smb/dcerpc/samr/samr_create_user2_in_domain_request.rb
@@ -1,0 +1,24 @@
+module RubySMB
+  module Dcerpc
+    module Samr
+
+      # [3.1.5.4.4 SamrCreateUser2InDomain (Opnum 50)](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/a98d7fbb-1735-4fbf-b41a-ef363c899002)
+      class SamrCreateUser2InDomainRequest < BinData::Record
+        attr_reader :opnum
+
+        endian :little
+
+        sampr_handle         :domain_handle
+        rpc_unicode_string   :name
+        ndr_uint32           :account_type
+        ndr_uint32           :desired_access
+
+        def initialize_instance
+          super
+          @opnum = SAMR_CREATE_USER2_IN_DOMAIN
+        end
+      end
+
+    end
+  end
+end

--- a/lib/ruby_smb/dcerpc/samr/samr_create_user2_in_domain_response.rb
+++ b/lib/ruby_smb/dcerpc/samr/samr_create_user2_in_domain_response.rb
@@ -1,0 +1,24 @@
+module RubySMB
+  module Dcerpc
+    module Samr
+
+      # [3.1.5.4.4 SamrCreateUser2InDomain (Opnum 50)](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/a98d7fbb-1735-4fbf-b41a-ef363c899002)
+      class SamrCreateUser2InDomainResponse < BinData::Record
+        attr_reader :opnum
+
+        endian :little
+
+        sampr_handle         :user_handle
+        ndr_uint32           :granted_access
+        ndr_uint32           :relative_id
+        ndr_uint32           :error_status
+
+        def initialize_instance
+          super
+          @opnum = SAMR_CREATE_USER2_IN_DOMAIN
+        end
+      end
+
+    end
+  end
+end

--- a/lib/ruby_smb/dcerpc/samr/samr_delete_user_request.rb
+++ b/lib/ruby_smb/dcerpc/samr/samr_delete_user_request.rb
@@ -1,0 +1,21 @@
+module RubySMB
+  module Dcerpc
+    module Samr
+
+      # [3.1.5.7.3 SamrDeleteUser (Opnum 35)](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/4643a579-56ec-4c66-a1ef-4ab78dd21d73)
+      class SamrDeleteUserRequest < BinData::Record
+        attr_reader :opnum
+
+        endian :little
+
+        sampr_handle :user_handle
+
+        def initialize_instance
+          super
+          @opnum = SAMR_DELETE_USER
+        end
+      end
+
+    end
+  end
+end

--- a/lib/ruby_smb/dcerpc/samr/samr_delete_user_response.rb
+++ b/lib/ruby_smb/dcerpc/samr/samr_delete_user_response.rb
@@ -1,0 +1,22 @@
+module RubySMB
+  module Dcerpc
+    module Samr
+
+      # [3.1.5.7.3 SamrDeleteUser (Opnum 35)](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/4643a579-56ec-4c66-a1ef-4ab78dd21d73)
+      class SamrDeleteUserResponse < BinData::Record
+        attr_reader :opnum
+
+        endian :little
+
+        sampr_handle :user_handle
+        ndr_uint32   :error_status
+
+        def initialize_instance
+          super
+          @opnum = SAMR_DELETE_USER
+        end
+      end
+
+    end
+  end
+end

--- a/lib/ruby_smb/dcerpc/samr/samr_enumerate_domains_in_sam_server_request.rb
+++ b/lib/ruby_smb/dcerpc/samr/samr_enumerate_domains_in_sam_server_request.rb
@@ -1,0 +1,25 @@
+module RubySMB
+  module Dcerpc
+    module Samr
+
+      # [3.1.5.2.1 SamrEnumerateDomainsInSamServer (Opnum 6)](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/2142fd2d-0854-42c1-a9fb-2fe964e381ce)
+      class SamrEnumerateDomainsInSamServerRequest < BinData::Record
+        attr_reader :opnum
+
+        endian :little
+
+        sampr_handle :server_handle
+        ndr_uint32   :enumeration_context
+        ndr_uint32   :prefered_maximum_length
+
+        def initialize_instance
+          super
+          @opnum = SAMR_ENUMERATE_DOMAINS_IN_SAM_SERVER
+        end
+      end
+
+    end
+  end
+end
+
+

--- a/lib/ruby_smb/dcerpc/samr/samr_enumerate_domains_in_sam_server_response.rb
+++ b/lib/ruby_smb/dcerpc/samr/samr_enumerate_domains_in_sam_server_response.rb
@@ -2,8 +2,8 @@ module RubySMB
   module Dcerpc
     module Samr
 
-      # [3.1.5.2.5 SamrEnumerateUsersInDomain (Opnum 13)](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/6bdc92c0-c692-4ffb-9de7-65858b68da75)
-      class SamrEnumerateUsersInDomainResponse < BinData::Record
+      # [3.1.5.2.1 SamrEnumerateDomainsInSamServer (Opnum 6)](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/2142fd2d-0854-42c1-a9fb-2fe964e381ce)
+      class SamrEnumerateDomainsInSamServerResponse < BinData::Record
         attr_reader :opnum
 
         endian :little
@@ -15,10 +15,11 @@ module RubySMB
 
         def initialize_instance
           super
-          @opnum = SAMR_ENUMERATE_USERS_IN_DOMAIN
+          @opnum = SAMR_ENUMERATE_DOMAINS_IN_SAM_SERVER
         end
       end
 
     end
   end
 end
+

--- a/lib/ruby_smb/dcerpc/samr/samr_get_alias_membership_response.rb
+++ b/lib/ruby_smb/dcerpc/samr/samr_get_alias_membership_response.rb
@@ -2,26 +2,13 @@ module RubySMB
   module Dcerpc
     module Samr
 
-      class PulongArray < Ndr::NdrConfArray
-        default_parameter type: :ndr_uint32
-        extend Ndr::PointerClassPlugin
-      end
-
-      # [2.2.7.4 SAMPR_ULONG_ARRAY](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/2feb3806-4db2-45b7-90d2-86c8336a31ba)
-      class PsamprUlongArray < Ndr::NdrStruct
-        default_parameter byte_align: 4
-
-        ndr_uint32   :elem_count, initial_value: -> { elements.size }
-        pulong_array :elements
-      end
-
       # [3.1.5.9.2 SamrGetAliasMembership (Opnum 16)](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/03184045-2208-4c02-b38b-ef955d6dc3ef)
       class SamrGetAliasMembershipResponse < BinData::Record
         attr_reader :opnum
 
         endian :little
 
-        psampr_ulong_array :membership
+        sampr_ulong_array  :membership
         ndr_uint32         :error_status
 
         def initialize_instance

--- a/lib/ruby_smb/dcerpc/samr/samr_lookup_names_in_domain_request.rb
+++ b/lib/ruby_smb/dcerpc/samr/samr_lookup_names_in_domain_request.rb
@@ -1,0 +1,23 @@
+module RubySMB
+  module Dcerpc
+    module Samr
+
+      # [3.1.5.11.2 SamrLookupNamesInDomain (Opnum 17)](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/d91271c6-7b2e-4194-9927-8fabfa429f90)
+      class SamrLookupNamesInDomainRequest < BinData::Record
+        attr_reader :opnum
+
+        endian :little
+
+        sampr_handle                      :domain_handle
+        ndr_uint32                        :names_count
+        rpc_unicode_string_conf_var_array :names
+
+        def initialize_instance
+          super
+          @opnum = SAMR_LOOKUP_NAMES_IN_DOMAIN
+        end
+      end
+
+    end
+  end
+end

--- a/lib/ruby_smb/dcerpc/samr/samr_lookup_names_in_domain_response.rb
+++ b/lib/ruby_smb/dcerpc/samr/samr_lookup_names_in_domain_response.rb
@@ -1,0 +1,23 @@
+module RubySMB
+  module Dcerpc
+    module Samr
+
+      # [3.1.5.11.2 SamrLookupNamesInDomain (Opnum 17)](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/d91271c6-7b2e-4194-9927-8fabfa429f90)
+      class SamrLookupNamesInDomainResponse < BinData::Record
+        attr_reader :opnum
+
+        endian :little
+
+        sampr_ulong_array  :relative_ids
+        sampr_ulong_array  :use
+        ndr_uint32         :error_status
+
+        def initialize_instance
+          super
+          @opnum = SAMR_LOOKUP_NAMES_IN_DOMAIN
+        end
+      end
+
+    end
+  end
+end

--- a/lib/ruby_smb/dcerpc/samr/samr_set_information_user2_request.rb
+++ b/lib/ruby_smb/dcerpc/samr/samr_set_information_user2_request.rb
@@ -1,0 +1,23 @@
+module RubySMB
+  module Dcerpc
+    module Samr
+
+      # [3.1.5.6.4 SamrSetInformationUser2 (Opnum 58)](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/99ee9f39-43e8-4bba-ac3a-82e0c0e0699e)
+      class SamrSetInformationUser2Request < BinData::Record
+        attr_reader :opnum
+
+        endian :little
+
+        sampr_handle           :user_handle
+        ndr_uint16             :user_information_class, initial_value: -> { buffer.tag }
+        sampr_user_info_buffer :buffer
+
+        def initialize_instance
+          super
+          @opnum = SAMR_SET_INFORMATION_USER2
+        end
+      end
+
+    end
+  end
+end

--- a/lib/ruby_smb/dcerpc/samr/samr_set_information_user2_response.rb
+++ b/lib/ruby_smb/dcerpc/samr/samr_set_information_user2_response.rb
@@ -1,0 +1,21 @@
+module RubySMB
+  module Dcerpc
+    module Samr
+
+      # [3.1.5.6.4 SamrSetInformationUser2 (Opnum 58)](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/99ee9f39-43e8-4bba-ac3a-82e0c0e0699e)
+      class SamrSetInformationUser2Response < BinData::Record
+        attr_reader :opnum
+
+        endian :little
+
+        ndr_uint32 :error_status
+
+        def initialize_instance
+          super
+          @opnum = SAMR_SET_INFORMATION_USER2
+        end
+      end
+
+    end
+  end
+end

--- a/spec/lib/ruby_smb/client_spec.rb
+++ b/spec/lib/ruby_smb/client_spec.rb
@@ -1881,6 +1881,7 @@ RSpec.describe RubySMB::Client do
           before :example do
             smb2_client.smb3 = true
             smb2_client.session_encrypt_data = false
+            smb2_client.preauth_integrity_hash_value = ''
           end
 
           it 'sets the session_encrypt_data parameter to true if the server requires encryption' do

--- a/spec/lib/ruby_smb/dcerpc/samr/samr_create_user2_in_domain_request_spec.rb
+++ b/spec/lib/ruby_smb/dcerpc/samr/samr_create_user2_in_domain_request_spec.rb
@@ -1,0 +1,69 @@
+RSpec.describe RubySMB::Dcerpc::Samr::SamrCreateUser2InDomainRequest do
+  subject(:packet) { described_class.new }
+
+  it { is_expected.to respond_to :domain_handle }
+  it { is_expected.to respond_to :name }
+  it { is_expected.to respond_to :account_type }
+  it { is_expected.to respond_to :desired_access }
+  it { is_expected.to respond_to :opnum }
+
+  it 'is little endian' do
+    expect(described_class.fields.instance_variable_get(:@hints)[:endian]).to eq :little
+  end
+
+  it 'is a BinData::Record' do
+    expect(packet).to be_a(BinData::Record)
+  end
+
+  describe '#domain_handle' do
+    it 'is a SamprHandle structure' do
+      expect(packet.domain_handle).to be_a RubySMB::Dcerpc::Samr::SamprHandle
+    end
+  end
+
+  describe '#name' do
+    it 'is a RpcUnicodeString' do
+      expect(packet.name).to be_a RubySMB::Dcerpc::RpcUnicodeString
+    end
+  end
+
+  describe '#account_type' do
+    it 'is a NdrUint32 structure' do
+      expect(packet.account_type).to be_a RubySMB::Dcerpc::Ndr::NdrUint32
+    end
+  end
+
+  describe '#desired_access' do
+    it 'is a NdrUint32 structure' do
+      expect(packet.desired_access).to be_a RubySMB::Dcerpc::Ndr::NdrUint32
+    end
+  end
+
+  describe '#initialize_instance' do
+    it 'sets #opnum to SAMR_CREATE_USER2_IN_DOMAIN constant' do
+      expect(packet.opnum).to eq(RubySMB::Dcerpc::Samr::SAMR_CREATE_USER2_IN_DOMAIN)
+    end
+  end
+
+  it 'reads itself' do
+    new_packet = described_class.new({
+      domain_handle: {
+        context_handle_attributes: 0,
+        context_handle_uuid: "fc873b90-d9a9-46a4-b9ea-f44bb1c272a7"
+      },
+      name: 'test',
+      account_type: 1,
+      desired_access: 2
+    })
+    expected_output = {
+      domain_handle: {
+        context_handle_attributes: 0,
+        context_handle_uuid: "fc873b90-d9a9-46a4-b9ea-f44bb1c272a7"
+      },
+      name: {:buffer=>"test".encode('utf-16le'), :buffer_length=>8, :maximum_length=>8},
+      account_type: 1,
+      desired_access: 2
+    }
+    expect(packet.read(new_packet.to_binary_s)).to eq(expected_output)
+  end
+end

--- a/spec/lib/ruby_smb/dcerpc/samr/samr_create_user2_in_domain_response_spec.rb
+++ b/spec/lib/ruby_smb/dcerpc/samr/samr_create_user2_in_domain_response_spec.rb
@@ -1,0 +1,69 @@
+RSpec.describe RubySMB::Dcerpc::Samr::SamrCreateUser2InDomainResponse do
+  subject(:packet) { described_class.new }
+
+  it { is_expected.to respond_to :user_handle }
+  it { is_expected.to respond_to :granted_access }
+  it { is_expected.to respond_to :relative_id }
+  it { is_expected.to respond_to :error_status }
+  it { is_expected.to respond_to :opnum }
+
+  it 'is little endian' do
+    expect(described_class.fields.instance_variable_get(:@hints)[:endian]).to eq :little
+  end
+
+  it 'is a BinData::Record' do
+    expect(packet).to be_a(BinData::Record)
+  end
+
+  describe '#user_handle' do
+    it 'is a SamprHandle structure' do
+      expect(packet.user_handle).to be_a RubySMB::Dcerpc::Samr::SamprHandle
+    end
+  end
+
+  describe '#granted_access' do
+    it 'is a NdrUint32' do
+      expect(packet.granted_access).to be_a RubySMB::Dcerpc::Ndr::NdrUint32
+    end
+  end
+
+  describe '#relative_id' do
+    it 'is a NdrUint32 structure' do
+      expect(packet.relative_id).to be_a RubySMB::Dcerpc::Ndr::NdrUint32
+    end
+  end
+
+  describe '#error_status' do
+    it 'is a NdrUint32 structure' do
+      expect(packet.error_status).to be_a RubySMB::Dcerpc::Ndr::NdrUint32
+    end
+  end
+
+  describe '#initialize_instance' do
+    it 'sets #opnum to SAMR_CREATE_USER2_IN_DOMAIN constant' do
+      expect(packet.opnum).to eq(RubySMB::Dcerpc::Samr::SAMR_CREATE_USER2_IN_DOMAIN)
+    end
+  end
+
+  it 'reads itself' do
+    new_packet = described_class.new({
+      user_handle: {
+        context_handle_attributes: 0,
+        context_handle_uuid: "fc873b90-d9a9-46a4-b9ea-f44bb1c272a7"
+      },
+      granted_access: 1,
+      relative_id: 2,
+      error_status: 0x11223344
+    })
+    expected_output = {
+      user_handle: {
+        context_handle_attributes: 0,
+        context_handle_uuid: "fc873b90-d9a9-46a4-b9ea-f44bb1c272a7"
+      },
+      granted_access: 1,
+      relative_id: 2,
+      error_status: 0x11223344
+    }
+    expect(packet.read(new_packet.to_binary_s)).to eq(expected_output)
+  end
+end

--- a/spec/lib/ruby_smb/dcerpc/samr/samr_delete_user_request_spec.rb
+++ b/spec/lib/ruby_smb/dcerpc/samr/samr_delete_user_request_spec.rb
@@ -1,0 +1,42 @@
+RSpec.describe RubySMB::Dcerpc::Samr::SamrDeleteUserRequest do
+  subject(:packet) { described_class.new }
+
+  it { is_expected.to respond_to :user_handle }
+  it { is_expected.to respond_to :opnum }
+
+  it 'is little endian' do
+    expect(described_class.fields.instance_variable_get(:@hints)[:endian]).to eq :little
+  end
+
+  it 'is a BinData::Record' do
+    expect(packet).to be_a(BinData::Record)
+  end
+
+  describe '#user_handle' do
+    it 'is a SamprHandle structure' do
+      expect(packet.user_handle).to be_a RubySMB::Dcerpc::Samr::SamprHandle
+    end
+  end
+
+  describe '#initialize_instance' do
+    it 'sets #opnum to SAMR_DELETE_USER constant' do
+      expect(packet.opnum).to eq(RubySMB::Dcerpc::Samr::SAMR_DELETE_USER)
+    end
+  end
+
+  it 'reads itself' do
+    new_packet = described_class.new({
+      user_handle: {
+        context_handle_attributes: 0,
+        context_handle_uuid: "fc873b90-d9a9-46a4-b9ea-f44bb1c272a7"
+      }
+    })
+    expected_output = {
+      user_handle: {
+        context_handle_attributes: 0,
+        context_handle_uuid: "fc873b90-d9a9-46a4-b9ea-f44bb1c272a7"
+      }
+    }
+    expect(packet.read(new_packet.to_binary_s)).to eq(expected_output)
+  end
+end

--- a/spec/lib/ruby_smb/dcerpc/samr/samr_delete_user_response_spec.rb
+++ b/spec/lib/ruby_smb/dcerpc/samr/samr_delete_user_response_spec.rb
@@ -1,0 +1,51 @@
+RSpec.describe RubySMB::Dcerpc::Samr::SamrDeleteUserResponse do
+  subject(:packet) { described_class.new }
+
+  it { is_expected.to respond_to :user_handle }
+  it { is_expected.to respond_to :error_status }
+  it { is_expected.to respond_to :opnum }
+
+  it 'is little endian' do
+    expect(described_class.fields.instance_variable_get(:@hints)[:endian]).to eq :little
+  end
+
+  it 'is a BinData::Record' do
+    expect(packet).to be_a(BinData::Record)
+  end
+
+  describe '#user_handle' do
+    it 'is a SamprHandle structure' do
+      expect(packet.user_handle).to be_a RubySMB::Dcerpc::Samr::SamprHandle
+    end
+  end
+
+  describe '#error_status' do
+    it 'is a NdrUint32 structure' do
+      expect(packet.error_status).to be_a RubySMB::Dcerpc::Ndr::NdrUint32
+    end
+  end
+
+  describe '#initialize_instance' do
+    it 'sets #opnum to SAMR_DELETE_USER constant' do
+      expect(packet.opnum).to eq(RubySMB::Dcerpc::Samr::SAMR_DELETE_USER)
+    end
+  end
+
+  it 'reads itself' do
+    new_packet = described_class.new({
+      user_handle: {
+        context_handle_attributes: 0,
+        context_handle_uuid: "fc873b90-d9a9-46a4-b9ea-f44bb1c272a7"
+      },
+      error_status: 0x11223344
+    })
+    expected_output = {
+      user_handle: {
+        context_handle_attributes: 0,
+        context_handle_uuid: "fc873b90-d9a9-46a4-b9ea-f44bb1c272a7"
+      },
+      error_status: 0x11223344
+    }
+    expect(packet.read(new_packet.to_binary_s)).to eq(expected_output)
+  end
+end

--- a/spec/lib/ruby_smb/dcerpc/samr/samr_enumerate_domains_in_sam_server_request_spec.rb
+++ b/spec/lib/ruby_smb/dcerpc/samr/samr_enumerate_domains_in_sam_server_request_spec.rb
@@ -1,0 +1,60 @@
+RSpec.describe RubySMB::Dcerpc::Samr::SamrEnumerateDomainsInSamServerRequest do
+  subject(:packet) { described_class.new }
+
+  it { is_expected.to respond_to :server_handle }
+  it { is_expected.to respond_to :enumeration_context }
+  it { is_expected.to respond_to :prefered_maximum_length }
+  it { is_expected.to respond_to :opnum }
+
+  it 'is little endian' do
+    expect(described_class.fields.instance_variable_get(:@hints)[:endian]).to eq :little
+  end
+
+  it 'is a BinData::Record' do
+    expect(packet).to be_a(BinData::Record)
+  end
+
+  describe '#server_handle' do
+    it 'is a SamprHandle structure' do
+      expect(packet.server_handle).to be_a RubySMB::Dcerpc::Samr::SamprHandle
+    end
+  end
+
+  describe '#enumeration_context' do
+    it 'is a NdrUint32 structure' do
+      expect(packet.enumeration_context).to be_a RubySMB::Dcerpc::Ndr::NdrUint32
+    end
+  end
+
+  describe '#prefered_maximum_length' do
+    it 'is a NdrUint32 structure' do
+      expect(packet.prefered_maximum_length).to be_a RubySMB::Dcerpc::Ndr::NdrUint32
+    end
+  end
+
+  describe '#initialize_instance' do
+    it 'sets #opnum to SAMR_ENUMERATE_DOMAINS_IN_SAM_SERVER constant' do
+      expect(packet.opnum).to eq(RubySMB::Dcerpc::Samr::SAMR_ENUMERATE_DOMAINS_IN_SAM_SERVER)
+    end
+  end
+
+  it 'reads itself' do
+    new_packet = described_class.new({
+      server_handle: {
+        context_handle_attributes: 0,
+        context_handle_uuid: "fc873b90-d9a9-46a4-b9ea-f44bb1c272a7"
+      },
+      enumeration_context: 1,
+      prefered_maximum_length: 2
+    })
+    expected_output = {
+      server_handle: {
+        context_handle_attributes: 0,
+        context_handle_uuid: "fc873b90-d9a9-46a4-b9ea-f44bb1c272a7"
+      },
+      enumeration_context: 1,
+      prefered_maximum_length: 2
+    }
+    expect(packet.read(new_packet.to_binary_s)).to eq(expected_output)
+  end
+end

--- a/spec/lib/ruby_smb/dcerpc/samr/samr_enumerate_domains_in_sam_server_response_spec.rb
+++ b/spec/lib/ruby_smb/dcerpc/samr/samr_enumerate_domains_in_sam_server_response_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe RubySMB::Dcerpc::Samr::SamrEnumerateUsersInDomainResponse do
+RSpec.describe RubySMB::Dcerpc::Samr::SamrEnumerateDomainsInSamServerResponse do
   subject(:packet) { described_class.new }
 
   it { is_expected.to respond_to :enumeration_context }
@@ -10,60 +10,65 @@ RSpec.describe RubySMB::Dcerpc::Samr::SamrEnumerateUsersInDomainResponse do
   it 'is little endian' do
     expect(described_class.fields.instance_variable_get(:@hints)[:endian]).to eq :little
   end
+
   it 'is a BinData::Record' do
     expect(packet).to be_a(BinData::Record)
   end
+
   describe '#enumeration_context' do
     it 'is a NdrUint32 structure' do
       expect(packet.enumeration_context).to be_a RubySMB::Dcerpc::Ndr::NdrUint32
     end
   end
+
   describe '#buffer' do
     it 'is a PsamprEnumerationBuffer structure' do
       expect(packet.buffer).to be_a RubySMB::Dcerpc::Samr::PsamprEnumerationBuffer
     end
   end
+
   describe '#count_returned' do
     it 'is a NdrUint32 structure' do
       expect(packet.count_returned).to be_a RubySMB::Dcerpc::Ndr::NdrUint32
     end
   end
+
   describe '#error_status' do
     it 'is a NdrUint32 structure' do
       expect(packet.error_status).to be_a RubySMB::Dcerpc::Ndr::NdrUint32
     end
   end
+
   describe '#initialize_instance' do
-    it 'sets #opnum to SAMR_ENUMERATE_USERS_IN_DOMAIN constant' do
-      expect(packet.opnum).to eq(RubySMB::Dcerpc::Samr::SAMR_ENUMERATE_USERS_IN_DOMAIN)
+    it 'sets #opnum to SAMR_ENUMERATE_DOMAINS_IN_SAM_SERVER constant' do
+      expect(packet.opnum).to eq(RubySMB::Dcerpc::Samr::SAMR_ENUMERATE_DOMAINS_IN_SAM_SERVER)
     end
   end
+
   it 'reads itself' do
-    new_packet = described_class.new(
-      enumeration_context: 0,
+    new_packet = described_class.new({
+      enumeration_context: 1,
       buffer: {
-        entries_read: 3,
+        entries_read: 2,
         buffer: [
-          { relative_id: 500, name: "Administrator" },
-          { relative_id: 501, name: "Guest" },
-          { relative_id: 1001, name: "WIN-DP0M1BC768$" }
+          {relative_id: 500, name: { buffer_length: 26, maximum_length: 26, buffer: "Builtin".encode('utf-16le') }},
+          {relative_id: 501, name: { buffer_length: 10, maximum_length: 10, buffer: "RUBYSMB".encode('utf-16le') }},
         ]
       },
-      count_returned: 3,
-      error_status: 0
-    )
+      count_returned: 2,
+      error_status: 0x11223344
+    })
     expected_output = {
-      enumeration_context: 0,
+      enumeration_context: 1,
       buffer: {
-        entries_read: 3,
+        entries_read: 2,
         buffer: [
-          {relative_id: 500, name: { buffer_length: 26, maximum_length: 26, buffer: "Administrator".encode('utf-16le') }},
-          {relative_id: 501, name: { buffer_length: 10, maximum_length: 10, buffer: "Guest".encode('utf-16le') }},
-          {relative_id: 1001, name: { buffer_length: 30, maximum_length: 30, buffer: "WIN-DP0M1BC768$".encode('utf-16le') }}
+          {relative_id: 500, name: { buffer_length: 26, maximum_length: 26, buffer: "Builtin".encode('utf-16le') }},
+          {relative_id: 501, name: { buffer_length: 10, maximum_length: 10, buffer: "RUBYSMB".encode('utf-16le') }},
         ]
       },
-      count_returned: 3,
-      error_status: 0
+      count_returned: 2,
+      error_status: 0x11223344
     }
     expect(packet.read(new_packet.to_binary_s)).to eq(expected_output)
   end

--- a/spec/lib/ruby_smb/dcerpc/samr/samr_lookup_names_in_domain_request_spec.rb
+++ b/spec/lib/ruby_smb/dcerpc/samr/samr_lookup_names_in_domain_request_spec.rb
@@ -1,0 +1,62 @@
+RSpec.describe RubySMB::Dcerpc::Samr::SamrLookupNamesInDomainRequest do
+  subject(:packet) { described_class.new }
+
+  it { is_expected.to respond_to :domain_handle }
+  it { is_expected.to respond_to :names_count }
+  it { is_expected.to respond_to :names }
+  it { is_expected.to respond_to :opnum }
+
+  it 'is little endian' do
+    expect(described_class.fields.instance_variable_get(:@hints)[:endian]).to eq :little
+  end
+
+  it 'is a BinData::Record' do
+    expect(packet).to be_a(BinData::Record)
+  end
+
+  describe '#domain_handle' do
+    it 'is a SamprHandle structure' do
+      expect(packet.domain_handle).to be_a RubySMB::Dcerpc::Samr::SamprHandle
+    end
+  end
+
+  describe '#names_count' do
+    it 'is a NdrUint32 structure' do
+      expect(packet.names_count).to be_a RubySMB::Dcerpc::Ndr::NdrUint32
+    end
+  end
+
+  describe '#names' do
+    it 'is a RpcUnicodeStringConfVarArray structure' do
+      expect(packet.names).to be_a RubySMB::Dcerpc::RpcUnicodeStringConfVarArray
+    end
+  end
+
+  describe '#initialize_instance' do
+    it 'sets #opnum to SAMR_LOOKUP_NAMES_IN_DOMAIN constant' do
+      expect(packet.opnum).to eq(RubySMB::Dcerpc::Samr::SAMR_LOOKUP_NAMES_IN_DOMAIN)
+    end
+  end
+
+  it 'reads itself' do
+    new_packet = described_class.new({
+      domain_handle: {
+        context_handle_attributes: 0,
+        context_handle_uuid: "fc873b90-d9a9-46a4-b9ea-f44bb1c272a7"
+      },
+      names_count: 1,
+      names: [ 'TEST' ]
+    })
+    expected_output = {
+      domain_handle: {
+        context_handle_attributes: 0,
+        context_handle_uuid: "fc873b90-d9a9-46a4-b9ea-f44bb1c272a7"
+      },
+      names_count: 1,
+      names: [
+        { buffer_length: 8, maximum_length: 8, buffer: "TEST".encode('utf-16le') }
+      ]
+    }
+    expect(packet.read(new_packet.to_binary_s)).to eq(expected_output)
+  end
+end

--- a/spec/lib/ruby_smb/dcerpc/samr/samr_lookup_names_in_domain_response_spec.rb
+++ b/spec/lib/ruby_smb/dcerpc/samr/samr_lookup_names_in_domain_response_spec.rb
@@ -1,0 +1,54 @@
+RSpec.describe RubySMB::Dcerpc::Samr::SamrLookupNamesInDomainResponse do
+  subject(:packet) { described_class.new }
+
+  it { is_expected.to respond_to :relative_ids }
+  it { is_expected.to respond_to :use }
+  it { is_expected.to respond_to :error_status }
+  it { is_expected.to respond_to :opnum }
+
+  it 'is little endian' do
+    expect(described_class.fields.instance_variable_get(:@hints)[:endian]).to eq :little
+  end
+
+  it 'is a BinData::Record' do
+    expect(packet).to be_a(BinData::Record)
+  end
+
+  describe '#relative_ids' do
+    it 'is a SamprHandle structure' do
+      expect(packet.relative_ids).to be_a RubySMB::Dcerpc::Samr::SamprUlongArray
+    end
+  end
+
+  describe '#use' do
+    it 'is a SamprHandle structure' do
+      expect(packet.use).to be_a RubySMB::Dcerpc::Samr::SamprUlongArray
+    end
+  end
+
+  describe '#error_status' do
+    it 'is a NdrUint32 structure' do
+      expect(packet.error_status).to be_a RubySMB::Dcerpc::Ndr::NdrUint32
+    end
+  end
+
+  describe '#initialize_instance' do
+    it 'sets #opnum to SAMR_LOOKUP_NAMES_IN_DOMAIN constant' do
+      expect(packet.opnum).to eq(RubySMB::Dcerpc::Samr::SAMR_LOOKUP_NAMES_IN_DOMAIN)
+    end
+  end
+
+  it 'reads itself' do
+    new_packet = described_class.new({
+      relative_ids: { element_count: 2, elements: [ 500, 501 ] },
+      use: { element_count: 2, elements:  [ 1, 2 ] },
+      error_status: 0x11223344
+    })
+    expected_output = {
+      relative_ids: { element_count: 2, elements: [ 500, 501 ] },
+      use: { element_count: 2, elements:  [ 1, 2 ] },
+      error_status: 0x11223344
+    }
+    expect(packet.read(new_packet.to_binary_s)).to eq(expected_output)
+  end
+end

--- a/spec/lib/ruby_smb/dcerpc/samr/samr_set_information_user2_request_spec.rb
+++ b/spec/lib/ruby_smb/dcerpc/samr/samr_set_information_user2_request_spec.rb
@@ -1,0 +1,67 @@
+RSpec.describe RubySMB::Dcerpc::Samr::SamrSetInformationUser2Request do
+  subject(:packet) { described_class.new }
+
+  it { is_expected.to respond_to :user_handle }
+  it { is_expected.to respond_to :user_information_class }
+  it { is_expected.to respond_to :buffer }
+  it { is_expected.to respond_to :opnum }
+
+  it 'is little endian' do
+    expect(described_class.fields.instance_variable_get(:@hints)[:endian]).to eq :little
+  end
+
+  it 'is a BinData::Record' do
+    expect(packet).to be_a(BinData::Record)
+  end
+
+  describe '#user_handle' do
+    it 'is a SamprHandle structure' do
+      expect(packet.user_handle).to be_a RubySMB::Dcerpc::Samr::SamprHandle
+    end
+  end
+
+  describe '#user_information_class' do
+    it 'is a NdrUint16 structure' do
+      expect(packet.user_information_class).to be_a RubySMB::Dcerpc::Ndr::NdrUint16
+    end
+  end
+
+  describe '#buffer' do
+    it 'is a SamprUserInfoBuffer structure' do
+      expect(packet.buffer).to be_a RubySMB::Dcerpc::Samr::SamprUserInfoBuffer
+    end
+  end
+
+  describe '#initialize_instance' do
+    it 'sets #opnum to SAMR_SET_INFORMATION_USER2 constant' do
+      expect(packet.opnum).to eq(RubySMB::Dcerpc::Samr::SAMR_SET_INFORMATION_USER2)
+    end
+  end
+
+  it 'reads itself' do
+    new_class = described_class.new(
+      user_handle: {
+        context_handle_attributes: 0,
+        context_handle_uuid: '2ef54a87-e29e-4d24-90e9-9da49b94449e'
+      },
+      user_information_class: RubySMB::Dcerpc::Samr::USER_CONTROL_INFORMATION,
+      buffer: {
+        tag: RubySMB::Dcerpc::Samr::USER_CONTROL_INFORMATION,
+        member: { user_account_control: RubySMB::Dcerpc::Samr::USER_WORKSTATION_TRUST_ACCOUNT }
+      }
+    )
+    expect(packet.read(new_class.to_binary_s)).to eq(
+      {
+        user_handle: {
+          context_handle_attributes: 0,
+          context_handle_uuid: '2ef54a87-e29e-4d24-90e9-9da49b94449e'
+        },
+        user_information_class: RubySMB::Dcerpc::Samr::USER_CONTROL_INFORMATION,
+        buffer: {
+          tag: RubySMB::Dcerpc::Samr::USER_CONTROL_INFORMATION,
+          member: { user_account_control: RubySMB::Dcerpc::Samr::USER_WORKSTATION_TRUST_ACCOUNT }
+        }
+      }
+    )
+  end
+end

--- a/spec/lib/ruby_smb/dcerpc/samr/samr_set_information_user2_response_spec.rb
+++ b/spec/lib/ruby_smb/dcerpc/samr/samr_set_information_user2_response_spec.rb
@@ -1,0 +1,35 @@
+RSpec.describe RubySMB::Dcerpc::Samr::SamrSetInformationUser2Response do
+  subject(:packet) { described_class.new }
+
+  it { is_expected.to respond_to :error_status }
+  it { is_expected.to respond_to :opnum }
+
+  it 'is little endian' do
+    expect(described_class.fields.instance_variable_get(:@hints)[:endian]).to eq :little
+  end
+
+  it 'is a BinData::Record' do
+    expect(packet).to be_a(BinData::Record)
+  end
+
+  describe '#error_status' do
+    it 'is a NdrUint32 structure' do
+      expect(packet.error_status).to be_a RubySMB::Dcerpc::Ndr::NdrUint32
+    end
+  end
+
+  describe '#initialize_instance' do
+    it 'sets #opnum to SAMR_SET_INFORMATION_USER2 constant' do
+      expect(packet.opnum).to eq(RubySMB::Dcerpc::Samr::SAMR_SET_INFORMATION_USER2)
+    end
+  end
+
+  it 'reads itself' do
+    new_class = described_class.new(error_status: 0x11223344)
+    expect(packet.read(new_class.to_binary_s)).to eq(
+      {
+        error_status: 0x11223344
+      }
+    )
+  end
+end

--- a/spec/lib/ruby_smb/dcerpc/samr_spec.rb
+++ b/spec/lib/ruby_smb/dcerpc/samr_spec.rb
@@ -7,6 +7,200 @@ RSpec.describe RubySMB::Dcerpc::Samr do
     )
   end
 
+  describe described_class::SamprRidEnumeration do
+    subject(:packet) { described_class.new }
+
+    it { is_expected.to respond_to :relative_id }
+    it { is_expected.to respond_to :name }
+
+    it 'is little endian' do
+      expect(described_class.fields.instance_variable_get(:@hints)[:endian]).to eq :little
+    end
+    it 'is a Ndr::NdrStruct' do
+      expect(packet).to be_a(RubySMB::Dcerpc::Ndr::NdrStruct)
+    end
+    it 'is four-byte aligned' do
+      expect(packet.eval_parameter(:byte_align)).to eq(4)
+    end
+    describe '#relative_id' do
+      it 'is a NdrUint32 structure' do
+        expect(packet.relative_id).to be_a RubySMB::Dcerpc::Ndr::NdrUint32
+      end
+    end
+    describe '#name' do
+      it 'is a RpcUnicodeString structure' do
+        expect(packet.name).to be_a RubySMB::Dcerpc::RpcUnicodeString
+      end
+    end
+    it 'reads itself' do
+      new_packet = described_class.new(relative_id: 4, name: 'Test String')
+      expected_output = {
+        relative_id: 4,
+        name: {
+           buffer_length: 22,
+           maximum_length: 22,
+           buffer: "Test String".encode('utf-16le')
+        }
+      }
+      expect(packet.read(new_packet.to_binary_s)).to eq(expected_output)
+    end
+  end
+
+  describe described_class::SamprRidEnumerationArray do
+    subject(:packet) { described_class.new }
+
+    it 'is a Ndr::NdrConfArray' do
+      expect(packet).to be_a(RubySMB::Dcerpc::Ndr::NdrConfArray)
+    end
+    it 'has element of type SamprRidEnumeration' do
+      packet << {relative_id: 4, name: ''}
+      expect(packet[0]).to be_a(RubySMB::Dcerpc::Samr::SamprRidEnumeration)
+    end
+    it 'reads itself' do
+      new_packet = described_class.new([
+        {relative_id: 4, name: 'Test1'},
+        {relative_id: 1, name: 'Test2'}
+      ])
+      expected_output = [
+      {
+        relative_id: 4,
+        name: {
+           buffer_length: 10,
+           maximum_length: 10,
+           buffer: "Test1".encode('utf-16le')
+        }
+      },
+      {
+        relative_id: 1,
+        name: {
+           buffer_length: 10,
+           maximum_length: 10,
+           buffer: "Test2".encode('utf-16le')
+        }
+      }]
+      expect(packet.read(new_packet.to_binary_s)).to eq(expected_output)
+    end
+  end
+
+  describe described_class::PsamprRidEnumerationArray do
+    subject(:packet) { described_class.new }
+
+    it 'is a SamprRidEnumerationArray' do
+      expect(packet).to be_a(RubySMB::Dcerpc::Samr::SamprRidEnumerationArray)
+    end
+    it 'is a NdrPointer' do
+      expect(described_class).to be_a(RubySMB::Dcerpc::Ndr::PointerClassPlugin)
+      expect(packet).to be_a(RubySMB::Dcerpc::Ndr::PointerPlugin)
+    end
+    it 'is four-byte aligned' do
+      expect(packet.eval_parameter(:byte_align)).to eq(4)
+    end
+    it 'reads itself' do
+      new_packet = described_class.new([
+        {relative_id: 4, name: 'Test1'},
+        {relative_id: 1, name: 'Test2'}
+      ])
+      expected_output = [
+      {
+        relative_id: 4,
+        name: {
+           buffer_length: 10,
+           maximum_length: 10,
+           buffer: "Test1".encode('utf-16le')
+        }
+      },
+      {
+        relative_id: 1,
+        name: {
+           buffer_length: 10,
+           maximum_length: 10,
+           buffer: "Test2".encode('utf-16le')
+        }
+      }]
+      expect(packet.read(new_packet.to_binary_s)).to eq(expected_output)
+    end
+  end
+
+  describe described_class::SamprEnumerationBuffer do
+    subject(:packet) { described_class.new }
+
+    it { is_expected.to respond_to :entries_read }
+    it { is_expected.to respond_to :buffer }
+
+    it 'is little endian' do
+      expect(described_class.fields.instance_variable_get(:@hints)[:endian]).to eq :little
+    end
+    it 'is a Ndr::NdrStruct' do
+      expect(packet).to be_a(RubySMB::Dcerpc::Ndr::NdrStruct)
+    end
+    it 'is four-byte aligned' do
+      expect(packet.eval_parameter(:byte_align)).to eq(4)
+    end
+    describe '#entries_read' do
+      it 'is a NdrUint32 structure' do
+        expect(packet.entries_read).to be_a RubySMB::Dcerpc::Ndr::NdrUint32
+      end
+    end
+    describe '#buffer' do
+      it 'is a PsamprRidEnumerationArray structure' do
+        expect(packet.buffer).to be_a RubySMB::Dcerpc::Samr::PsamprRidEnumerationArray
+      end
+    end
+    it 'reads itself' do
+      new_packet = described_class.new(
+        entries_read: 3,
+        buffer: [
+          { relative_id: 500, name: "Administrator" },
+          { relative_id: 501, name: "Guest" },
+          { relative_id: 1001, name: "WIN-DP0M1BC768$" }
+        ]
+      )
+      expected_output = {
+        entries_read: 3,
+        buffer: [
+          {relative_id: 500, name: { buffer_length: 26, maximum_length: 26, buffer: "Administrator".encode('utf-16le') }},
+          {relative_id: 501, name: { buffer_length: 10, maximum_length: 10, buffer: "Guest".encode('utf-16le') }},
+          {relative_id: 1001, name: { buffer_length: 30, maximum_length: 30, buffer: "WIN-DP0M1BC768$".encode('utf-16le') }}
+        ]
+      }
+      expect(packet.read(new_packet.to_binary_s)).to eq(expected_output)
+    end
+  end
+
+  describe described_class::PsamprEnumerationBuffer do
+    subject(:packet) { described_class.new }
+
+    it 'is a SamprEnumerationBuffer' do
+      expect(packet).to be_a(RubySMB::Dcerpc::Samr::SamprEnumerationBuffer)
+    end
+    it 'is a NdrPointer' do
+      expect(described_class).to be_a(RubySMB::Dcerpc::Ndr::PointerClassPlugin)
+      expect(packet).to be_a(RubySMB::Dcerpc::Ndr::PointerPlugin)
+    end
+    it 'is four-byte aligned' do
+      expect(packet.eval_parameter(:byte_align)).to eq(4)
+    end
+    it 'reads itself' do
+      new_packet = described_class.new(
+        entries_read: 3,
+        buffer: [
+          { relative_id: 500, name: "Administrator" },
+          { relative_id: 501, name: "Guest" },
+          { relative_id: 1001, name: "WIN-DP0M1BC768$" }
+        ]
+      )
+      expected_output = {
+        entries_read: 3,
+        buffer: [
+          {relative_id: 500, name: { buffer_length: 26, maximum_length: 26, buffer: "Administrator".encode('utf-16le') }},
+          {relative_id: 501, name: { buffer_length: 10, maximum_length: 10, buffer: "Guest".encode('utf-16le') }},
+          {relative_id: 1001, name: { buffer_length: 30, maximum_length: 30, buffer: "WIN-DP0M1BC768$".encode('utf-16le') }}
+        ]
+      }
+      expect(packet.read(new_packet.to_binary_s)).to eq(expected_output)
+    end
+  end
+
   describe described_class::SamprHandle do
     it 'is a Ndr::NdrContextHandle' do
       expect(described_class).to be < RubySMB::Dcerpc::Ndr::NdrContextHandle


### PR DESCRIPTION
This adds the necessary SAMR definitions for:

* SamrEnumerateDomainsInSamServer
* SamrLookupNamesInDomain
* SamrCreateUesr2InDomain
* SamrDeleteUser
* SamrSetInformationUser2

It also adds the functions to wrap each, making them available to call more easily. `SamrEnumeratDomainsInSamServer` uses the common `PsamprEnumerationBuffer` type definition, so that one and some others that were already defined were moved into the higher-level `samr.rb` file. Also the application key is now calculated by the client for SMB v3 dialects. This is necessary for some DCERPC operations.

Basic unit tests were added for the new data definitions.

The easiest way to test this will be with the accompanying Metasploit module which will be posted shortly.