### PR TITLE
virtual_disk: Add 'pathname' require

### DIFF
--- a/lib/ruby_smb/server/share/provider/virtual_disk/virtual_pathname.rb
+++ b/lib/ruby_smb/server/share/provider/virtual_disk/virtual_pathname.rb
@@ -3,6 +3,8 @@ module RubySMB
     module Share
       module Provider
         class VirtualDisk < Disk
+          require 'pathname'
+
           # This object emulates Ruby's builtin Pathname object but uses a virtual file system instead of the real local
           # one.
           class VirtualPathname


### PR DESCRIPTION
Needed for join()'s call to Pathname.new(). Only comes up if disabling simplecov because of a transitive-require.