### PR TITLE
Add the #remove_share method to the server

### DIFF
--- a/lib/ruby_smb/server.rb
+++ b/lib/ruby_smb/server.rb
@@ -58,6 +58,14 @@ module RubySMB
       @shares[share_provider.name] = share_provider
     end
 
+    def remove_share(share_provider)
+      share_provider = share_provder.name if share_provider.is_a?(RubySMB::Server::Share::Provider::Base)
+      logger.debug("Removing share: #{share_provider}")
+      @shares.delete(share_provider)
+
+      nil
+    end
+
     # Run the server and accept any connections. For each connection, the block will be executed if specified. When the
     # block returns false, the loop will exit and the server will no long accept new connections.
     def run(&block)

--- a/lib/ruby_smb/server.rb
+++ b/lib/ruby_smb/server.rb
@@ -53,13 +53,15 @@ module RubySMB
       }
     end
 
+    # @param [Share::Provider::Base] share_provider the share provider to register
     def add_share(share_provider)
       logger.debug("Adding #{share_provider.type} share: #{share_provider.name}")
       @shares[share_provider.name] = share_provider
     end
 
+    # @param [String, Share::Provider::Base] share_provider the share provider to deregister
     def remove_share(share_provider)
-      share_provider = share_provder.name if share_provider.is_a?(RubySMB::Server::Share::Provider::Base)
+      share_provider = share_provider.name if share_provider.is_a?(RubySMB::Server::Share::Provider::Base)
       logger.debug("Removing share: #{share_provider}")
       @shares.delete(share_provider)
 


### PR DESCRIPTION
This is an easy one. It just adds the `#remove_share` method to the server. I'll need to use it to clean up once a single server instance can be shared by multiple modules in Metasploit as an HTTP service can be.

For testing, the easiest thing would probably be to wait until the corresponding Metasploit PR has been made and then just check that the cleanup method used it to remove the share using `smbclient` (e.g. `smbclient //192.168.159.128/Share1 -U smcintyre -N -c "dir *"`).