### PR TITLE
Add a couple of MS-DFSNM definitions and functions

### DIFF
--- a/lib/ruby_smb/dcerpc.rb
+++ b/lib/ruby_smb/dcerpc.rb
@@ -46,6 +46,7 @@ module RubySMB
     require 'ruby_smb/dcerpc/epm'
     require 'ruby_smb/dcerpc/drsr'
     require 'ruby_smb/dcerpc/sec_trailer'
+    require 'ruby_smb/dcerpc/dfsnm'
     require 'ruby_smb/dcerpc/request'
     require 'ruby_smb/dcerpc/response'
     require 'ruby_smb/dcerpc/rpc_auth3'

--- a/lib/ruby_smb/dcerpc/dfsnm.rb
+++ b/lib/ruby_smb/dcerpc/dfsnm.rb
@@ -15,12 +15,21 @@ module RubySMB
       require 'ruby_smb/dcerpc/dfsnm/netr_dfs_remove_std_root_request'
       require 'ruby_smb/dcerpc/dfsnm/netr_dfs_remove_std_root_response'
 
-      def netr_dfs_add_std_root(server_name, root_share, comment: '', api_flags: 0)
+      # Create a new stand-alone DFS namespace.
+      #
+      # @param server_name [String] The host name of the DFS root target.
+      # @param root_share [String] The DFS root target share name.
+      # @param comment [String] A comment associated with the DFS namespace.
+      # @return nothing is returned on success
+      # @raise [RubySMB::Dcerpc::Error::InvalidPacket] if the response is not a
+      #   NetrDfsAddStdRootResponse packet
+      # @raise [RubySMB::Dcerpc::Error::DfsnmError] if the response error status
+      #   is not ERROR_SUCCESS
+      def netr_dfs_add_std_root(server_name, root_share, comment: '')
         netr_dfs_add_std_root_request = NetrDfsAddStdRootRequest.new(
           server_name: server_name,
           root_share: root_share,
-          comment: comment,
-          api_flags: api_flags
+          comment: comment
         )
         response = dcerpc_request(netr_dfs_add_std_root_request)
         begin
@@ -39,11 +48,19 @@ module RubySMB
         nil
       end
 
-      def netr_dfs_remove_std_root(server_name, root_share, api_flags: 0)
+      # Delete the specified stand-alone DFS namespace.
+      #
+      # @param server_name [String] The host name of the DFS root target.
+      # @param root_share [String] The DFS root target share name.
+      # @return nothing is returned on success
+      # @raise [RubySMB::Dcerpc::Error::InvalidPacket] if the response is not a
+      #   NetrDfsRemoveStdRootResponse packet
+      # @raise [RubySMB::Dcerpc::Error::DfsnmError] if the response error status
+      #   is not ERROR_SUCCESS
+      def netr_dfs_remove_std_root(server_name, root_share)
         netr_dfs_remove_std_root_request = NetrDfsRemoveStdRootRequest.new(
           server_name: server_name,
-          root_share: root_share,
-          api_flags: api_flags
+          root_share: root_share
         )
         response = dcerpc_request(netr_dfs_remove_std_root_request)
         begin

--- a/lib/ruby_smb/dcerpc/dfsnm.rb
+++ b/lib/ruby_smb/dcerpc/dfsnm.rb
@@ -3,7 +3,7 @@ module RubySMB
     module Dfsnm
 
       UUID = '4fc742e0-4a10-11cf-8273-00aa004ae673'
-      VER_MAJOR = 1
+      VER_MAJOR = 3
       VER_MINOR = 0
 
       # Operation numbers
@@ -15,11 +15,12 @@ module RubySMB
       require 'ruby_smb/dcerpc/dfsnm/netr_dfs_remove_std_root_request'
       require 'ruby_smb/dcerpc/dfsnm/netr_dfs_remove_std_root_response'
 
