### PR TITLE
Add definitions for three new EFS RPC requests and responses

### DIFF
--- a/lib/ruby_smb/dcerpc/encrypting_file_system.rb
+++ b/lib/ruby_smb/dcerpc/encrypting_file_system.rb
@@ -82,6 +82,8 @@ module RubySMB
       require 'ruby_smb/dcerpc/encrypting_file_system/efs_rpc_open_file_raw_response'
       require 'ruby_smb/dcerpc/encrypting_file_system/efs_rpc_query_recover_agents_request'
       require 'ruby_smb/dcerpc/encrypting_file_system/efs_rpc_query_recover_agents_response'
+      require 'ruby_smb/dcerpc/encrypting_file_system/efs_rpc_query_users_on_file_request'
+      require 'ruby_smb/dcerpc/encrypting_file_system/efs_rpc_query_users_on_file_response'
     end
   end
 end

--- a/lib/ruby_smb/dcerpc/encrypting_file_system.rb
+++ b/lib/ruby_smb/dcerpc/encrypting_file_system.rb
@@ -35,12 +35,53 @@ module RubySMB
       OVERWRITE_HIDDEN = 0x00000004
       EFS_DROP_ALTERNATE_STREAMS = 0x00000010
 
+      class EfsHashBlob < Ndr::NdrStruct
+        endian :little
+        default_parameter byte_align: 4
+
+        ndr_uint32   :cb_data
+        ndr_byte_conf_array_ptr :b_data
+      end
+
+      class EfsHashBlobPtr < EfsHashBlob
+        extend Ndr::PointerClassPlugin
+      end
+
+      class EncryptionCertificateHash < Ndr::NdrStruct
+        endian :little
+        default_parameter byte_align: 4
+
+        ndr_uint32                :cb_total_length
+        prpc_sid                  :user_sid
+        efs_hash_blob_ptr         :certificate_hash
+        ndr_wide_stringz_ptr      :lp_display_information
+      end
+
+      class EncryptionCertificateHashPtr < EncryptionCertificateHash
+        default_parameter byte_align: 4
+        extend Ndr::PointerClassPlugin
+      end
+
+      class EncryptionCertificateHashList < BinData::Record
+        endian :little
+        default_parameter byte_align: 4
+
+        uint32 :ncert_hash
+        ndr_var_array :users, type: :encryption_certificate_hash_ptr
+      end
+
+      class EncryptionCertificateHashListPtr < EncryptionCertificateHashList
+        extend Ndr::PointerClassPlugin
+      end
+
       require 'ruby_smb/dcerpc/encrypting_file_system/efs_rpc_decrypt_file_srv_request'
       require 'ruby_smb/dcerpc/encrypting_file_system/efs_rpc_decrypt_file_srv_response'
       require 'ruby_smb/dcerpc/encrypting_file_system/efs_rpc_encrypt_file_srv_request'
       require 'ruby_smb/dcerpc/encrypting_file_system/efs_rpc_encrypt_file_srv_response'
       require 'ruby_smb/dcerpc/encrypting_file_system/efs_rpc_open_file_raw_request'
       require 'ruby_smb/dcerpc/encrypting_file_system/efs_rpc_open_file_raw_response'
+      require 'ruby_smb/dcerpc/encrypting_file_system/efs_rpc_query_recover_agents_request'
+      require 'ruby_smb/dcerpc/encrypting_file_system/efs_rpc_query_recover_agents_response'
     end
   end
 end

--- a/lib/ruby_smb/dcerpc/encrypting_file_system.rb
+++ b/lib/ruby_smb/dcerpc/encrypting_file_system.rb
@@ -35,6 +35,7 @@ module RubySMB
       OVERWRITE_HIDDEN = 0x00000004
       EFS_DROP_ALTERNATE_STREAMS = 0x00000010
 
+      # [2.2.7 EFS_HASH_BLOB](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-efsr/242d857f-ac8e-4cc8-b5e4-9314a942f45e)
       class EfsHashBlob < Ndr::NdrStruct
         endian :little
         default_parameter byte_align: 4
@@ -47,6 +48,7 @@ module RubySMB
         extend Ndr::PointerClassPlugin
       end
 
+      # [2.2.10 ENCRYPTION_CERTIFICATE_HASH](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-efsr/3a7e7151-edcb-4b32-a119-35cdce1584c0)
       class EncryptionCertificateHash < Ndr::NdrStruct
         endian :little
         default_parameter byte_align: 4
