### PR TITLE
Fix DCERPC Encrypted Fragments

### DIFF
--- a/lib/ruby_smb/dcerpc/ndr.rb
+++ b/lib/ruby_smb/dcerpc/ndr.rb
@@ -247,12 +247,22 @@ module RubySMB::Dcerpc::Ndr
 
     def do_read(io)
       if is_a?(ConfPlugin) && should_process_max_count?
-        set_max_count(io.readbytes(4).unpack('L<').first)
+        max_count = io.readbytes(4).unpack1('L<')
+        BinData.trace_message do |tracer|
+          tracer.trace_obj("#{debug_name}.max_count", max_count.to_s)
+        end
+        set_max_count(max_count)
       end
 
       if is_a?(VarPlugin)
         @offset = io.readbytes(4).unpack('L<').first
+        BinData.trace_message do |tracer|
+          tracer.trace_obj("#{debug_name}.offset", @offset.to_s)
+        end
         @actual_count = @read_until_index = io.readbytes(4).unpack('L<').first
+        BinData.trace_message do |tracer|
+          tracer.trace_obj("#{debug_name}.actual_count", @actual_count.to_s)
+        end
       end
 
       if has_elements_to_read?
@@ -523,7 +533,11 @@ module RubySMB::Dcerpc::Ndr
 
     def do_read(io)
       if should_process_max_count?
-        set_max_count(io.readbytes(4).unpack('L<').first)
+        max_count = io.readbytes(4).unpack1('L<')
+        BinData.trace_message do |tracer|
+          tracer.trace_obj("#{debug_name}.max_count", max_count.to_s)
+        end
+        set_max_count(max_count)
       end
       super
     end
@@ -582,7 +596,13 @@ module RubySMB::Dcerpc::Ndr
 
     def do_read(io)
       @offset = io.readbytes(4).unpack('L<').first
+       BinData.trace_message do |tracer|
+        tracer.trace_obj("#{debug_name}.offset", @offset.to_s)
+      end
       @actual_count = io.readbytes(4).unpack('L<').first
+      BinData.trace_message do |tracer|
+        tracer.trace_obj("#{debug_name}.actual_count", @actual_count.to_s)
+      end
       super if @actual_count > 0
     end
 
@@ -702,7 +722,11 @@ module RubySMB::Dcerpc::Ndr
 
     def do_read(io)
       if should_process_max_count?
-        set_max_count(io.readbytes(4).unpack('L<').first)
+        max_count = io.readbytes(4).unpack1('L<')
+        BinData.trace_message do |tracer|
+          tracer.trace_obj("#{debug_name}.max_count", max_count.to_s)
+        end
+        set_max_count(max_count)
 
         # Align the structure according to the alignment rules for the structure
         if respond_to?(:referent_bytes_align)
@@ -1034,6 +1058,9 @@ module RubySMB::Dcerpc::Ndr
         end
       else
         @ref_id = io.readbytes(4).unpack('L<').first
+        BinData.trace_message do |tracer|
+          tracer.trace_obj("#{debug_name}.ref_id", @ref_id.to_s)
+        end
         parent_obj = nil
         if parent&.is_a?(ConstructedTypePlugin)
           parent_obj = parent.get_top_level_constructed_type

--- a/lib/ruby_smb/smb1/pipe.rb
+++ b/lib/ruby_smb/smb1/pipe.rb
@@ -147,6 +147,10 @@ module RubySMB
             break if dcerpc_response.pdu_header.pfc_flags.last_frag == 1
             raw_data = read(bytes: @tree.client.max_buffer_size)
             dcerpc_response = dcerpc_response_from_raw_response(raw_data)
+            if options[:auth_level] &&
+               [RPC_C_AUTHN_LEVEL_PKT_INTEGRITY, RPC_C_AUTHN_LEVEL_PKT_PRIVACY].include?(options[:auth_level])
+              handle_integrity_privacy(dcerpc_response, auth_level: options[:auth_level], auth_type: options[:auth_type])
+            end
             stub_data << dcerpc_response.stub.to_s
           end
           stub_data

--- a/lib/ruby_smb/smb2/pipe.rb
+++ b/lib/ruby_smb/smb2/pipe.rb
@@ -145,6 +145,10 @@ module RubySMB
             break if dcerpc_response.pdu_header.pfc_flags.last_frag == 1
             raw_data = read(bytes: @tree.client.max_buffer_size)
             dcerpc_response = dcerpc_response_from_raw_response(raw_data)
+            if options[:auth_level] &&
+               [RPC_C_AUTHN_LEVEL_PKT_INTEGRITY, RPC_C_AUTHN_LEVEL_PKT_PRIVACY].include?(options[:auth_level])
+              handle_integrity_privacy(dcerpc_response, auth_level: options[:auth_level], auth_type: options[:auth_type])
+            end
             stub_data << dcerpc_response.stub.to_s
           end
           stub_data


### PR DESCRIPTION
This makes two changes.

The first fixes an error where when encryption is used, only the first fragment of a fragmented response would be decrypted. This means the rest of the data would be corrupt which leads to weird parsing errors. Those weird parsing errors are what I was debugging and I originally thought the issue was in the BinData definitions, so while digging into that I added tracing to all of the direct IO read operations in `dcerpc/ndr.rb` which is the second change. Now if the user enables bindata read tracing to do what I was doing, they'll get additional information like what the ref ID, and max_count files are being set to.

The tracing output was pretty helpful because it made it obvious that the size field was incorrect, it just wasn't BinData's fault in my case.

## Example Tracing Output

```
BinData.trace_reading { RubySMB::Dcerpc::Icpr::CertServerRequestResponse.read(File.binread('/tmp/response_good.bin')) }
obj.pdw_request_id => 59
obj.pdw_disposition => 3
obj.pctb_cert.cb => 2662
obj.pctb_cert.pb.ref_id => 131072
obj.pctb_cert.pb.max_count => 2662
obj.pctb_cert.pb[0] => 48
obj.pctb_cert.pb[1] => 130
obj.pctb_cert.pb[2] => 10
obj.pctb_cert.pb[3] => 98
```