### PR TITLE
Add NDR Type Serialization Version 1 structures

### DIFF
--- a/lib/ruby_smb/dcerpc/ndr.rb
+++ b/lib/ruby_smb/dcerpc/ndr.rb
@@ -1315,5 +1315,40 @@ module RubySMB::Dcerpc::Ndr
     end
   end
 
+  # (IDL/NDR) Pickles as defined in
+  # [(IDL/NDR) # Pickles](https://pubs.opengroup.org/onlinepubs/9668899/chap2.htm#tagcjh_05_01_07)
+  # and
+  # [2.2.6 Type Serialization Version # 1](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rpce/9a1d0f97-eac0-49ab-a197-f1a581c2d6a0)
+
+  # [2.2.6.1 Common Type Header for the Serialization Stream](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rpce/6d75d40e-e2d2-4420-b9e9-8508a726a9ae)
+  class TypeSerialization1CommonTypeHeader < NdrStruct
+    default_parameter byte_align: 8
+    endian :little
+
+    ndr_uint8  :version, initial_value: 1
+    ndr_uint8  :endianness, initial_value: 0x10
+    ndr_uint16 :common_header_length, initial_value: 8
+    ndr_uint32 :filler, initial_value: 0xCCCCCCCC
+  end
+
+  # [2.2.6.2 Private Header for Constructed Type](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rpce/63949ba8-bc88-4c0c-9377-23f14b197827)
+  class TypeSerialization1PrivateHeader < NdrStruct
+    default_parameter byte_align: 8
+    endian :little
+
+    ndr_uint32 :object_buffer_length
+    ndr_uint32 :filler, initial_value: 0x00000000
+  end
+
+  # [2.2.6 Type Serialization Version 1](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rpce/9a1d0f97-eac0-49ab-a197-f1a581c2d6a0)
+  class TypeSerialization1 < NdrStruct
+    default_parameter byte_align: 8
+    endian :little
+    search_prefix :type_serialization1
+
+    common_type_header  :common_header
+    private_header      :private_header
+  end
+
 end
 

--- a/lib/ruby_smb/dcerpc/ndr.rb
+++ b/lib/ruby_smb/dcerpc/ndr.rb
@@ -1321,33 +1321,116 @@ module RubySMB::Dcerpc::Ndr
   # [2.2.6 Type Serialization Version # 1](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rpce/9a1d0f97-eac0-49ab-a197-f1a581c2d6a0)
 
   # [2.2.6.1 Common Type Header for the Serialization Stream](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rpce/6d75d40e-e2d2-4420-b9e9-8508a726a9ae)
-  class TypeSerialization1CommonTypeHeader < NdrStruct
+  class TypeSerialization1CommonTypeHeader < BinData::Record
     default_parameter byte_align: 8
     endian :little
 
-    ndr_uint8  :version, initial_value: 1
-    ndr_uint8  :endianness, initial_value: 0x10
-    ndr_uint16 :common_header_length, initial_value: 8
-    ndr_uint32 :filler, initial_value: 0xCCCCCCCC
+    uint8  :version, initial_value: 1
+    uint8  :endianness, initial_value: 0x10
+    uint16 :common_header_length, initial_value: 8
+    uint32 :filler, initial_value: 0xCCCCCCCC
   end
 
   # [2.2.6.2 Private Header for Constructed Type](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rpce/63949ba8-bc88-4c0c-9377-23f14b197827)
-  class TypeSerialization1PrivateHeader < NdrStruct
+  class TypeSerialization1PrivateHeader < BinData::Record
     default_parameter byte_align: 8
     endian :little
 
-    ndr_uint32 :object_buffer_length
-    ndr_uint32 :filler, initial_value: 0x00000000
+    uint32 :object_buffer_length, initial_value: -> { buffer_length(@obj) }
+    uint32 :filler, initial_value: 0x00000000
+
+    def buffer_length(obj)
+      parent.respond_to?(:field_length) ? parent.field_length(obj.parent) : 0
+    end
   end
 
   # [2.2.6 Type Serialization Version 1](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rpce/9a1d0f97-eac0-49ab-a197-f1a581c2d6a0)
