### PR TITLE
Run Ubuntu 22.04 in test matrix

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,5 +1,21 @@
 name: Verify
 
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
+permissions:
+  actions: none
+  checks: none
+  contents: none
+  deployments: none
+  id-token: none
+  issues: none
+  discussions: none
+  packages: none
+  pages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: none
+
 on:
   push:
     branches:
@@ -10,7 +26,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 40
 
     strategy:
@@ -19,15 +35,22 @@ jobs:
         ruby:
           - 2.6
           - 2.7
-          - 3.0.3
-          - 3.1.1
+          - 3.0
+          - 3.1
+        os:
+          - ubuntu-18.04
+          - ubuntu-22.04
+        exclude:
+          - { os: ubuntu-22.04, ruby: 2.6 }
+          - { os: ubuntu-22.04, ruby: 2.7 }
+          - { os: ubuntu-22.04, ruby: 3.0 }
         test_cmd:
           - bundle exec rspec
 
     env:
       RAILS_ENV: test
 
-    name: Ruby ${{ matrix.ruby }} - ${{ matrix.test_cmd }}
+    name: ${{ matrix.os }} - Ruby ${{ matrix.ruby }} - ${{ matrix.test_cmd }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # RubySMB
 
 [![Code Climate](https://codeclimate.com/github/rapid7/ruby_smb.png)](https://codeclimate.com/github/rapid7/ruby_smb)
-[![Coverage Status](https://coveralls.io/repos/github/rapid7/ruby_smb/badge.svg?branch=master)](https://coveralls.io/github/rapid7/ruby_smb?branch=master)
 
 This is a native Ruby implementation of the SMB Protocol Family. It currently supports:
 

--- a/lib/ruby_smb/signing.rb
+++ b/lib/ruby_smb/signing.rb
@@ -12,8 +12,8 @@ module RubySMB
     # @param [RubySMB::GenericPacket] packet The packet to sign.
     # @return [RubySMB::GenericPacket] the signed packet
     def smb1_sign(packet)
-      packet = Signing::smb1_sign(packet, @session_key, @sequence_counter)
-      @sequence_counter += 1
+      packet = Signing::smb1_sign(packet, session_key, sequence_counter)
+      self.sequence_counter += 1
 
       packet
     end
@@ -41,7 +41,7 @@ module RubySMB
     # @param [RubySMB::GenericPacket] packet The packet to sign.
     # @return [RubySMB::GenericPacket] the signed packet
     def smb2_sign(packet)
-      Signing::smb2_sign(packet, @session_key)
+      Signing::smb2_sign(packet, session_key)
     end
 
     # Take an SMB2 packet and sign it. This version is a module function that
@@ -51,6 +51,8 @@ module RubySMB
     # @param [String] session_key The key to use for signing.
     # @return [RubySMB::GenericPacket] the signed packet
     def self.smb2_sign(packet, session_key)
+      return packet if session_key.nil? || session_key == ''
+
       packet.smb2_header.flags.signed = 1
       packet.smb2_header.signature = "\x00" * 16
       hmac = OpenSSL::HMAC.digest(OpenSSL::Digest.new('SHA256'), session_key, packet.to_binary_s)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,18 +1,16 @@
+# Enable legacy providers
+ENV['OPENSSL_CONF'] = File.expand_path(
+  File.join(File.dirname(__FILE__), 'support', 'openssl.conf')
+)
+
 require 'simplecov'
 
 SimpleCov.start unless SimpleCov.running
 SimpleCov.add_filter '/spec/'
 
-require 'coveralls'
 require 'ruby_smb'
 
-if ENV['CI'] == 'true'
-  # don't generate local report as it is inaccessible on travis-ci, which is
-  # why coveralls is being used.
-  SimpleCov.formatter = Coveralls::SimpleCov::Formatter
-else
-  SimpleCov.formatter = SimpleCov::Formatter::HTMLFormatter
-end
+SimpleCov.formatter = SimpleCov::Formatter::HTMLFormatter
 
 Dir['./spec/support/**/*.rb'].sort.each { |f| require f }
 

--- a/spec/support/openssl.conf
+++ b/spec/support/openssl.conf
@@ -1,0 +1,14 @@
+openssl_conf = openssl_init
+
+[openssl_init]
+providers = provider_sect
+
+[provider_sect]
+default = default_sect
+legacy = legacy_sect
+
+[default_sect]
+activate = 1
+
+[legacy_sect]
+activate = 1


### PR DESCRIPTION
Relates to https://github.com/rapid7/metasploit-framework/issues/16818

Let's run Ubuntu 22.04 in our test matrix, to catch any OpenSSL v3 regression issues

Behind the scenes this depended on two changes to dependencies:
- https://github.com/SmallLars/openssl-ccm/pull/10
- https://github.com/SmallLars/openssl-cmac/pull/5

Currently not a blocker to this particular PR - but additional changes to RubyNTLM will be required. Such as:
- https://github.com/WinRb/rubyntlm/pull/51
- https://github.com/WinRb/rubyntlm/pull/53

## Verification

- Code review
- Verify CI passes