### PR TITLE
Fix encoding issue with non-ASCII characters

### DIFF
--- a/lib/ruby_smb.rb
+++ b/lib/ruby_smb.rb
@@ -30,4 +30,5 @@ module RubySMB
   require 'ruby_smb/server'
   require 'ruby_smb/dialect'
   require 'ruby_smb/smb_error'
+  require 'ruby_smb/utils'
 end

--- a/lib/ruby_smb.rb
+++ b/lib/ruby_smb.rb
@@ -6,6 +6,7 @@ require 'openssl/ccm'
 require 'openssl/cmac'
 require 'windows_error'
 require 'windows_error/nt_status'
+require 'ruby_smb/ntlm/custom/ntlm'
 # A packet parsing and manipulation library for the SMB1 and SMB2 protocols
 #
 # [[MS-SMB] Server Message Block (SMB) Protocol Version 1](https://msdn.microsoft.com/en-us/library/cc246482.aspx)

--- a/lib/ruby_smb.rb
+++ b/lib/ruby_smb.rb
@@ -11,6 +11,7 @@ require 'windows_error/nt_status'
 # [[MS-SMB] Server Message Block (SMB) Protocol Version 1](https://msdn.microsoft.com/en-us/library/cc246482.aspx)
 # [[MS-SMB2] Server Message Block (SMB) Protocol Versions 2 and 3](https://msdn.microsoft.com/en-us/library/cc246482.aspx)
 module RubySMB
+  require 'ruby_smb/utils'
   require 'ruby_smb/error'
   require 'ruby_smb/create_actions'
   require 'ruby_smb/dispositions'
@@ -30,5 +31,4 @@ module RubySMB
   require 'ruby_smb/server'
   require 'ruby_smb/dialect'
   require 'ruby_smb/smb_error'
-  require 'ruby_smb/utils'
 end

--- a/lib/ruby_smb/client.rb
+++ b/lib/ruby_smb/client.rb
@@ -14,7 +14,6 @@ module RubySMB
     require 'ruby_smb/client/encryption'
 
     include RubySMB::Signing
-    include RubySMB::Utils
     include RubySMB::NTLM
     include RubySMB::Client::Negotiation
     include RubySMB::Client::Authentication
@@ -325,7 +324,7 @@ module RubySMB
       @pid               = rand(0xFFFF)
       @domain            = domain
       @local_workstation = local_workstation
-      @password          = safe_encode((password||''), 'utf-8')
+      @password          = RubySMB::Utils.safe_encode((password||''), 'utf-8')
       @sequence_counter  = 0
       @session_id        = 0x00
       @session_key       = ''
@@ -335,7 +334,7 @@ module RubySMB
       @smb1              = smb1
       @smb2              = smb2
       @smb3              = smb3
-      @username          = safe_encode((username||''), 'utf-8')
+      @username          = RubySMB::Utils.safe_encode((username||''), 'utf-8')
       @max_buffer_size   = MAX_BUFFER_SIZE
       # These sizes will be modified during negotiation
       @server_max_buffer_size = SERVER_MAX_BUFFER_SIZE
@@ -418,8 +417,8 @@ module RubySMB
                       local_workstation: self.local_workstation, ntlm_flags: NTLM::DEFAULT_CLIENT_FLAGS)
       @domain            = domain
       @local_workstation = local_workstation