-  class TypeSerialization1 < NdrStruct
+  #
+  # This structure is not meant to be instantiated directly. Instead, the
+  # structure with the fields to be serialized needs to inherit from
+  # TypeSerialization1. This class will take care of adding the
+  # TypeSerialization1PrivateHeader fields in front of any NDR constructed type
+  # structures and setting the buffer length field (:object_buffer_length) to
+  # the correct value.
+  #
+  # Example:
+  #
+  # class TestStruct < RubySMB::Dcerpc::Ndr::NdrStruct
+  #   default_parameters byte_align: 8
+  #   endian :little
+
+  #   rpc_unicode_string :full_name
+  #   ndr_uint32 :user_id
+  # end
+
+  # class TestTypeSerialization1 < RubySMB::Dcerpc::Ndr::TypeSerialization1
+  #   default_parameter byte_align: 8
+  #   endian :little
+  #
+  #   test_struct :data1
+  #   uint32 :value1, initial_value: 5
+  #   uint32 :value2, initial_value: 6
+  #   test_struct :data2
+  #   uint32 :value3, initial_value: 7
+  #   test_struct :data3
+  # end
+  #
+  # This will result in the following structure:
+  # {
+  #   :common_header => {:version=>1, :endianness=>16, :common_header_length=>8, :filler=>3435973836},
+  #   :private_header1 => {:object_buffer_length=>12, :filler=>0},
+  #   :data1 => {:full_name=>{:buffer_length=>0, :maximum_length=>0, :buffer=>:null}, :user_id=>0},
+  #   :value1 => 5,
+  #   :value2 => 6,
+  #   :private_header2 => {:object_buffer_length=>12, :filler=>0},
+  #   :data2 => {:full_name=>{:buffer_length=>0, :maximum_length=>0, :buffer=>:null}, :user_id=>0},
+  #   :value3 => 7,
+  #   :private_header3 => {:object_buffer_length=>12, :filler=>0},
+  #   :data3 => {:full_name=>{:buffer_length=>0, :maximum_length=>0, :buffer=>:null}, :user_id=>0}
+  # }
+  #
+  class TypeSerialization1 < BinData::Record
+    PRIVATE_HEADER_BASE_NAME = 'private_header'.freeze
+
     default_parameter byte_align: 8
     endian :little
     search_prefix :type_serialization1
 
