### PR TITLE
Fix rails 7 deprecation warning

### DIFF
--- a/lib/ruby_smb/dcerpc/samr.rb
+++ b/lib/ruby_smb/dcerpc/samr.rb
@@ -461,7 +461,7 @@ module RubySMB
         array  :old_credentials, type: :kerb_key_data_new, initial_length: :old_credential_count
         array  :older_credentials, type: :kerb_key_data_new, initial_length: :older_credential_count
         string :default_salt, read_length: -> { credentials.map { |e| e.key_offset }.min - @obj.abs_offset }
-        string :key_values, read_length: -> { credentials.map { |e| e.key_length }.sum }
+        string :key_values, read_length: -> { credentials.map { |e| e.key_length }.sum(&:to_i) }
 
         def get_key_values
           credentials.map do |credential|


### PR DESCRIPTION
Fixes an issue when running Rails 7 and RubySMB - https://github.com/rapid7/metasploit-framework/pull/17291

When running Metasplotit's secrets dump module we get a deprecation warning from rails:

```
DEPRECATION WARNING: Rails 7.0 has deprecated Enumerable.sum in favor of Ruby's native implementation available since 2.4. Sum of non-numeric elements requires an initial argument. (call    ed from block in decrypt_supplemental_info at /tmp/metasploit-framework/modules/auxiliary/gather/windows_secrets_dump.rb:658)
```

Tracked the warning down to:

https://github.com/rails/rails/commit/afa83350deef906ed01b7acb5da6e9285aab661f#diff-55ebe1b9975bc2c8530cd262bd89b31434a4a852f39d1e79a17dcf7f9f03b8ffR66-R68

Because BinData's integers don't pass the `first.is_a?(Numeric)` logic check
Minimal example in Rails prompt:

```
>> [BinData::Int64le.new(123)].sum
DEPRECATION WARNING: Rails 7.0 has deprecated Enumerable.sum in favor of Ruby's native implementation available since 2.4. Sum of non-numeric elements requires an initial argument. (called from <top (required)> at (irb):6)
```

Whilst the following works in both Rails and Ruby

```
>> [BinData::Int64le.new(123)].sum(&:to_i)
=> 123
```