-      def netr_dfs_add_std_root(server_name, root_share, comment: nil)
+      def netr_dfs_add_std_root(server_name, root_share, comment: '', api_flags: 0)
         netr_dfs_add_std_root_request = NetrDfsAddStdRootRequest.new(
           server_name: server_name,
           root_share: root_share,
-          comment: comment
+          comment: comment,
+          api_flags: api_flags
         )
         response = dcerpc_request(netr_dfs_add_std_root_request)
         begin
@@ -27,20 +28,22 @@ module RubySMB
         rescue IOError
           raise RubySMB::Dcerpc::Error::InvalidPacket, 'Error reading NetrDfsAddStdRootResponse'
         end
-        unless netr_dfs_add_std_root_response.error_status == WindowsError::NTStatus::STATUS_SUCCESS
-          raise RubySMB::Dcerpc::Error::DfsnmError,
+        unless netr_dfs_add_std_root_response.error_status == WindowsError::Win32::ERROR_SUCCESS
+          raise RubySMB::Dcerpc::Error::DfsnmError.new(
             "Error returned with netr_dfs_add_std_root: "\
-            "#{WindowsError::NTStatus.find_by_retval(netr_dfs_add_std_root_response.error_status.value).join(',')}",
+            "#{WindowsError::Win32.find_by_retval(netr_dfs_add_std_root_response.error_status.value).join(',')}",
             error_status: netr_dfs_add_std_root_response.error_status.value
+          )
         end
 
         nil
       end
 
-      def netr_dfs_remove_std_root(server_name, root_share)
+      def netr_dfs_remove_std_root(server_name, root_share, api_flags: 0)
         netr_dfs_remove_std_root_request = NetrDfsRemoveStdRootRequest.new(
           server_name: server_name,
-          root_share: root_share
+          root_share: root_share,
+          api_flags: api_flags
         )
         response = dcerpc_request(netr_dfs_remove_std_root_request)
         begin
@@ -48,11 +51,12 @@ module RubySMB
         rescue IOError
           raise RubySMB::Dcerpc::Error::InvalidPacket, 'Error reading NetrDfsRemoveStdRootResponse'
         end
-        unless netr_dfs_remove_std_root_response.error_status == WindowsError::NTStatus::STATUS_SUCCESS
-          raise RubySMB::Dcerpc::Error::DfsnmError,
+        unless netr_dfs_remove_std_root_response.error_status == WindowsError::Win32::ERROR_SUCCESS
+          raise RubySMB::Dcerpc::Error::DfsnmError.new(
             "Error returned with netr_dfs_remove_std_root: "\
-            "#{WindowsError::NTStatus.find_by_retval(netr_dfs_remove_std_root_response.error_status.value).join(',')}",
+            "#{WindowsError::Win32.find_by_retval(netr_dfs_remove_std_root_response.error_status.value).join(',')}",
             error_status: netr_dfs_remove_std_root_response.error_status.value
+          )
         end
 
         nil

--- a/lib/ruby_smb/dcerpc/dfsnm.rb
+++ b/lib/ruby_smb/dcerpc/dfsnm.rb
@@ -38,10 +38,10 @@ module RubySMB
           raise RubySMB::Dcerpc::Error::InvalidPacket, 'Error reading NetrDfsAddStdRootResponse'
         end
         unless netr_dfs_add_std_root_response.error_status == WindowsError::Win32::ERROR_SUCCESS
+          status_code = WindowsError::Win32.find_by_retval(netr_dfs_add_std_root_response.error_status.value).first
           raise RubySMB::Dcerpc::Error::DfsnmError.new(
-            "Error returned with netr_dfs_add_std_root: "\
-            "#{WindowsError::Win32.find_by_retval(netr_dfs_add_std_root_response.error_status.value).join(',')}",
-            error_status: netr_dfs_add_std_root_response.error_status.value
+            "Error returned with netr_dfs_add_std_root: #{status_code}",
+            status_code: status_code
           )
         end
 
