### PR TITLE
Use the correct TREE_CONNECT Response access mask

### DIFF
--- a/lib/ruby_smb/smb2/packet/tree_connect_response.rb
+++ b/lib/ruby_smb/smb2/packet/tree_connect_response.rb
@@ -21,7 +21,11 @@ module RubySMB
         uint8                 :reserved,       label: 'Reserved Space', initial_value: 0x00
         share_flags           :share_flags
         share_capabilities    :capabilities
-        file_access_mask      :maximal_access, label: 'Maximal Access'
+        choice                :maximal_access, label: 'Maximal Access', selection: -> { share_type } do
+          file_access_mask      SMB2_SHARE_TYPE_PIPE
+          file_access_mask      SMB2_SHARE_TYPE_PRINT
+          directory_access_mask SMB2_SHARE_TYPE_DISK
+        end
 
         def initialize_instance
           super


### PR DESCRIPTION
Fixes https://github.com/rapid7/metasploit-framework/issues/16745

A wrong structure was used for the `:maximal_access` field of a TREE_CONNECT Response. Before this fix, a `file_access_mask` was used even for disk directory shares. Now, the structure sets either a `file_access_mask` or a `directory_access_mask` according to the share type.

This can be tested using Metasploit `auxiliary/scanner/smb/smb_login` module, as described in https://github.com/rapid7/metasploit-framework/issues/16745. This module checks the Tree `add_file` permission on the `ADMIN$` share is set to detect if the user has Administrator level. The `add_file` field only exists in `directory_access_mask`, which was failing before since `file_access_mask` was returned by the TREE_CONNECT Response.

### Before
The module successfully login with the Administrator credentials but does not report it with Administrator access level:
```
msf6 auxiliary(scanner/smb/smb_login) > run SMBUser=Administrator SMBPass=123456 RHOSTS=10.0.0.22 verbose=true

[*] 10.0.0.22:445   - 10.0.0.22:445 - Starting SMB login bruteforce
[+] 10.0.0.22:445   - 10.0.0.22:445 - Success: '.\Administrator:123456'
[*] 10.0.0.22:445   - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

### After
Now, it is reported with the Administrator access level:
```
msf6 auxiliary(scanner/smb/smb_login) > run SMBUser=Administrator SMBPass=123456 RHOSTS=10.0.0.22 verbose=true

[*] 10.0.0.22:445   - 10.0.0.22:445 - Starting SMB login bruteforce
[+] 10.0.0.22:445   - 10.0.0.22:445 - Success: '.\Administrator:123456' Administrator
[*] 10.0.0.22:445   - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```
