### PR TITLE
Don't crash when the buffer is empty

### DIFF
--- a/lib/ruby_smb/dcerpc/icpr.rb
+++ b/lib/ruby_smb/dcerpc/icpr.rb
@@ -51,6 +51,7 @@ module RubySMB
         end
 
         ret = {
+          certificate: nil,
           disposition: cert_server_request_response.pdw_disposition.value,
           disposition_message: cert_server_request_response.pctb_disposition_message.buffer.chomp("\x00\x00").force_encoding('utf-16le').encode,
           status: {
@@ -72,7 +73,7 @@ module RubySMB
               status_code: status_code
             )
           end
-        else
+        elsif !cert_server_request_response.pctb_encoded_cert.buffer.empty?
           ret[:certificate] = OpenSSL::X509::Certificate.new(cert_server_request_response.pctb_encoded_cert.buffer)
         end
 


### PR DESCRIPTION
When the response status is 'submitted', the certificate buffer may be empty. In that case, don't load the certificate because it will crash.

There will need to be a Metasploit PR to handle cases where the result is `:submitted` and the certificate is absent.