@@ -69,10 +69,10 @@ module RubySMB
           raise RubySMB::Dcerpc::Error::InvalidPacket, 'Error reading NetrDfsRemoveStdRootResponse'
         end
         unless netr_dfs_remove_std_root_response.error_status == WindowsError::Win32::ERROR_SUCCESS
+          status_code = WindowsError::Win32.find_by_retval(netr_dfs_remove_std_root_response.error_status.value).first
           raise RubySMB::Dcerpc::Error::DfsnmError.new(
-            "Error returned with netr_dfs_remove_std_root: "\
-            "#{WindowsError::Win32.find_by_retval(netr_dfs_remove_std_root_response.error_status.value).join(',')}",
-            error_status: netr_dfs_remove_std_root_response.error_status.value
+            "Error returned with netr_dfs_remove_std_root: #{status_code}",
+            status_code: status_code
           )
         end
 

--- a/lib/ruby_smb/dcerpc/dfsnm.rb
+++ b/lib/ruby_smb/dcerpc/dfsnm.rb
@@ -1,0 +1,61 @@
+module RubySMB
+  module Dcerpc
+    module Dfsnm
+
+      UUID = '4fc742e0-4a10-11cf-8273-00aa004ae673'
+      VER_MAJOR = 1
+      VER_MINOR = 0
+
+      # Operation numbers
+      NETR_DFS_ADD_STD_ROOT    = 0x000c
+      NETR_DFS_REMOVE_STD_ROOT = 0x000d
+
+      require 'ruby_smb/dcerpc/dfsnm/netr_dfs_add_std_root_request'
+      require 'ruby_smb/dcerpc/dfsnm/netr_dfs_add_std_root_response'
+      require 'ruby_smb/dcerpc/dfsnm/netr_dfs_remove_std_root_request'
+      require 'ruby_smb/dcerpc/dfsnm/netr_dfs_remove_std_root_response'
+
+      def netr_dfs_add_std_root(server_name, root_share, comment: nil)
+        netr_dfs_add_std_root_request = NetrDfsAddStdRootRequest.new(
+          server_name: server_name,
+          root_share: root_share,
+          comment: comment
+        )
+        response = dcerpc_request(netr_dfs_add_std_root_request)
+        begin
+          netr_dfs_add_std_root_response = NetrDfsAddStdRootResponse.read(response)
+        rescue IOError
+          raise RubySMB::Dcerpc::Error::InvalidPacket, 'Error reading NetrDfsAddStdRootResponse'
+        end
+        unless netr_dfs_add_std_root_response.error_status == WindowsError::NTStatus::STATUS_SUCCESS
+          raise RubySMB::Dcerpc::Error::SamrError,
+            "Error returned with netr_dfs_add_std_root: "\
+            "#{WindowsError::NTStatus.find_by_retval(netr_dfs_add_std_root_response.error_status.value).join(',')}"
+        end
+
+        nil
+      end
+
+      def netr_dfs_remove_std_root(server_name, root_share)
+        netr_dfs_remove_std_root_request = NetrDfsRemoveStdRootRequest.new(
+          server_name: server_name,
+          root_share: root_share
+        )
+        response = dcerpc_request(netr_dfs_remove_std_root_request)
+        begin
+          netr_dfs_remove_std_root_response = NetrDfsRemoveStdRootResponse.read(response)
+        rescue IOError
+          raise RubySMB::Dcerpc::Error::InvalidPacket, 'Error reading NetrDfsRemoveStdRootResponse'
+        end
+        unless netr_dfs_remove_std_root_response.error_status == WindowsError::NTStatus::STATUS_SUCCESS
+          raise RubySMB::Dcerpc::Error::SamrError,
+            "Error returned with netr_dfs_remove_std_root: "\
+            "#{WindowsError::NTStatus.find_by_retval(netr_dfs_remove_std_root_response.error_status.value).join(',')}"
+        end
+
+        nil
+      end
+
+    end
+  end
+end

