### PR TITLE
Fix `fix_dump_secrets_from_sid` Example

### DIFF
--- a/examples/dump_secrets_from_sid.rb
+++ b/examples/dump_secrets_from_sid.rb
@@ -26,6 +26,7 @@ client = RubySMB::Dcerpc::Client.new(
 client.connect
 puts('Binding to DRSR...')
 client.bind(
+  endpoint: RubySMB::Dcerpc::Drsr,
   auth_level: RubySMB::Dcerpc::RPC_C_AUTHN_LEVEL_PKT_PRIVACY,
   auth_type: RubySMB::Dcerpc::RPC_C_AUTHN_WINNT
 )


### PR DESCRIPTION
The `endpoint:` argument was missing when calling `#bind`.

- Before the fix
```
❯ ruby examples/dump_secrets_from_sid.rb 10.0.0.24 Administrator 123456 FOOLAB S-1-5-21-419957332-8987628-4871342532-500
Binding to DRSR...
/home/msfuser/.rvm/gems/ruby-3.0.2@ruby_smb/gems/bindata-2.4.14/lib/bindata/lazy.rb:71:in `method_missing': undefined method `endpoint' for #<BinData::LazyEvaluator:0x00007feb828c5ff8> (NoMethodError)
...
```
- After the fix
```
❯ ruby examples/dump_secrets_from_sid.rb 10.0.0.24 Administrator 123456 FOOLAB S-1-5-21-419957332-8987628-4871342532-500
Binding to DRSR...
Bound to DRSR
ph_drs: {:context_handle_attributes=>0, :context_handle_uuid=>"3cda99a9-b8a4-4e6b-9339-c9855fd812f8"}
...
```