### PR TITLE
Adds EOFError raise when a session is dead

### DIFF
--- a/lib/ruby_smb/client.rb
+++ b/lib/ruby_smb/client.rb
@@ -578,9 +578,9 @@ module RubySMB
         raw_response = dispatcher.recv_packet
       rescue RubySMB::Error::CommunicationError => e
         if encrypt
-          raise RubySMB::Error::EncryptionError, "Communication error with the "\
-            "remote host: #{e.message}. The server supports encryption but was "\
-            "not able to handle the encrypted request."
+          raise e, "Communication error with the "\
+            "remote host: #{e.message}. The server supports encryption and this error "\
+            "may have been caused by encryption issues, but not always."
         else
           raise e
         end

--- a/spec/lib/ruby_smb/client_spec.rb
+++ b/spec/lib/ruby_smb/client_spec.rb
@@ -471,9 +471,9 @@ RSpec.describe RubySMB::Client do
       it 'raises an EncryptionError exception if an error occurs while receiving the response' do
         allow(dispatcher).to receive(:recv_packet).and_raise(RubySMB::Error::CommunicationError)
         expect { client.recv_packet(encrypt: true) }.to raise_error(
-          RubySMB::Error::EncryptionError,
+          RubySMB::Error::CommunicationError,
           'Communication error with the remote host: RubySMB::Error::CommunicationError. '\
-          'The server supports encryption but was not able to handle the encrypted request.'
+          'The server supports encryption and this error may have been caused by encryption issues, but not always.'
         )
       end
 
@@ -2853,4 +2853,3 @@ RSpec.describe RubySMB::Client do
     end
   end
 end
-


### PR DESCRIPTION
> [!note]
This PR is in conjunction with a PR in [Metasploit-Framework](https://github.com/rapid7/metasploit-framework/pull/18960) . This PR will need to be landed before the framework PR.

This PR is to add a more precise error being raised when a session is dead. Currently in Metasploit-Framework if a session dies we would have had a `RubySMB::Error::EncryptionError` error being raised which wasn't accurate. This change will now raise an `RubySMB::Error::CommunicationError` when a session dies, which feels a lot closer in terms of accuracy.