--- a/lib/ruby_smb/dcerpc/dfsnm.rb
+++ b/lib/ruby_smb/dcerpc/dfsnm.rb
@@ -28,9 +28,10 @@ module RubySMB
           raise RubySMB::Dcerpc::Error::InvalidPacket, 'Error reading NetrDfsAddStdRootResponse'
         end
         unless netr_dfs_add_std_root_response.error_status == WindowsError::NTStatus::STATUS_SUCCESS
-          raise RubySMB::Dcerpc::Error::SamrError,
+          raise RubySMB::Dcerpc::Error::DfsnmError,
             "Error returned with netr_dfs_add_std_root: "\
-            "#{WindowsError::NTStatus.find_by_retval(netr_dfs_add_std_root_response.error_status.value).join(',')}"
+            "#{WindowsError::NTStatus.find_by_retval(netr_dfs_add_std_root_response.error_status.value).join(',')}",
+            error_status: netr_dfs_add_std_root_response.error_status.value
         end
 
         nil
@@ -48,9 +49,10 @@ module RubySMB
           raise RubySMB::Dcerpc::Error::InvalidPacket, 'Error reading NetrDfsRemoveStdRootResponse'
         end
         unless netr_dfs_remove_std_root_response.error_status == WindowsError::NTStatus::STATUS_SUCCESS
-          raise RubySMB::Dcerpc::Error::SamrError,
+          raise RubySMB::Dcerpc::Error::DfsnmError,
             "Error returned with netr_dfs_remove_std_root: "\
-            "#{WindowsError::NTStatus.find_by_retval(netr_dfs_remove_std_root_response.error_status.value).join(',')}"
+            "#{WindowsError::NTStatus.find_by_retval(netr_dfs_remove_std_root_response.error_status.value).join(',')}",
+            error_status: netr_dfs_remove_std_root_response.error_status.value
         end
 
         nil

--- a/lib/ruby_smb/dcerpc/dfsnm/netr_dfs_add_std_root_request.rb
+++ b/lib/ruby_smb/dcerpc/dfsnm/netr_dfs_add_std_root_request.rb
@@ -8,10 +8,10 @@ module RubySMB
 
         endian :little
 
-        ndr_wide_string_ptr :server_name
-        ndr_wide_string_ptr :root_share
-        ndr_wide_string_ptr :comment
-        ndr_uint32          :api_flags
+        ndr_conf_var_wide_stringz :server_name
+        ndr_conf_var_wide_stringz :root_share
+        ndr_conf_var_wide_stringz :comment
+        ndr_uint32                :api_flags
 
         def initialize_instance
           super

--- a/lib/ruby_smb/dcerpc/dfsnm/netr_dfs_add_std_root_request.rb
+++ b/lib/ruby_smb/dcerpc/dfsnm/netr_dfs_add_std_root_request.rb
@@ -1,0 +1,24 @@
+module RubySMB
+  module Dcerpc
+    module Dfsnm
+
+      # [3.1.4.4.1 NetrDfsAddStdRoot (Opnum 12)](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-dfsnm/b18ef17a-7a9c-4e22-b1bf-6a4d07e87b2d)
+      class NetrDfsAddStdRootRequest < BinData::Record
+        attr_reader :opnum
+
+        endian :little
+
+        ndr_wide_string_ptr :server_name
+        ndr_wide_string_ptr :root_share
+        ndr_wide_string_ptr :comment
+        ndr_uint32          :api_flags
+
+        def initialize_instance
+          super
+          @opnum = NETR_DFS_ADD_STD_ROOT
+        end
+      end
+
+    end
+  end
+end