-      @password          = safe_encode((pass||''), 'utf-8')
-      @username          = safe_encode((user||''), 'utf-8')
+      @password          = RubySMB::Utils.safe_encode((pass||''), 'utf-8')
+      @username          = RubySMB::Utils.safe_encode((user||''), 'utf-8')
 
       @ntlm_client = RubySMB::NTLM::Client.new(
           @username,

--- a/lib/ruby_smb/client.rb
+++ b/lib/ruby_smb/client.rb
@@ -4,6 +4,7 @@ module RubySMB
   class Client
     require 'ruby_smb/ntlm'
     require 'ruby_smb/signing'
+    require 'ruby_smb/utils'
     require 'ruby_smb/client/negotiation'
     require 'ruby_smb/client/authentication'
     require 'ruby_smb/client/tree_connect'
@@ -13,6 +14,8 @@ module RubySMB
     require 'ruby_smb/client/encryption'
 
     include RubySMB::Signing
+    include RubySMB::Utils
+    include RubySMB::NTLM
     include RubySMB::Client::Negotiation
     include RubySMB::Client::Authentication
     include RubySMB::Client::TreeConnect
@@ -322,7 +325,7 @@ module RubySMB
       @pid               = rand(0xFFFF)
       @domain            = domain
       @local_workstation = local_workstation
-      @password          = password.encode('utf-8') || ''.encode('utf-8')
+      @password          = safe_encode((password||''), 'utf-8')
       @sequence_counter  = 0
       @session_id        = 0x00
       @session_key       = ''
@@ -332,7 +335,7 @@ module RubySMB
       @smb1              = smb1
       @smb2              = smb2
       @smb3              = smb3
-      @username          = username.encode('utf-8') || ''.encode('utf-8')
+      @username          = safe_encode((username||''), 'utf-8')
       @max_buffer_size   = MAX_BUFFER_SIZE
       # These sizes will be modified during negotiation
       @server_max_buffer_size = SERVER_MAX_BUFFER_SIZE
@@ -415,8 +418,8 @@ module RubySMB
                       local_workstation: self.local_workstation, ntlm_flags: NTLM::DEFAULT_CLIENT_FLAGS)
       @domain            = domain
       @local_workstation = local_workstation
