### PR TITLE
Close the opened directory after listing it's contents

### DIFF
--- a/lib/ruby_smb/smb2/tree.rb
+++ b/lib/ruby_smb/smb2/tree.rb
@@ -85,6 +85,7 @@ module RubySMB
       # @raise [RubySMB::Error::InvalidPacket] if the response is not a QueryDirectoryResponse packet
       def list(directory: nil, pattern: '*', type: RubySMB::Fscc::FileInformation::FileIdFullDirectoryInformation)
         create_response = open_directory(directory: directory)
+        opened_directory = RubySMB::SMB2::File.new(tree: self, response: create_response, name: directory)
         file_id         = create_response.file_id
 
         directory_request                         = RubySMB::SMB2::Packet::QueryDirectoryRequest.new
@@ -127,7 +128,7 @@ module RubySMB
           # Reset the message id so the client can update appropriately.
           directory_request.smb2_header.message_id = 0
         end
-
+        opened_directory.close
         files
       end
 

--- a/lib/ruby_smb/smb2/tree.rb
+++ b/lib/ruby_smb/smb2/tree.rb
@@ -128,8 +128,9 @@ module RubySMB
           # Reset the message id so the client can update appropriately.
           directory_request.smb2_header.message_id = 0
         end
-        opened_directory.close
         files
+      ensure
+        opened_directory.close
       end
 
       # 'Opens' a directory file on the remote end, using a CreateRequest. This

--- a/lib/ruby_smb/smb2/tree.rb
+++ b/lib/ruby_smb/smb2/tree.rb
@@ -130,7 +130,7 @@ module RubySMB
         end
         files
       ensure
-        opened_directory.close
+        opened_directory.close if opened_directory
       end
 
       # 'Opens' a directory file on the remote end, using a CreateRequest. This

--- a/spec/lib/ruby_smb/smb2/tree_spec.rb
+++ b/spec/lib/ruby_smb/smb2/tree_spec.rb
@@ -166,10 +166,14 @@ RSpec.describe RubySMB::SMB2::Tree do
     let(:create_res) { double('create response') }
     let(:query_dir_req) { RubySMB::SMB2::Packet::QueryDirectoryRequest.new }
     let(:query_dir_res) { RubySMB::SMB2::Packet::QueryDirectoryResponse.new }
+    let(:open_dir) { instance_double(RubySMB::SMB2::File) }
 
     before :example do
       allow(tree).to receive(:open_directory).and_return(create_res)
       allow(create_res).to receive(:file_id)
+      allow(RubySMB::SMB2::File).to receive(:new).and_return(open_dir)
+      allow(open_dir).to receive(:close)
+      allow(create_res).to receive(:file_attributes)
       allow(RubySMB::SMB2::Packet::QueryDirectoryRequest).to receive(:new).and_return(query_dir_req)
       allow(client).to receive(:send_recv)
       allow(RubySMB::SMB2::Packet::QueryDirectoryResponse).to receive(:read).and_return(query_dir_res)
@@ -180,6 +184,7 @@ RSpec.describe RubySMB::SMB2::Tree do
       dir = '/dir'
       expect(tree).to receive(:open_directory).with(directory: dir).and_return(create_res)
       tree.list(directory: dir)
+      expect(open_dir).to have_received(:close)
     end
 
     it 'uses the File ID from the create response' do


### PR DESCRIPTION
Noticed an issue when working on https://github.com/rapid7/metasploit-framework/pull/18539 where when listing the contents of a directory we don't close the handle to it resulting in weirdness on windows like not being able to rename any files located in that directory

To replicate add:
```
require 'pry-byebug'; binding.pry
puts 'done'
```
to the end of `examples/list_directory` to pause execution of the script so we don't disconnect
run this command `bundle exec ruby list_directory.rb <ip> <user> <pass> <share>`  example: `bundle exec ruby list_directory.rb 172.16.158.159 vagrant vagrant foo`

Then try to rename a file in the share you're listing and you'll get an error like this:

<img width="799" alt="image" src="https://github.com/rapid7/ruby_smb/assets/19910435/744a9786-64db-4291-99dc-db0cf9e8be18">

Check out this PR and run through the same steps and you should no longer hit the issue
