### PR TITLE
Revert "Always track sequence counter regardless of having a session key present"

### DIFF
--- a/lib/ruby_smb/client.rb
+++ b/lib/ruby_smb/client.rb
@@ -462,7 +462,6 @@ module RubySMB
         packet.smb_header.uid = self.user_id if self.user_id
         packet.smb_header.pid_low = self.pid if self.pid
         packet = smb1_sign(packet) if signing_required && !session_key.empty?
-        self.sequence_counter += 1
       when 'SMB2'
         packet = increment_smb_message_id(packet)
         packet.smb2_header.session_id = session_id
@@ -502,7 +501,7 @@ module RubySMB
         break
       end unless version == 'SMB1'
 
-      self.sequence_counter += 1
+      self.sequence_counter += 1 if signing_required && !session_key.empty?
       # update the SMB2 message ID according to the received Credit Charged
       self.smb2_message_id += smb2_header.credit_charge - 1 if smb2_header && self.server_supports_multi_credit
       raw_response

--- a/lib/ruby_smb/signing.rb
+++ b/lib/ruby_smb/signing.rb
@@ -13,6 +13,7 @@ module RubySMB
     # @return [RubySMB::GenericPacket] the signed packet
     def smb1_sign(packet)
       packet = Signing::smb1_sign(packet, @session_key, @sequence_counter)
+      @sequence_counter += 1
 
       packet
     end

--- a/spec/lib/ruby_smb/client_spec.rb
+++ b/spec/lib/ruby_smb/client_spec.rb
@@ -239,27 +239,6 @@ RSpec.describe RubySMB::Client do
     end
 
     context 'with SMB1' do
-      context 'when tracking sequence numbers' do
-        it 'increments the sequence_counter by 2 when successfully sending and receiving a message' do
-          expect { smb1_client.send_recv(smb1_request) }.to change { smb1_client.sequence_counter }.from(0).to(2)
-        end
-
-        it 'increments the sequence_counter by 1 when waiting for the server response' do
-          expect(smb1_client).to receive(:recv_packet)
-          allow(smb1_client).to receive(:recv_packet) do |*args, **kwargs|
-            expect(smb1_client.sequence_counter).to eq(1)
-          end
-          smb1_client.send_recv(smb1_request)
-        end
-
-        it 'does not increment the sequence_counter again if there is a communication error with the server' do
-          expect do
-            allow(smb1_client).to receive(:recv_packet).and_raise RubySMB::Error::CommunicationError
-            smb1_client.send_recv(smb1_request) rescue RubySMB::Error::CommunicationError
-          end.to change { smb1_client.sequence_counter }.from(0).to(1)
-        end
-      end
-
       it 'does not check if it is a STATUS_PENDING response' do
         expect(smb1_client).to_not receive(:is_status_pending?)
         smb1_client.send_recv(smb1_request)


### PR DESCRIPTION
Reverts rapid7/ruby_smb#230

Going to revert this for now to reduce the possibility of introducing a regression in Metasploit. It looks like negotiation packets shouldn't increment the sequence number in ruby_smb, and there's the possibility other edgecases/assumptions in Metasploit that are invalidated by this change - for instance ms17_010_eternal blue has copy/pasted the old implementation and assumes that `smb1_sign` has the side effect of incrementing sequence counter.

https://github.com/rapid7/metasploit-framework/blob/be48b1481ad80f79862c91a56bf2c584845b163e/modules/exploits/windows/smb/ms17_010_eternalblue.rb#L934-L942

This should all be easy enough to patch up / resolve / retest, but I don't want this to block the main focus of delivering Kerberos work