-      @password          = pass.encode('utf-8') || ''.encode('utf-8')
-      @username          = user.encode('utf-8') || ''.encode('utf-8')
+      @password          = safe_encode((pass||''), 'utf-8')
+      @username          = safe_encode((user||''), 'utf-8')
 
       @ntlm_client = RubySMB::NTLM::Client.new(
           @username,

--- a/lib/ruby_smb/dcerpc/client.rb
+++ b/lib/ruby_smb/dcerpc/client.rb
@@ -5,7 +5,7 @@ module RubySMB
     class Client
       require 'bindata'
       require 'windows_error'
-      require 'net/ntlm'
+      require 'ruby_smb/ntlm'
       require 'ruby_smb/dcerpc'
       require 'ruby_smb/gss'
       require 'ruby_smb/peer_info'
@@ -120,15 +120,15 @@ module RubySMB
         @read_timeout      = read_timeout
         @domain            = domain
         @local_workstation = local_workstation
-        @username          = safe_encode(username, 'utf-8')
-        @password          = safe_encode(password, 'utf-8')
+        @username          = RubySMB::Utils.safe_encode(username, 'utf-8')
+        @password          = RubySMB::Utils.safe_encode(password, 'utf-8')
         @max_buffer_size   = MAX_BUFFER_SIZE
         @call_id           = 1
         @ctx_id            = 0
         @auth_ctx_id_base  = rand(0xFFFFFFFF)
 
         unless username.empty? && password.empty?
-          @ntlm_client = Net::NTLM::Client.new(
+          @ntlm_client = RubySMB::NTLM::Client.new(
             @username,
             @password,
             workstation: @local_workstation,

--- a/lib/ruby_smb/dcerpc/client.rb
+++ b/lib/ruby_smb/dcerpc/client.rb
@@ -9,10 +9,12 @@ module RubySMB
       require 'ruby_smb/dcerpc'
       require 'ruby_smb/gss'
       require 'ruby_smb/peer_info'
+      require 'ruby_smb/utils'
 
       include Dcerpc
       include Epm
       include PeerInfo
+      include Utils
 
       # The default maximum size of a RPC message that the Client accepts (in bytes)
       MAX_BUFFER_SIZE = 64512
@@ -118,8 +120,8 @@ module RubySMB
         @read_timeout      = read_timeout
         @domain            = domain
         @local_workstation = local_workstation
-        @username          = username.encode('utf-8')
-        @password          = password.encode('utf-8')
+        @username          = safe_encode(username, 'utf-8')
+        @password          = safe_encode(password, 'utf-8')
         @max_buffer_size   = MAX_BUFFER_SIZE
         @call_id           = 1
         @ctx_id            = 0

--- a/lib/ruby_smb/dcerpc/icpr.rb
+++ b/lib/ruby_smb/dcerpc/icpr.rb
@@ -35,7 +35,7 @@ module RubySMB
       def cert_server_request(attributes:, authority:, csr:)
         cert_server_request_request = CertServerRequestRequest.new(
           pwsz_authority: authority,
-          pctb_attribs: { pb: (attributes.map { |k,v| "#{k}:#{v}" }.join("\n").encode('UTF-16le').force_encoding('ASCII-8bit') + "\x00\x00".b) },
+          pctb_attribs: { pb: (safe_encode(attributes.map { |k,v| "#{k}:#{v}" }.join("\n"), 'UTF-16le').force_encoding('ASCII-8bit') + "\x00\x00".b) },
           pctb_request: { pb: csr.to_der }
         )
 

--- a/lib/ruby_smb/dcerpc/icpr.rb
+++ b/lib/ruby_smb/dcerpc/icpr.rb
@@ -35,7 +35,7 @@ module RubySMB
       def cert_server_request(attributes:, authority:, csr:)
         cert_server_request_request = CertServerRequestRequest.new(
           pwsz_authority: authority,
-          pctb_attribs: { pb: (safe_encode(attributes.map { |k,v| "#{k}:#{v}" }.join("\n"), 'UTF-16le').force_encoding('ASCII-8bit') + "\x00\x00".b) },
+          pctb_attribs: { pb: (RubySMB::Utils.safe_encode(attributes.map { |k,v| "#{k}:#{v}" }.join("\n"), 'UTF-16le').force_encoding('ASCII-8bit') + "\x00\x00".b) },
           pctb_request: { pb: csr.to_der }
         )
 

--- a/lib/ruby_smb/dcerpc/samr.rb
+++ b/lib/ruby_smb/dcerpc/samr.rb
@@ -320,7 +320,7 @@ module RubySMB
 
         def self.encrypt_password(password, key)
           # see: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/5fe3c4c4-e71b-440d-b2fd-8448bfaf6e04
-          password = password.encode('UTF-16LE').force_encoding('ASCII-8bit')
+          password = safe_encode(password, 'UTF-16LE').force_encoding('ASCII-8bit')
           buffer = password.rjust(512, "\x00") + [ password.length ].pack('V')
           salt = SecureRandom.random_bytes(16)
           key = OpenSSL::Digest::MD5.new(salt + key).digest

--- a/lib/ruby_smb/dcerpc/samr.rb
+++ b/lib/ruby_smb/dcerpc/samr.rb
@@ -320,7 +320,7 @@ module RubySMB
 
         def self.encrypt_password(password, key)
           # see: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/5fe3c4c4-e71b-440d-b2fd-8448bfaf6e04
-          password = safe_encode(password, 'UTF-16LE').force_encoding('ASCII-8bit')
+          password = RubySMB::Utils.safe_encode(password, 'UTF-16LE').force_encoding('ASCII-8bit')
           buffer = password.rjust(512, "\x00") + [ password.length ].pack('V')
           salt = SecureRandom.random_bytes(16)
           key = OpenSSL::Digest::MD5.new(salt + key).digest

--- a/lib/ruby_smb/gss/provider/ntlm.rb
+++ b/lib/ruby_smb/gss/provider/ntlm.rb
@@ -141,7 +141,7 @@ module RubySMB
             case type3_msg.ntlm_version
             when :ntlmv1
               my_ntlm_response = Net::NTLM::ntlm_response(
-                ntlm_hash: Net::NTLM::ntlm_hash(account.password.encode('UTF-16LE'), unicode: true),
+                ntlm_hash: Net::NTLM::ntlm_hash(safe_encode(account.password, 'UTF-16LE'), unicode: true),
                 challenge: @server_challenge
               )
               matches = my_ntlm_response == type3_msg.ntlm_response
@@ -151,9 +151,9 @@ module RubySMB
               their_blob = type3_msg.ntlm_response[digest.digest_length..-1]
 
               ntlmv2_hash = Net::NTLM.ntlmv2_hash(
-                account.username.encode('UTF-16LE'),
-                account.password.encode('UTF-16LE'),
-                type3_msg.domain.encode('UTF-16LE'),  # don't use the account domain because of the special '.' value
+                safe_encode(account.username, 'UTF-16LE'),
+                safe_encode(account.password, 'UTF-16LE'),
+                safe_encode(type3_msg.domain, 'UTF-16LE'),  # don't use the account domain because of the special '.' value
                 {client_challenge: their_blob[16...24], unicode: true}
               )
 
@@ -305,7 +305,7 @@ module RubySMB
           username = username.downcase
           domain = @default_domain if domain.nil? || domain == '.'.encode(domain.encoding)
           domain = domain.downcase
-          @accounts.find { |account| account.username.encode(username.encoding).downcase == username && account.domain.encode(domain.encoding).downcase == domain }
+          @accounts.find { |account| safe_encode(account.username, username.encoding).downcase == username && safe_encode(account.domain, domain.encoding).downcase == domain }
         end
 
         #

--- a/lib/ruby_smb/gss/provider/ntlm.rb
+++ b/lib/ruby_smb/gss/provider/ntlm.rb
@@ -9,6 +9,7 @@ module RubySMB
       #
       class NTLM < Base
         include RubySMB::NTLM
+        include RubySMB::Utils
 
         # An account representing an identity for which this provider will accept authentication attempts.
         Account = Struct.new(:username, :password, :domain) do
@@ -18,6 +19,8 @@ module RubySMB
         end
 
         class Authenticator < Authenticator::Base
+          include RubySMB::Utils
+
           def reset!
             super
             @server_challenge = nil

--- a/lib/ruby_smb/gss/provider/ntlm.rb
+++ b/lib/ruby_smb/gss/provider/ntlm.rb
@@ -9,7 +9,6 @@ module RubySMB
       #
       class NTLM < Base
         include RubySMB::NTLM
-        include RubySMB::Utils
 
         # An account representing an identity for which this provider will accept authentication attempts.
         Account = Struct.new(:username, :password, :domain) do
@@ -19,7 +18,6 @@ module RubySMB
         end
 
         class Authenticator < Authenticator::Base
-          include RubySMB::Utils
 
           def reset!
             super
@@ -144,7 +142,10 @@ module RubySMB
             case type3_msg.ntlm_version
             when :ntlmv1
               my_ntlm_response = Net::NTLM::ntlm_response(
-                ntlm_hash: Net::NTLM::ntlm_hash(safe_encode(account.password, 'UTF-16LE'), unicode: true),
+                ntlm_hash: Net::NTLM::ntlm_hash(
+                  RubySMB::Utils.safe_encode(account.password, 'UTF-16LE'),
+                  unicode: true
+                ),
                 challenge: @server_challenge
               )
               matches = my_ntlm_response == type3_msg.ntlm_response
@@ -154,9 +155,9 @@ module RubySMB
               their_blob = type3_msg.ntlm_response[digest.digest_length..-1]
 
               ntlmv2_hash = Net::NTLM.ntlmv2_hash(
-                safe_encode(account.username, 'UTF-16LE'),
-                safe_encode(account.password, 'UTF-16LE'),
-                safe_encode(type3_msg.domain, 'UTF-16LE'),  # don't use the account domain because of the special '.' value
+                RubySMB::Utils.safe_encode(account.username, 'UTF-16LE'),
+                RubySMB::Utils.safe_encode(account.password, 'UTF-16LE'),
+                RubySMB::Utils.safe_encode(type3_msg.domain, 'UTF-16LE'),  # don't use the account domain because of the special '.' value
                 {client_challenge: their_blob[16...24], unicode: true}
               )
 
@@ -308,7 +309,10 @@ module RubySMB
           username = username.downcase
           domain = @default_domain if domain.nil? || domain == '.'.encode(domain.encoding)
           domain = domain.downcase
-          @accounts.find { |account| safe_encode(account.username, username.encoding).downcase == username && safe_encode(account.domain, domain.encoding).downcase == domain }
+          @accounts.find do |account|
+            RubySMB::Utils.safe_encode(account.username, username.encoding).downcase == username &&
+              RubySMB::Utils.safe_encode(account.domain, domain.encoding).downcase == domain
+          end
         end
 
         #

--- a/lib/ruby_smb/ntlm.rb
+++ b/lib/ruby_smb/ntlm.rb
@@ -56,6 +56,41 @@ module RubySMB
         "Version #{major}.#{minor} (Build #{build}); NTLM Current Revision #{ntlm_revision}"
       end
     end
+
+    class << self
+
+      # Generate a NTLMv2 Hash
+      # @param [String] user The username
+      # @param [String] password The password
+      # @param [String] target The domain or workstation to authenticate to
+      # @option opt :unicode (false) Unicode encode the domain
+      def ntlmv2_hash(user, password, target, opt={})
+        if Net::NTLM.is_ntlm_hash? password
+          decoded_password = Net::NTLM::EncodeUtil.decode_utf16le(password)
+          ntlmhash = [decoded_password.upcase[33,65]].pack('H32')
+        else
+          ntlmhash = Net::NTLM.ntlm_hash(password, opt)
+        end
+
+        if opt[:unicode]
+          # Uppercase operation on username containing non-ASCI characters
+          # after behing unicode encoded with `EncodeUtil.encode_utf16le`
+          # doesn't play well. Upcase should be done before encoding.
+          user_upcase = Net::NTLM::EncodeUtil.decode_utf16le(user).upcase
+          user_upcase = Net::NTLM::EncodeUtil.encode_utf16le(user_upcase)
+        else
+          user_upcase = user.upcase
+        end
+        userdomain = user_upcase + target
+
+        unless opt[:unicode]
+          userdomain = Net::NTLM::EncodeUtil.encode_utf16le(userdomain)
+        end
+        OpenSSL::HMAC.digest(OpenSSL::Digest::MD5.new, ntlmhash, userdomain)
+      end
+
+    end
+
   end
 end
 

--- a/lib/ruby_smb/ntlm.rb
+++ b/lib/ruby_smb/ntlm.rb
@@ -1,3 +1,5 @@
+require 'ruby_smb/ntlm/custom/ntlm'
+
 module RubySMB
   module NTLM
     # [[MS-NLMP] 2.2.2.5](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-nlmp/99d90ff4-957f-4c8a-80e4-5bfe5a9a9832)

--- a/lib/ruby_smb/ntlm/client.rb
+++ b/lib/ruby_smb/ntlm/client.rb
@@ -1,9 +1,3 @@
-class Net::NTLM::EncodeUtil
-  def self.encode_utf16le(str)
-    str.dup.force_encoding('UTF-8').encode(Encoding::UTF_16LE, Encoding::UTF_8).force_encoding('ASCII-8BIT')
-  end
-end
-
 module RubySMB::NTLM
   module Message
     def deflag

--- a/lib/ruby_smb/ntlm/client.rb
+++ b/lib/ruby_smb/ntlm/client.rb
@@ -1,3 +1,9 @@
+class Net::NTLM::EncodeUtil
+  def self.encode_utf16le(str)
+    str.dup.force_encoding('UTF-8').encode(Encoding::UTF_16LE, Encoding::UTF_8).force_encoding('ASCII-8BIT')
+  end
+end
+
 module RubySMB::NTLM
   module Message
     def deflag

--- a/lib/ruby_smb/ntlm/client.rb
+++ b/lib/ruby_smb/ntlm/client.rb
@@ -51,6 +51,10 @@ module RubySMB::NTLM
         !challenge_message.has_flag?(:UNICODE) && challenge_message.has_flag?(:OEM)
       end
 
+      def ntlmv2_hash
+        @ntlmv2_hash ||= RubySMB::NTLM.ntlmv2_hash(username, password, domain, {:client_challenge => client_challenge, :unicode => !use_oem_strings?})
+      end
+
       def calculate_user_session_key!
         if is_anonymous?
           # see MS-NLMP section 3.4

--- a/lib/ruby_smb/ntlm/custom/ntlm.rb
+++ b/lib/ruby_smb/ntlm/custom/ntlm.rb
@@ -1,0 +1,19 @@
+require 'net/ntlm'
+
+module Custom
+  module NTLM
+
+    def self.prepended(base)
+      base.singleton_class.send(:prepend, ClassMethods)
+    end
+
+    module ClassMethods
+      def encode_utf16le(str)
+        str.dup.force_encoding('UTF-8').encode(Encoding::UTF_16LE, Encoding::UTF_8).force_encoding('ASCII-8BIT')
+      end
+    end
+
+  end
+end
+
+Net::NTLM::EncodeUtil.send(:prepend, Custom::NTLM)

--- a/lib/ruby_smb/server/server_client/tree_connect.rb
+++ b/lib/ruby_smb/server/server_client/tree_connect.rb
@@ -7,7 +7,7 @@ module RubySMB
           # see: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/b062f3e3-1b65-4a9a-854a-0ee432499d8f
           response = RubySMB::SMB1::Packet::TreeConnectResponse.new
 
-          share_name = safe_encode(request.data_block.path, 'UTF-8').split('\\', 4).last
+          share_name = RubySMB::Utils.safe_encode(request.data_block.path, 'UTF-8').split('\\', 4).last
           share_provider = @server.shares.transform_keys(&:downcase)[share_name.downcase]
           if share_provider.nil?
             logger.warn("Received TREE_CONNECT request for non-existent share: #{share_name}")
@@ -49,7 +49,7 @@ module RubySMB
             return response
           end
 
-          share_name = safe_encode(request.path, 'UTF-8').split('\\', 4).last
+          share_name = RubySMB::Utils.safe_encode(request.path, 'UTF-8').split('\\', 4).last
           share_provider = @server.shares.transform_keys(&:downcase)[share_name.downcase]
 
           if share_provider.nil?

--- a/lib/ruby_smb/server/server_client/tree_connect.rb
+++ b/lib/ruby_smb/server/server_client/tree_connect.rb
@@ -7,7 +7,7 @@ module RubySMB
           # see: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/b062f3e3-1b65-4a9a-854a-0ee432499d8f
           response = RubySMB::SMB1::Packet::TreeConnectResponse.new
 
-          share_name = request.data_block.path.encode('UTF-8').split('\\', 4).last
+          share_name = safe_encode(request.data_block.path, 'UTF-8').split('\\', 4).last
           share_provider = @server.shares.transform_keys(&:downcase)[share_name.downcase]
           if share_provider.nil?
             logger.warn("Received TREE_CONNECT request for non-existent share: #{share_name}")
@@ -49,7 +49,7 @@ module RubySMB
             return response
           end
 
-          share_name = request.path.encode('UTF-8').split('\\', 4).last
+          share_name = safe_encode(request.path, 'UTF-8').split('\\', 4).last
           share_provider = @server.shares.transform_keys(&:downcase)[share_name.downcase]
 
           if share_provider.nil?

--- a/lib/ruby_smb/utils.rb
+++ b/lib/ruby_smb/utils.rb
@@ -1,0 +1,15 @@
+module RubySMB
+  module Utils
+
+    def safe_encode(str, encoding)
+      str.encode(encoding)
+    rescue EncodingError
+      if str.encoding == ::Encoding::ASCII_8BIT
+        str.force_encoding(encoding)
+      else
+        raise
+      end
+    end
+
+  end
+end

--- a/lib/ruby_smb/utils.rb
+++ b/lib/ruby_smb/utils.rb
@@ -5,7 +5,7 @@ module RubySMB
       str.encode(encoding)
     rescue EncodingError
       if str.encoding == ::Encoding::ASCII_8BIT
-        str.force_encoding(encoding)
+        str.dup.force_encoding(encoding)
       else
         raise
       end

--- a/lib/ruby_smb/utils.rb
+++ b/lib/ruby_smb/utils.rb
@@ -1,7 +1,7 @@
 module RubySMB
   module Utils
 
-    def safe_encode(str, encoding)
+    def self.safe_encode(str, encoding)
       str.encode(encoding)
     rescue EncodingError
       if str.encoding == ::Encoding::ASCII_8BIT


### PR DESCRIPTION
This is related to this Metasploit [issue](https://github.com/rapid7/metasploit-framework/issues/11405).

This PR addresses an authentication error when usernames with non-ASCII characters are used. This PR fixes two things:

1. Metasploit converts strings containing non-ASCII characters to `ASCII-8BIT` encoding.

Calling `String#encode` on those strings were throwing a `Encoding::UndefinedConversionError` exception. To address this, a `safe_encode` wrapper method has been added. This method handles this specific Metasploit case and prevents it from breaking. This wrapper simply catches `Encoding` exceptions and `#force_encode` instead of `#encode` the string. This might not be the best solution, but since it seems to only happen in this specific scenario, I'm confident it is safe to do.

Every calls to `String#encode` on a string that could come from a user input directly have been replace by `#safe_encode`.

2. Fix NTLMv2 hash when username contains non-ASCII characters in the [`rubyntlm`](https://github.com/WinRb/rubyntlm) library

See https://github.com/WinRb/rubyntlm/issues/55 for details. A [PR](https://github.com/WinRb/rubyntlm/pull/56) has been submitted, but since we want this to be fixed ASAP, the fix has been added to RubySMB directly. This PR adds the patched `rubyntlm`'s `ntlmv2_hash` method and forces the `RubySMB::Client` to use `RubySMB::NTLM` instead of `rubyntlm` library.

### Before the fix
```
❯ ruby examples/tree_connect.rb --username юзер --password 123456 10.0.0.68 IPC$
SMB3 : (0xc000006d) STATUS_LOGON_FAILURE: The attempted logon is invalid. This is either due to a bad username or authentication information.
Authentication failed!
```

### After the fix
```
❯ ruby examples/tree_connect.rb --username юзер --password 123456 10.0.0.168 IPC$
SMB3 : (0x00000000) STATUS_SUCCESS: The operation completed successfully.
Connected to \\192.168.144.168\IPC$ successfully!
```