--- a/lib/ruby_smb/dcerpc/dfsnm/netr_dfs_add_std_root_response.rb
+++ b/lib/ruby_smb/dcerpc/dfsnm/netr_dfs_add_std_root_response.rb
@@ -1,0 +1,21 @@
+module RubySMB
+  module Dcerpc
+    module Dfsnm
+
+      # [3.1.4.4.1 NetrDfsAddStdRoot (Opnum 12)](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-dfsnm/b18ef17a-7a9c-4e22-b1bf-6a4d07e87b2d)
+      class NetrDfsAddStdRootResponse < BinData::Record
+        attr_reader :opnum
+
+        endian :little
+
+        ndr_uint32 :error_status
+
+        def initialize_instance
+          super
+          @opnum = NETR_DFS_ADD_STD_ROOT
+        end
+      end
+
+    end
+  end
+end

--- a/lib/ruby_smb/dcerpc/dfsnm/netr_dfs_remove_std_root_request.rb
+++ b/lib/ruby_smb/dcerpc/dfsnm/netr_dfs_remove_std_root_request.rb
@@ -8,9 +8,9 @@ module RubySMB
 
         endian :little
 
-        ndr_wide_string_ptr :server_name
-        ndr_wide_string_ptr :root_share
-        ndr_uint32          :api_flags
+        ndr_conf_var_wide_stringz :server_name
+        ndr_conf_var_wide_stringz :root_share
+        ndr_uint32                :api_flags
 
         def initialize_instance
           super

--- a/lib/ruby_smb/dcerpc/dfsnm/netr_dfs_remove_std_root_request.rb
+++ b/lib/ruby_smb/dcerpc/dfsnm/netr_dfs_remove_std_root_request.rb
@@ -1,0 +1,23 @@
+module RubySMB
+  module Dcerpc
+    module Dfsnm
+
+      # [3.1.4.4.2 NetrDfsRemoveStdRoot (Opnum 13)](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-dfsnm/e9da023d-554a-49bc-837a-69f22d59fd18)
+      class NetrDfsRemoveStdRootRequest < BinData::Record
+        attr_reader :opnum
+
+        endian :little
+
+        ndr_wide_string_ptr :server_name
+        ndr_wide_string_ptr :root_share
+        ndr_uint32          :api_flags
+
+        def initialize_instance
+          super
+          @opnum = NETR_DFS_REMOVE_STD_ROOT
+        end
+      end
+
+    end
+  end
+end

--- a/lib/ruby_smb/dcerpc/dfsnm/netr_dfs_remove_std_root_response.rb
+++ b/lib/ruby_smb/dcerpc/dfsnm/netr_dfs_remove_std_root_response.rb
@@ -3,7 +3,7 @@ module RubySMB
     module Dfsnm
 
       # [3.1.4.4.2 NetrDfsRemoveStdRoot (Opnum 13)](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-dfsnm/e9da023d-554a-49bc-837a-69f22d59fd18)
-      class NetrDfsRemoveStdRootResponse< BinData::Record
+      class NetrDfsRemoveStdRootResponse < BinData::Record
         attr_reader :opnum
 
         endian :little

--- a/lib/ruby_smb/dcerpc/dfsnm/netr_dfs_remove_std_root_response.rb
+++ b/lib/ruby_smb/dcerpc/dfsnm/netr_dfs_remove_std_root_response.rb
@@ -1,0 +1,21 @@
+module RubySMB
+  module Dcerpc
+    module Dfsnm
+
+      # [3.1.4.4.2 NetrDfsRemoveStdRoot (Opnum 13)](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-dfsnm/e9da023d-554a-49bc-837a-69f22d59fd18)
+      class NetrDfsRemoveStdRootResponse< BinData::Record
+        attr_reader :opnum
+
+        endian :little
+
+        ndr_uint32 :error_status
+
+        def initialize_instance
+          super
+          @opnum = NETR_DFS_REMOVE_STD_ROOT
+        end
+      end
+
+    end
+  end
+end

--- a/lib/ruby_smb/dcerpc/error.rb
+++ b/lib/ruby_smb/dcerpc/error.rb
@@ -46,6 +46,15 @@ module RubySMB
 
       # Raised when an error is returned during a Epm operation
       class EpmError < DcerpcError; end