@@ -58,10 +60,10 @@ module RubySMB
       end
 
       class EncryptionCertificateHashPtr < EncryptionCertificateHash
-        default_parameter byte_align: 4
         extend Ndr::PointerClassPlugin
       end
 
+      # [2.2.11 ENCRYPTION_CERTIFICATE_HASH_LIST](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-efsr/2718804c-6ab9-45fd-98cf-541bc3b6bc75)
       class EncryptionCertificateHashList < BinData::Record
         endian :little
         default_parameter byte_align: 4

--- a/lib/ruby_smb/dcerpc/encrypting_file_system.rb
+++ b/lib/ruby_smb/dcerpc/encrypting_file_system.rb
@@ -35,6 +35,8 @@ module RubySMB
       OVERWRITE_HIDDEN = 0x00000004
       EFS_DROP_ALTERNATE_STREAMS = 0x00000010
 
+      require 'ruby_smb/dcerpc/encrypting_file_system/efs_rpc_decrypt_file_srv_request'
+      require 'ruby_smb/dcerpc/encrypting_file_system/efs_rpc_decrypt_file_srv_response'
       require 'ruby_smb/dcerpc/encrypting_file_system/efs_rpc_encrypt_file_srv_request'
       require 'ruby_smb/dcerpc/encrypting_file_system/efs_rpc_encrypt_file_srv_response'
       require 'ruby_smb/dcerpc/encrypting_file_system/efs_rpc_open_file_raw_request'

--- a/lib/ruby_smb/dcerpc/encrypting_file_system.rb
+++ b/lib/ruby_smb/dcerpc/encrypting_file_system.rb
@@ -63,13 +63,18 @@ module RubySMB
         extend Ndr::PointerClassPlugin
       end
 
+      class EncryptionCertificateHashPtrArrayPtr < Ndr::NdrConfArray
+        default_parameter type: :encryption_certificate_hash_ptr
+        extend Ndr::PointerClassPlugin
+      end
+
       # [2.2.11 ENCRYPTION_CERTIFICATE_HASH_LIST](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-efsr/2718804c-6ab9-45fd-98cf-541bc3b6bc75)
       class EncryptionCertificateHashList < BinData::Record
         endian :little
         default_parameter byte_align: 4
 
-        uint32 :ncert_hash
-        ndr_var_array :users, type: :encryption_certificate_hash_ptr
+        uint32                                    :ncert_hash
+        encryption_certificate_hash_ptr_array_ptr :users
       end
 
       class EncryptionCertificateHashListPtr < EncryptionCertificateHashList

--- a/lib/ruby_smb/dcerpc/encrypting_file_system/efs_rpc_decrypt_file_srv_request.rb
+++ b/lib/ruby_smb/dcerpc/encrypting_file_system/efs_rpc_decrypt_file_srv_request.rb
@@ -1,0 +1,22 @@
+module RubySMB
+  module Dcerpc
+    module EncryptingFileSystem
+
+      # [3.1.4.2.6 Receiving an EfsRpcDecryptFileSrv Message (Opnum 5)](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-efsr/043715de-caee-402a-a61b-921743337e78)
+      class EfsRpcDecryptFileSrvRequest < BinData::Record
+        attr_reader :opnum
+
+        endian :little
+
+        ndr_conf_var_wide_stringz :file_name
+        ndr_uint32                :open_flag
+
+        def initialize_instance
+          super
+          @opnum = EFS_RPC_DECRYPT_FILE_SRV
+        end
+      end
+
+    end
+  end
+end

--- a/lib/ruby_smb/dcerpc/encrypting_file_system/efs_rpc_decrypt_file_srv_response.rb
+++ b/lib/ruby_smb/dcerpc/encrypting_file_system/efs_rpc_decrypt_file_srv_response.rb
@@ -1,0 +1,21 @@
+module RubySMB
+  module Dcerpc
+    module EncryptingFileSystem
+
+      # [3.1.4.2.6 Receiving an EfsRpcDecryptFileSrv Message (Opnum 5)](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-efsr/043715de-caee-402a-a61b-921743337e78)
+      class EfsRpcDecryptFileSrvResponse < BinData::Record
+        attr_reader :opnum
+
+        endian :little
+
+        ndr_uint32         :error_status
+
+        def initialize_instance
+          super
+          @opnum = EFS_RPC_DECRYPT_FILE_SRV
+        end
+      end
+
+    end
+  end
+end