-    common_type_header  :common_header
-    private_header      :private_header
+    common_type_header :common_header
+
+    def field_length(obj)
+      length = 0
+      index = find_index_of(obj)
+      if index
+        each_pair {|n, o| length = o.num_bytes if n == field_names[index + 1]}
+      end
+      length
+    end
+
+    def self.method_missing(symbol, *args, &block)
+      return super if dsl_parser.respond_to?(symbol)
+
+      klass = BinData::RegisteredClasses.lookup(symbol, {endian: dsl_parser.endian, search_prefix: dsl_parser.search_prefix})
+      if klass.new.is_a?(ConstructedTypePlugin)
+        # We cannot have two fields with the same name. So, here we look for
+        # existing TypeSerialization1PrivateHeader fields and just increment
+        # the ending number of the last TypeSerialization1PrivateHeader field
+        # to make the new name unique.
+        names = dsl_parser.fields.find_all do |field|
+          field.prototype.instance_variable_get(:@obj_class) == TypeSerialization1PrivateHeader
+        end.map(&:name).sort
+        if names.empty?
+          new_name = "#{PRIVATE_HEADER_BASE_NAME}1"
+        else
+          num = names.last.match(/#{PRIVATE_HEADER_BASE_NAME}(\d)$/)[1].to_i
+          new_name = "#{PRIVATE_HEADER_BASE_NAME}#{num + 1}"
+        end
+
+        super(:private_header, new_name.to_sym)
+      end
+
+      super
+    end
   end
 
 end

--- a/spec/lib/ruby_smb/dcerpc/ndr_spec.rb
+++ b/spec/lib/ruby_smb/dcerpc/ndr_spec.rb
@@ -4146,3 +4146,131 @@ RSpec.describe 'Alignment' do
     end
   end
 end
+
+RSpec.describe RubySMB::Dcerpc::Ndr::TypeSerialization1CommonTypeHeader do
+  it 'is a BinData::NdrStruct class' do
+    expect(described_class).to be < RubySMB::Dcerpc::Ndr::NdrStruct
+  end
+  it 'has :byte_align parameter set to the expected value' do
+    expect(described_class.default_parameters[:byte_align]).to eq(8)
+  end
+
+  subject { described_class.new }
+
+  it { is_expected.to respond_to :version }
+  it { is_expected.to respond_to :endianness }
+  it { is_expected.to respond_to :common_header_length }
+  it { is_expected.to respond_to :filler }
+
+  context 'with #version' do
+    it 'is a NdrUint8' do
+      expect(subject.version).to be_a RubySMB::Dcerpc::Ndr::NdrUint8
+    end
+    it 'returns 1 by default' do
+      expect(subject.version).to eq(1)
+    end
+  end
+
+  context 'with #endianness' do
+    it 'is a NdrUint8' do
+      expect(subject.endianness).to be_a RubySMB::Dcerpc::Ndr::NdrUint8
+    end
+    it 'returns 0x10 by default' do
+      expect(subject.endianness).to eq(0x10)
+    end
+  end
+
+  context 'with #common_header_length' do
+    it 'is a NdrUint16' do
+      expect(subject.common_header_length).to be_a RubySMB::Dcerpc::Ndr::NdrUint16
+    end
+    it 'returns 8 by default' do
+      expect(subject.common_header_length).to eq(8)
+    end
+  end
+
+  context 'with #filler' do
+    it 'is a NdrUint32' do
+      expect(subject.filler).to be_a RubySMB::Dcerpc::Ndr::NdrUint32
+    end
+    it 'returns 0xCCCCCCCC by default' do
+      expect(subject.filler).to eq(0xCCCCCCCC)
+    end
+  end
+
+  it 'reads itself' do
+    values = {version: 4, endianness: 0x33, common_header_length: 44, filler: 0xFFFFFFFF}
+    struct_instance = described_class.new(values)
+    expect(described_class.read(struct_instance.to_binary_s)).to eq(values)
+  end
+end
+
+RSpec.describe RubySMB::Dcerpc::Ndr::TypeSerialization1PrivateHeader do
+  it 'is a BinData::NdrStruct class' do
+    expect(described_class).to be < RubySMB::Dcerpc::Ndr::NdrStruct
+  end
+  it 'has :byte_align parameter set to the expected value' do
+    expect(described_class.default_parameters[:byte_align]).to eq(8)
+  end
+
+  subject { described_class.new }
+
+  it { is_expected.to respond_to :object_buffer_length }
+  it { is_expected.to respond_to :filler }
+
+  context 'with #object_buffer_length' do
+    it 'is a NdrUint32' do
+      expect(subject.object_buffer_length).to be_a RubySMB::Dcerpc::Ndr::NdrUint32
+    end
+  end
+
+  context 'with #filler' do
+    it 'is a NdrUint32' do
+      expect(subject.filler).to be_a RubySMB::Dcerpc::Ndr::NdrUint32
+    end
+    it 'returns 0x00000000 by default' do
+      expect(subject.filler).to eq(0x00000000)
+    end
+  end
+
+  it 'reads itself' do
+    values = {object_buffer_length: 4, filler: 0xFFFFFFFF}
+    struct_instance = described_class.new(values)
+    expect(described_class.read(struct_instance.to_binary_s)).to eq(values)
+  end
+end
+
+RSpec.describe RubySMB::Dcerpc::Ndr::TypeSerialization1 do
+  it 'is a BinData::NdrStruct class' do
+    expect(described_class).to be < RubySMB::Dcerpc::Ndr::NdrStruct
+  end
+  it 'has :byte_align parameter set to the expected value' do
+    expect(described_class.default_parameters[:byte_align]).to eq(8)
+  end
+
+  subject { described_class.new }
+
+  it { is_expected.to respond_to :common_header }
+  it { is_expected.to respond_to :private_header }
+
+  context 'with #common_header' do
+    it 'is a TypeSerialization1CommonTypeHeader structure' do
+      expect(subject.common_header).to be_a RubySMB::Dcerpc::Ndr::TypeSerialization1CommonTypeHeader
+    end
+  end
+
+  context 'with #private_header' do
+    it 'is a TypeSerialization1PrivateHeader structure' do
+      expect(subject.private_header).to be_a RubySMB::Dcerpc::Ndr::TypeSerialization1PrivateHeader
+    end
+  end
+
+  it 'reads itself' do
+    values = {
+      common_header: {version: 4, endianness: 0x33, common_header_length: 44, filler: 0xFFFFFFFF},
+      private_header: {object_buffer_length: 4, filler: 0xFFFFFFFF}
+    }
+    struct_instance = described_class.new(values)
+    expect(described_class.read(struct_instance.to_binary_s)).to eq(values)
+  end
+end

--- a/spec/lib/ruby_smb/dcerpc/ndr_spec.rb
+++ b/spec/lib/ruby_smb/dcerpc/ndr_spec.rb
@@ -4148,8 +4148,8 @@ RSpec.describe 'Alignment' do
 end
 
 RSpec.describe RubySMB::Dcerpc::Ndr::TypeSerialization1CommonTypeHeader do
-  it 'is a BinData::NdrStruct class' do
-    expect(described_class).to be < RubySMB::Dcerpc::Ndr::NdrStruct
+  it 'is a BinData::Record class' do
+    expect(described_class).to be < BinData::Record
   end
   it 'has :byte_align parameter set to the expected value' do
     expect(described_class.default_parameters[:byte_align]).to eq(8)
@@ -4163,8 +4163,8 @@ RSpec.describe RubySMB::Dcerpc::Ndr::TypeSerialization1CommonTypeHeader do
   it { is_expected.to respond_to :filler }
 
   context 'with #version' do
-    it 'is a NdrUint8' do
-      expect(subject.version).to be_a RubySMB::Dcerpc::Ndr::NdrUint8
+    it 'is a BinData::Uint8' do
+      expect(subject.version).to be_a BinData::Uint8
     end
     it 'returns 1 by default' do
       expect(subject.version).to eq(1)
@@ -4172,8 +4172,8 @@ RSpec.describe RubySMB::Dcerpc::Ndr::TypeSerialization1CommonTypeHeader do
   end
 
   context 'with #endianness' do
-    it 'is a NdrUint8' do
-      expect(subject.endianness).to be_a RubySMB::Dcerpc::Ndr::NdrUint8
+    it 'is a BinData::Uint8' do
+      expect(subject.endianness).to be_a BinData::Uint8
     end
     it 'returns 0x10 by default' do
       expect(subject.endianness).to eq(0x10)
@@ -4181,8 +4181,8 @@ RSpec.describe RubySMB::Dcerpc::Ndr::TypeSerialization1CommonTypeHeader do
   end
 
   context 'with #common_header_length' do
-    it 'is a NdrUint16' do
-      expect(subject.common_header_length).to be_a RubySMB::Dcerpc::Ndr::NdrUint16
+    it 'is a BinData::Uint16le' do
+      expect(subject.common_header_length).to be_a BinData::Uint16le
     end
     it 'returns 8 by default' do
       expect(subject.common_header_length).to eq(8)
@@ -4190,8 +4190,8 @@ RSpec.describe RubySMB::Dcerpc::Ndr::TypeSerialization1CommonTypeHeader do
   end
 
   context 'with #filler' do
-    it 'is a NdrUint32' do
-      expect(subject.filler).to be_a RubySMB::Dcerpc::Ndr::NdrUint32
+    it 'is a BinData::Uint32le' do
+      expect(subject.filler).to be_a BinData::Uint32le
     end
     it 'returns 0xCCCCCCCC by default' do
       expect(subject.filler).to eq(0xCCCCCCCC)
@@ -4206,8 +4206,8 @@ RSpec.describe RubySMB::Dcerpc::Ndr::TypeSerialization1CommonTypeHeader do
 end
 
 RSpec.describe RubySMB::Dcerpc::Ndr::TypeSerialization1PrivateHeader do
-  it 'is a BinData::NdrStruct class' do
-    expect(described_class).to be < RubySMB::Dcerpc::Ndr::NdrStruct
+  it 'is a BinData::Record class' do
+    expect(described_class).to be < BinData::Record
   end
   it 'has :byte_align parameter set to the expected value' do
     expect(described_class.default_parameters[:byte_align]).to eq(8)
@@ -4219,14 +4219,27 @@ RSpec.describe RubySMB::Dcerpc::Ndr::TypeSerialization1PrivateHeader do
   it { is_expected.to respond_to :filler }
 
   context 'with #object_buffer_length' do
-    it 'is a NdrUint32' do
-      expect(subject.object_buffer_length).to be_a RubySMB::Dcerpc::Ndr::NdrUint32
+    it 'is a BinData::Uint32le' do
+      expect(subject.object_buffer_length).to be_a BinData::Uint32le
+    end
+    it 'calls its parent\'s #field_length method to set its default value' do
+      test_struct = Class.new(BinData::Record) do
+        endian :little
+        type_serialization1_private_header :header
+
+        def field_length(obj);end
+      end.new
+      expect(test_struct).to receive(:field_length).and_return(4)
+      expect(test_struct.header.object_buffer_length).to eq(4)
+    end
+    it 'sets the default value to 0 when its parent doesn\'t implemet #field_length' do
+      expect(subject.object_buffer_length).to eq(0)
     end
   end
 
   context 'with #filler' do
-    it 'is a NdrUint32' do
-      expect(subject.filler).to be_a RubySMB::Dcerpc::Ndr::NdrUint32
+    it 'is a BinData::Uint32le' do
+      expect(subject.filler).to be_a BinData::Uint32le
     end
     it 'returns 0x00000000 by default' do
       expect(subject.filler).to eq(0x00000000)
@@ -4241,8 +4254,8 @@ RSpec.describe RubySMB::Dcerpc::Ndr::TypeSerialization1PrivateHeader do
 end
 
 RSpec.describe RubySMB::Dcerpc::Ndr::TypeSerialization1 do
-  it 'is a BinData::NdrStruct class' do
-    expect(described_class).to be < RubySMB::Dcerpc::Ndr::NdrStruct
+  it 'is a BinData::Record class' do
+    expect(described_class).to be < BinData::Record
   end
   it 'has :byte_align parameter set to the expected value' do
     expect(described_class.default_parameters[:byte_align]).to eq(8)
@@ -4251,7 +4264,6 @@ RSpec.describe RubySMB::Dcerpc::Ndr::TypeSerialization1 do
   subject { described_class.new }
 
   it { is_expected.to respond_to :common_header }
-  it { is_expected.to respond_to :private_header }
 
   context 'with #common_header' do
     it 'is a TypeSerialization1CommonTypeHeader structure' do
@@ -4259,18 +4271,76 @@ RSpec.describe RubySMB::Dcerpc::Ndr::TypeSerialization1 do
     end
   end
 
-  context 'with #private_header' do
-    it 'is a TypeSerialization1PrivateHeader structure' do
-      expect(subject.private_header).to be_a RubySMB::Dcerpc::Ndr::TypeSerialization1PrivateHeader
-    end
-  end
-
   it 'reads itself' do
     values = {
-      common_header: {version: 4, endianness: 0x33, common_header_length: 44, filler: 0xFFFFFFFF},
-      private_header: {object_buffer_length: 4, filler: 0xFFFFFFFF}
+      common_header: {version: 4, endianness: 0x33, common_header_length: 44, filler: 0xFFFFFFFF}
     }
     struct_instance = described_class.new(values)
     expect(described_class.read(struct_instance.to_binary_s)).to eq(values)
+  end
+
+  context 'when inherited' do
+    let(:test_struct) do
+      Class.new(RubySMB::Dcerpc::Ndr::NdrStruct) do
+        default_parameters byte_align: 8
+        endian :little
+
+        rpc_unicode_string :full_name
+        ndr_uint32 :user_id
+      end
+    end
+    before :example do
+      BinData::RegisteredClasses.register('test_struct', test_struct)
+    end
+    after :example do
+      BinData::RegisteredClasses.unregister('test_struct')
+    end
+
+    subject do
+      Class.new(described_class) do
+        default_parameter byte_align: 8
+        endian :little
+
+        test_struct :data1
+        uint32 :value1, initial_value: 5
+        uint32 :value2, initial_value: 6
+        test_struct :data2
+        uint32 :value3, initial_value: 7
+        test_struct :data3
+      end.new
+    end
+
+    it { is_expected.to respond_to :common_header }
+    it { is_expected.to respond_to :private_header1 }
+    it { is_expected.to respond_to :data1 }
+    it { is_expected.to respond_to :value1 }
+    it { is_expected.to respond_to :value2 }
+    it { is_expected.to respond_to :private_header2 }
+    it { is_expected.to respond_to :data2 }
+    it { is_expected.to respond_to :value3 }
+    it { is_expected.to respond_to :private_header3 }
+    it { is_expected.to respond_to :data3 }
+
+    it 'sets the expected default values' do
+      data_obj = test_struct.new
+      expect(subject.data1).to eq(data_obj)
+      expect(subject.value1).to eq(5)
+      expect(subject.value2).to eq(6)
+      expect(subject.data2).to eq(data_obj)
+      expect(subject.value3).to eq(7)
+      expect(subject.data3).to eq(data_obj)
+    end
+
+    it 'sets the correct private header\'s object_buffer_length field value' do
+      data1 = test_struct.new(full_name: 'test string')
+      subject.data1 = data1
+      expect(subject.private_header1.object_buffer_length).to eq(data1.num_bytes)
+      data2 = test_struct.new(full_name: 'another test string')
+      subject.data2 = data2
+      expect(subject.private_header2.object_buffer_length).to eq(data2.num_bytes)
+      data3 = test_struct.new(full_name: 'more string!!!')
+      subject.data3 = data3
+      expect(subject.private_header3.object_buffer_length).to eq(data3.num_bytes)
+    end
   end
 end


### PR DESCRIPTION
This adds the NDR `Type Serialization Version 1` structures as defined [here](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rpce/9a1d0f97-eac0-49ab-a197-f1a581c2d6a0).

These structures are referred as `Pickles` by the NDR protocol (see [(IDL/NDR) # Pickles](https://pubs.opengroup.org/onlinepubs/9668899/chap2.htm#tagcjh_05_01_07)). These structures are needed by this Metasploit [module](https://github.com/rapid7/metasploit-framework/pull/17066) and already implemented [here](https://github.com/cdelafuente-r7/metasploit-framework/blob/1e5b13581711746b089c4b41a1e2d9e70524ef31/lib/rex/proto/kerberos/pac/credential_info.rb#L3-L34). They should be moved to RubySMB, since they are DCERPC NDR structures.