+
+      # Raised when an error is returned during a Dfsnm operation
+      class DfsnmError < DcerpcError
+        attr_accessor :error_status
+        def initialize(msg, error_status: nil)
+          @error_status = error_status
+          super
+        end
+      end
     end
   end
 end

--- a/lib/ruby_smb/dcerpc/error.rb
+++ b/lib/ruby_smb/dcerpc/error.rb
@@ -49,9 +49,11 @@ module RubySMB
 
       # Raised when an error is returned during a Dfsnm operation
       class DfsnmError < DcerpcError
-        attr_accessor :error_status
-        def initialize(msg, error_status: nil)
-          @error_status = error_status
+        include RubySMB::Error::UnexpectedStatusCode::Mixin
+
+        def initialize(msg, status_code: nil)
+          self.status_code = status_code unless status_code.nil?
+
           super(msg)
         end
       end

--- a/lib/ruby_smb/dcerpc/error.rb
+++ b/lib/ruby_smb/dcerpc/error.rb
@@ -52,7 +52,7 @@ module RubySMB
         attr_accessor :error_status
         def initialize(msg, error_status: nil)
           @error_status = error_status
-          super
+          super(msg)
         end
       end
     end

--- a/lib/ruby_smb/dcerpc/request.rb
+++ b/lib/ruby_smb/dcerpc/request.rb
@@ -90,7 +90,12 @@ module RubySMB
           drs_domain_controller_info_request Drsr::DRS_DOMAIN_CONTROLLER_INFO
           drs_crack_names_request            Drsr::DRS_CRACK_NAMES
           drs_get_nc_changes_request         Drsr::DRS_GET_NC_CHANGES
-          string                      :default
+          string                             :default
+        end
+        choice 'Dfsnm', selection: -> { opnum } do
+          netr_dfs_add_std_root_request    Dfsnm::NETR_DFS_ADD_STD_ROOT
+          netr_dfs_remove_std_root_request Dfsnm::NETR_DFS_REMOVE_STD_ROOT
+          string                           :default
         end
         string :default
       end

--- a/lib/ruby_smb/smb1/pipe.rb
+++ b/lib/ruby_smb/smb1/pipe.rb
@@ -28,6 +28,8 @@ module RubySMB
           extend RubySMB::Dcerpc::Samr
         when 'wkssvc', '\\wkssvc'
           extend RubySMB::Dcerpc::Wkssvc
+        when 'netdfs', '\\netdfs'
+          extend RubySMB::Dcerpc::Dfsnm
         end
         super(tree: tree, response: response, name: name)
       end

--- a/lib/ruby_smb/smb2/pipe.rb
+++ b/lib/ruby_smb/smb2/pipe.rb
@@ -25,6 +25,8 @@ module RubySMB
           extend RubySMB::Dcerpc::Samr
         when 'wkssvc', '\\wkssvc'
           extend RubySMB::Dcerpc::Wkssvc
+        when 'netdfs', '\\netdfs'
+          extend RubySMB::Dcerpc::Dfsnm
         end
         super(tree: tree, response: response, name: name)
       end