--- a/lib/ruby_smb/dcerpc/encrypting_file_system/efs_rpc_query_recover_agents_request.rb
+++ b/lib/ruby_smb/dcerpc/encrypting_file_system/efs_rpc_query_recover_agents_request.rb
@@ -1,0 +1,20 @@
+module RubySMB
+  module Dcerpc
+    module EncryptingFileSystem
+
+      # [3.1.4.2.8 Receiving an EfsRpcQueryRecoveryAgents Message (Opnum 7)](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-efsr/cf759c00-1b90-4c33-9ace-f51c20149cea)
+      class EfsRpcQueryRecoveryAgentsRequest < BinData::Record
+        attr_reader :opnum
+
+        endian :little
+
+        ndr_conf_var_wide_stringz :file_name
+
+        def initialize_instance
+          super
+          @opnum = EFS_RPC_QUERY_RECOVERY_AGENTS
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby_smb/dcerpc/encrypting_file_system/efs_rpc_query_recover_agents_response.rb
+++ b/lib/ruby_smb/dcerpc/encrypting_file_system/efs_rpc_query_recover_agents_response.rb
@@ -1,0 +1,21 @@
+module RubySMB
+  module Dcerpc
+    module EncryptingFileSystem
+
+      # [3.1.4.2.8 Receiving an EfsRpcQueryRecoveryAgents Message (Opnum 7)](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-efsr/cf759c00-1b90-4c33-9ace-f51c20149cea)
+      class EfsRpcQueryRecoveryAgentsResponse < BinData::Record
+        attr_reader :opnum
+
+        endian :little
+
+        encryption_certificate_hash_list_ptr :recover_agents
+        ndr_uint32                           :error_status
+
+        def initialize_instance
+          super
+          @opnum = EFS_RPC_QUERY_RECOVERY_AGENTS
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby_smb/dcerpc/encrypting_file_system/efs_rpc_query_users_on_file_request.rb
+++ b/lib/ruby_smb/dcerpc/encrypting_file_system/efs_rpc_query_users_on_file_request.rb
@@ -1,0 +1,20 @@
+module RubySMB
+  module Dcerpc
+    module EncryptingFileSystem
+
+      # [3.1.4.2.7 Receiving an EfsRpcQueryUsersOnFile Message (Opnum 6)](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-efsr/a058dc6c-bb7e-491c-9143-a5cb1f7e7cea)
+      class EfsRpcQueryUsersOnFileRequest < BinData::Record
+        attr_reader :opnum
+
+        endian :little
+
+        ndr_conf_var_wide_stringz :file_name
+
+        def initialize_instance
+          super
+          @opnum = EFS_RPC_QUERY_USERS_ON_FILE
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby_smb/dcerpc/encrypting_file_system/efs_rpc_query_users_on_file_response.rb
+++ b/lib/ruby_smb/dcerpc/encrypting_file_system/efs_rpc_query_users_on_file_response.rb
@@ -1,0 +1,21 @@
+module RubySMB
+  module Dcerpc
+    module EncryptingFileSystem
+
+      # [3.1.4.2.7 Receiving an EfsRpcQueryUsersOnFile Message (Opnum 6)](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-efsr/a058dc6c-bb7e-491c-9143-a5cb1f7e7cea)
+      class EfsRpcQueryUsersOnFileResponse < BinData::Record
+        attr_reader :opnum
+
+        endian :little
+
+        encryption_certificate_hash_list_ptr :users
+        ndr_uint32                           :error_status
+
+        def initialize_instance
+          super
+          @opnum = EFS_RPC_QUERY_USERS_ON_FILE
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds definitions for the following three EFS RPC methods. They'll be required by updates to the petitpotam module I will submit to Metasploit soon.

* [EfsRpcDecryptFileSrv](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-efsr/043715de-caee-402a-a61b-921743337e78)
* [EfsRpcQueryRecoveryAgents](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-efsr/cf759c00-1b90-4c33-9ace-f51c20149cea)
* [EfsQueryUsersOnFile](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-efsr/a058dc6c-bb7e-491c-9143-a5cb1f7e7cea)

The easiest way to test this will be with the new petitpotam module changes which will add each of these in as a new method that can be selected. More detailed steps will be posted in that PR.