### PR TITLE
Add desired delete permissions when opening directory

### DIFF
--- a/lib/ruby_smb/smb2/tree.rb
+++ b/lib/ruby_smb/smb2/tree.rb
@@ -147,10 +147,11 @@ module RubySMB
       # @raise [RubySMB::Error::InvalidPacket] if the response is not a CreateResponse packet
       def open_directory(directory: nil, disposition: RubySMB::Dispositions::FILE_OPEN,
                          impersonation: RubySMB::ImpersonationLevels::SEC_IMPERSONATE,
-                         read: true, write: false, delete: false)
+                         read: true, write: false, delete: false, desired_delete: false)
 
         create_request  = open_directory_packet(directory: directory, disposition: disposition,
-                                                impersonation: impersonation, read: read, write: write, delete: delete)
+                                                impersonation: impersonation, read: read, write: write, delete: delete,
+                                                desired_delete: desired_delete)
         raw_response    = client.send_recv(create_request, encrypt: @tree_connect_encrypt_data)
         response = RubySMB::SMB2::Packet::CreateResponse.read(raw_response)
         unless response.valid?
@@ -178,7 +179,7 @@ module RubySMB
       # @return [RubySMB::SMB2::Packet::CreateRequest] the request packet to send to the server
       def open_directory_packet(directory: nil, disposition: RubySMB::Dispositions::FILE_OPEN,
                                 impersonation: RubySMB::ImpersonationLevels::SEC_IMPERSONATE,
-                                read: true, write: false, delete: false)
+                                read: true, write: false, delete: false, desired_delete: false)
         create_request = RubySMB::SMB2::Packet::CreateRequest.new
         create_request = set_header_fields(create_request)
 
@@ -189,6 +190,7 @@ module RubySMB
         create_request.share_access.read_access       = 1 if read
         create_request.share_access.write_access      = 1 if write
         create_request.share_access.delete_access     = 1 if delete
+        create_request.desired_access.delete_access   = 1 if desired_delete
         create_request.create_disposition             = disposition
 
         if directory.nil? || directory.empty?

--- a/ruby_smb.gemspec
+++ b/ruby_smb.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'rubyntlm'
   spec.add_runtime_dependency 'windows_error', '>= 0.1.4'
-  spec.add_runtime_dependency 'bindata'
+  spec.add_runtime_dependency 'bindata', '2.4.15'
   spec.add_runtime_dependency 'openssl-ccm'
   spec.add_runtime_dependency 'openssl-cmac'
 end


### PR DESCRIPTION
Drafted while we debug some issues with psexec

Pins the bindata version to 2.4.15 as 2.5.0 introduces significant changes that aren't currently compatible with ruby smb

Also aligns the permissions set when openign a directory with those of opening a file

Used by https://github.com/rapid7/metasploit-framework/pull/18895