--- a/spec/lib/ruby_smb/dcerpc/dfsnm/netr_dfs_add_std_root_request_spec.rb
+++ b/spec/lib/ruby_smb/dcerpc/dfsnm/netr_dfs_add_std_root_request_spec.rb
@@ -1,0 +1,57 @@
+RSpec.describe RubySMB::Dcerpc::Dfsnm::NetrDfsAddStdRootRequest do
+  subject(:packet) { described_class.new }
+
+  it { is_expected.to respond_to :server_name }
+  it { is_expected.to respond_to :root_share }
+  it { is_expected.to respond_to :comment }
+  it { is_expected.to respond_to :api_flags }
+  it { is_expected.to respond_to :opnum }
+
+  it 'is little endian' do
+    expect(described_class.fields.instance_variable_get(:@hints)[:endian]).to eq :little
+  end
+  it 'is a BinData::Record' do
+    expect(packet).to be_a(BinData::Record)
+  end
+  describe '#server_name' do
+    it 'is a NdrConfVarWideStringz structure' do
+      expect(packet.server_name).to be_a RubySMB::Dcerpc::Ndr::NdrConfVarWideStringz
+    end
+  end
+  describe '#root_share' do
+    it 'is a NdrConfVarWideStringz structure' do
+      expect(packet.root_share).to be_a RubySMB::Dcerpc::Ndr::NdrConfVarWideStringz
+    end
+  end
+  describe '#comment' do
+    it 'is a NdrConfVarWideStringz structure' do
+      expect(packet.comment).to be_a RubySMB::Dcerpc::Ndr::NdrConfVarWideStringz
+    end
+  end
+  describe '#api_flags' do
+    it 'is a NdrUint32 structure' do
+      expect(packet.api_flags).to be_a RubySMB::Dcerpc::Ndr::NdrUint32
+    end
+  end
+  describe '#initialize_instance' do
+    it 'sets #opnum to NETR_DFS_ADD_STD_ROOT constant' do
+      expect(packet.opnum).to eq(RubySMB::Dcerpc::Dfsnm::NETR_DFS_ADD_STD_ROOT)
+    end
+  end
+  it 'reads itself' do
+    new_packet = described_class.new({
+      server_name: 'serverName',
+      root_share: 'rootShare',
+      comment: 'comment'
+    })
+    expected_output = {
+      server_name: 'serverName'.encode('utf-16le'),
+      root_share: 'rootShare'.encode('utf-16le'),
+      comment: 'comment'.encode('utf-16le'),
+      api_flags: 0
+    }
+    expect(packet.read(new_packet.to_binary_s)).to eq(expected_output)
+  end
+end
+
+

--- a/spec/lib/ruby_smb/dcerpc/dfsnm/netr_dfs_add_std_root_response_spec.rb
+++ b/spec/lib/ruby_smb/dcerpc/dfsnm/netr_dfs_add_std_root_response_spec.rb
@@ -1,0 +1,34 @@
+RSpec.describe RubySMB::Dcerpc::Dfsnm::NetrDfsAddStdRootResponse do
+  subject(:packet) { described_class.new }
+
+  it { is_expected.to respond_to :error_status }
+  it { is_expected.to respond_to :opnum }
+
+  it 'is little endian' do
+    expect(described_class.fields.instance_variable_get(:@hints)[:endian]).to eq :little
+  end
+  it 'is a BinData::Record' do
+    expect(packet).to be_a(BinData::Record)
+  end
+  describe '#error_status' do
+    it 'is a NdrUint32 structure' do
+      expect(packet.error_status).to be_a RubySMB::Dcerpc::Ndr::NdrUint32
+    end
+  end
+  describe '#initialize_instance' do
+    it 'sets #opnum to NETR_DFS_ADD_STD_ROOT constant' do
+      expect(packet.opnum).to eq(RubySMB::Dcerpc::Dfsnm::NETR_DFS_ADD_STD_ROOT)
+    end
+  end
+  it 'reads itself' do
+    new_packet = described_class.new({
+      error_status: 0
+    })
+    expected_output = {
+      error_status: 0
+    }
+    expect(packet.read(new_packet.to_binary_s)).to eq(expected_output)
+  end
+end
+
+

