### PR TITLE
Fix an issue with SMB2 create context padding

### DIFF
--- a/lib/ruby_smb/smb2/create_context.rb
+++ b/lib/ruby_smb/smb2/create_context.rb
@@ -51,8 +51,11 @@ module RubySMB
         def calc_buffer_size
           align = 8
           size = 0
-          size += name_length + ((align - name_length % align) % align)
-          size += data_length + ((align - data_length % align) % align)
+          size += name_length
+          size += ((align - size % align) % align) if name_offset < data_offset
+          size += data_length
+          size += ((align - size % align) % align) if data_offset < name_offset
+          size += ((align - size % align) % align) if next_offset != 0
           size
         end
 

--- a/spec/lib/ruby_smb/smb2/create_context/create_context_request_spec.rb
+++ b/spec/lib/ruby_smb/smb2/create_context/create_context_request_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe RubySMB::SMB2::CreateContext::CreateContextRequest do
   it { is_expected.to respond_to :name_length }
   it { is_expected.to respond_to :data_offset }
   it { is_expected.to respond_to :data_length }
+  it { is_expected.to respond_to :buffer }
   it { is_expected.to respond_to :name }
   it { is_expected.to respond_to :data }
 
@@ -37,6 +38,40 @@ RSpec.describe RubySMB::SMB2::CreateContext::CreateContextRequest do
 
     it 'returns 0 if the data field is empty' do
       expect(struct.data_offset).to eq 0
+    end
+  end
+
+  context 'when reading a packet with extra padding' do
+    # :name_offset=>120,
+    # :name_length=>14,
+    # :contexts_offset=>136,
+    # :contexts_length=>60,
+    # :bytes_remaining=>76,
+    # :buffer=> "t\x00e\x00s\x00t\x00.\x00r\x00b\x00\x00\x00\x00\x00\x00[...SNIP...]"
+    let(:raw_data) {
+      "\x00\x00\x00\x00\x10\x00\x04\x00\x00\x00\x18\x00\x24\x00\x00\x00\x44\x48\x32\x43\x00\x00"\
+      "\x00\x00\x04\xfa\xb6\x0c\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xd7\x43\xe0\x35"\
+      "\x5c\x6e\xee\x11\xb8\xbb\x00\x0c\x29\xc1\x13\xd0\x00\x00\x00\x00".b
+    }
+
+    it 'reads without error' do
+      expect { described_class.read(raw_data) }.to_not raise_error
+    end
+
+    context 'when getting #name and #data' do
+      let(:create_request_packet) { described_class.read(raw_data) }
+
+      it 'gets the expected #name value' do
+        create_request_packet.name.read_now!
+        expect(create_request_packet.name).to eq 'DH2C'
+      end
+
+      it 'gets the expected #data value' do
+        create_request_packet.data.read_now!
+        expected_data = "\x04\xfa\xb6\x0c\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xd7\x43"\
+                        "\xe0\x35\x5c\x6e\xee\x11\xb8\xbb\x00\x0c\x29\xc1\x13\xd0\x00\x00\x00\x00".b
+        expect(create_request_packet.data).to eq expected_data
+      end
     end
   end
 end


### PR DESCRIPTION
This fixes an issue with SMB2 padding. Basically both the name and data fields were always being calculated into the buffer size and padded to the alignment. Now, the value is only padded for the first field, and then the second field is only padded if there is another entry (as determined by `next_offset != 0`.

This came up while I was testing an SMB server file. To validate the code in isolation, you can use this script. The data was taken from "Extra Info" field the last packet in the attached PCAP file. Right click and copy as a hex stream.

```
$LOAD_PATH.unshift(File.dirname(__FILE__) + '/lib')
require 'bindata'
require 'ruby_smb'
require 'pp'


bad_cc = '00000000100004000000180024000000444832430000000049df34a0000000000000000000000000d614e2b8517aee1197bd50eb711a599000000000'.scan(/../).map { |x| x.hex.chr }.join

ccar = nil
BinData::trace_reading do
  ccar = RubySMB::SMB2::CreateContext::CreateContextRequest.read(bad_cc)
end
PP.pp(ccar.snapshot)
```

## Before (Broken)

```
obj.next_offset => 0
obj.name_offset => 16
obj.name_length => 4
obj.reserved => 0
obj.data_offset => 24
obj.data_length => 36
/home/smcintyre/.rvm/gems/ruby-3.0.4/gems/bindata-2.4.15/lib/bindata/io.rb:317:in `read': data truncated (IOError)
	from /home/smcintyre/.rvm/gems/ruby-3.0.4/gems/bindata-2.4.15/lib/bindata/io.rb:278:in `readbytes'
	from /home/smcintyre/.rvm/gems/ruby-3.0.4/gems/bindata-2.4.15/lib/bindata/string.rb:118:in `read_and_return_value'
	from /home/smcintyre/.rvm/gems/ruby-3.0.4/gems/bindata-2.4.15/lib/bindata/base_primitive.rb:129:in `do_read'
	from /home/smcintyre/.rvm/gems/ruby-3.0.4/gems/bindata-2.4.15/lib/bindata/trace.rb:59:in `do_read_with_hook'
	from /home/smcintyre/.rvm/gems/ruby-3.0.4/gems/bindata-2.4.15/lib/bindata/struct.rb:140:in `block in do_read'
	from /home/smcintyre/.rvm/gems/ruby-3.0.4/gems/bindata-2.4.15/lib/bindata/struct.rb:140:in `each'
	from /home/smcintyre/.rvm/gems/ruby-3.0.4/gems/bindata-2.4.15/lib/bindata/struct.rb:140:in `do_read'
	from /home/smcintyre/.rvm/gems/ruby-3.0.4/gems/bindata-2.4.15/lib/bindata/base.rb:147:in `block in read'
	from /home/smcintyre/.rvm/gems/ruby-3.0.4/gems/bindata-2.4.15/lib/bindata/base.rb:253:in `start_read'
	from /home/smcintyre/.rvm/gems/ruby-3.0.4/gems/bindata-2.4.15/lib/bindata/base.rb:145:in `read'
	from /home/smcintyre/.rvm/gems/ruby-3.0.4/gems/bindata-2.4.15/lib/bindata/base.rb:21:in `read'
	from test.rb:11:in `block in <main>'
	from /home/smcintyre/.rvm/gems/ruby-3.0.4/gems/bindata-2.4.15/lib/bindata/trace.rb:32:in `trace_reading'
	from test.rb:10:in `<main>'
```

## After (Fixed)

```
obj.next_offset => 0
obj.name_offset => 16
obj.name_length => 4
obj.reserved => 0
obj.data_offset => 24
obj.data_length => 36
obj.buffer => "DH2C\x00\x00\x00\x00I\xDF4\xA0...
{:next_offset=>0,
 :name_offset=>16,
 :name_length=>4,
 :reserved=>0,
 :data_offset=>24,
 :data_length=>36,
 :buffer=>
  "DH2C\x00\x00\x00\x00I\xDF4\xA0\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xD6\x14\xE2\xB8Qz\xEE\x11\x97\xBDP\xEBq\x1AY\x90\x00\x00\x00\x00",
 :name=>"",
 :data=>""}
```
[bad_smb2_create_context.zip](https://github.com/rapid7/ruby_smb/files/13253131/bad_smb2_create_context.zip)