--- a/spec/lib/ruby_smb/dcerpc/dfsnm/netr_dfs_remove_std_root_request_spec.rb
+++ b/spec/lib/ruby_smb/dcerpc/dfsnm/netr_dfs_remove_std_root_request_spec.rb
@@ -1,0 +1,49 @@
+RSpec.describe RubySMB::Dcerpc::Dfsnm::NetrDfsRemoveStdRootRequest do
+  subject(:packet) { described_class.new }
+
+  it { is_expected.to respond_to :server_name }
+  it { is_expected.to respond_to :root_share }
+  it { is_expected.to respond_to :api_flags }
+  it { is_expected.to respond_to :opnum }
+
+  it 'is little endian' do
+    expect(described_class.fields.instance_variable_get(:@hints)[:endian]).to eq :little
+  end
+  it 'is a BinData::Record' do
+    expect(packet).to be_a(BinData::Record)
+  end
+  describe '#server_name' do
+    it 'is a NdrConfVarWideStringz structure' do
+      expect(packet.server_name).to be_a RubySMB::Dcerpc::Ndr::NdrConfVarWideStringz
+    end
+  end
+  describe '#root_share' do
+    it 'is a NdrConfVarWideStringz structure' do
+      expect(packet.root_share).to be_a RubySMB::Dcerpc::Ndr::NdrConfVarWideStringz
+    end
+  end
+  describe '#api_flags' do
+    it 'is a NdrUint32 structure' do
+      expect(packet.api_flags).to be_a RubySMB::Dcerpc::Ndr::NdrUint32
+    end
+  end
+  describe '#initialize_instance' do
+    it 'sets #opnum to NETR_DFS_REMOVE_STD_ROOT constant' do
+      expect(packet.opnum).to eq(RubySMB::Dcerpc::Dfsnm::NETR_DFS_REMOVE_STD_ROOT)
+    end
+  end
+  it 'reads itself' do
+    new_packet = described_class.new({
+      server_name: 'serverName',
+      root_share: 'rootShare',
+    })
+    expected_output = {
+      server_name: 'serverName'.encode('utf-16le'),
+      root_share: 'rootShare'.encode('utf-16le'),
+      api_flags: 0
+    }
+    expect(packet.read(new_packet.to_binary_s)).to eq(expected_output)
+  end
+end
+
+

--- a/spec/lib/ruby_smb/dcerpc/dfsnm/netr_dfs_remove_std_root_response_spec.rb
+++ b/spec/lib/ruby_smb/dcerpc/dfsnm/netr_dfs_remove_std_root_response_spec.rb
@@ -1,0 +1,34 @@
+RSpec.describe RubySMB::Dcerpc::Dfsnm::NetrDfsRemoveStdRootResponse do
+  subject(:packet) { described_class.new }
+
+  it { is_expected.to respond_to :error_status }
+  it { is_expected.to respond_to :opnum }
+
+  it 'is little endian' do
+    expect(described_class.fields.instance_variable_get(:@hints)[:endian]).to eq :little
+  end
+  it 'is a BinData::Record' do
+    expect(packet).to be_a(BinData::Record)
+  end
+  describe '#error_status' do
+    it 'is a NdrUint32 structure' do
+      expect(packet.error_status).to be_a RubySMB::Dcerpc::Ndr::NdrUint32
+    end
+  end
+  describe '#initialize_instance' do
+    it 'sets #opnum to NETR_DFS_REMOVE_STD_ROOT constant' do
+      expect(packet.opnum).to eq(RubySMB::Dcerpc::Dfsnm::NETR_DFS_REMOVE_STD_ROOT)
+    end
+  end
+  it 'reads itself' do
+    new_packet = described_class.new({
+      error_status: 0
+    })
+    expected_output = {
+      error_status: 0
+    }
+    expect(packet.read(new_packet.to_binary_s)).to eq(expected_output)
+  end
+end
+
+


### PR DESCRIPTION
This adds the MS-DFSNM definitions and functions to implement the Dfscoerce attack which is similar to petitpotam.

# Testing
- [x] Make sure the unit tests pass
- [x] Use the Metasploit module with both `METHOD` options (one for each function implemented here)

Looking through the documentation for [NetrDfsAddStdRoot](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-dfsnm/b18ef17a-7a9c-4e22-b1bf-6a4d07e87b2d), I was unable to get the function to work with a nil / null pointer comment. From what I can tell the comment *must* be specified as a string. Also the parameter types are all marked as `WCHAR*` but the invocation fails when the types are defined as `ndr_wide_stringz_ptr`. 