### PR TITLE
Handle SMB2 compound related requests

### DIFF
--- a/lib/ruby_smb/server/server_client/session_setup.rb
+++ b/lib/ruby_smb/server/server_client/session_setup.rb
@@ -92,6 +92,8 @@ module RubySMB
             update_preauth_hash(response)
           end
 
+          @smb2_related_operations_state[:session_id] = session_id
+
           response
         end
 

--- a/lib/ruby_smb/server/server_client/session_setup.rb
+++ b/lib/ruby_smb/server/server_client/session_setup.rb
@@ -53,10 +53,12 @@ module RubySMB
         end
 
         def do_session_setup_smb2(request, session)
+          @smb2_related_operations_state.delete(:session_id)
+
           session_id = request.smb2_header.session_id
           if session_id == 0
             session_id = rand(1..0xfffffffe)
-            session = @session_table[session_id] = Session.new(session_id)
+            session = Session.new(session_id)
           else
             session = @session_table[session_id]
             if session.nil?
@@ -92,6 +94,8 @@ module RubySMB
             update_preauth_hash(response)
           end
 
+
+          @session_table[session_id] = session
           @smb2_related_operations_state[:session_id] = session_id
 
           response

--- a/lib/ruby_smb/server/server_client/share_io.rb
+++ b/lib/ruby_smb/server/server_client/share_io.rb
@@ -20,16 +20,46 @@ module RubySMB
         alias :do_transactions2_smb1  :proxy_share_io_smb1
 
         def proxy_share_io_smb2(request, session)
-          # see: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/9a639360-87be-4d49-a1dd-4c6be0c020bd
-          share_processor = session.tree_connect_table[request.smb2_header.tree_id]
+          if request.smb2_header.flags.related_operations == 0
+            # see: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/9a639360-87be-4d49-a1dd-4c6be0c020bd
+            share_processor = session.tree_connect_table[request.smb2_header.tree_id]
+            @smb2_related_operations_state[:tree_id] = request.smb2_header.tree_id
+          else
+            # see: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/46dd4182-62d3-4e30-9fe5-e2ec124edca1
+            if @smb2_related_operations_state.fetch(:tree_id) == 0
+              response = SMB2::Packet::ErrorPacket.new
+              response.smb2_header.nt_status = WindowsError::NTStatus::STATUS_INVALID_PARAMETER
+              return response
+            end
+            share_processor = session.tree_connect_table[@smb2_related_operations_state[:tree_id]]
+          end
+
           if share_processor.nil?
             response = SMB2::Packet::ErrorPacket.new
             response.smb2_header.nt_status = WindowsError::NTStatus::STATUS_NETWORK_NAME_DELETED
             return response
           end
 
+          if request.field_names.include?(:file_id)
+            if request.smb2_header.flags.related_operations == 0
+              @smb2_related_operations_state[:file_id] = request.file_id
+            elsif @smb2_related_operations_state[:file_id].nil?
+              response = SMB2::Packet::ErrorPacket.new
+              response.smb2_header.nt_status = WindowsError::NTStatus::STATUS_INVALID_HANDLE
+              return response
+            else
+              request.file_id = @smb2_related_operations_state[:file_id]
+            end
+          end
+
           logger.debug("Received #{SMB2::Commands.name(request.smb2_header.command)} request for share: #{share_processor.provider.name}")
-          share_processor.share_io(__callee__, request)
+          response = share_processor.share_io(__callee__, request)
+
+          if response.field_names.include?(:file_id)
+            @smb2_related_operations_state[:file_id] = response.file_id
+          end
+
+          response
         end
 
         alias :do_close_smb2           :proxy_share_io_smb2

--- a/lib/ruby_smb/server/server_client/tree_connect.rb
+++ b/lib/ruby_smb/server/server_client/tree_connect.rb
@@ -41,6 +41,8 @@ module RubySMB
         end
 
         def do_tree_connect_smb2(request, session)
+          @smb2_related_operations_state.delete(:tree_id)
+
           response = RubySMB::SMB2::Packet::TreeConnectResponse.new
           response.smb2_header.credits = 1
           if session.tree_connect_table.length >= MAX_TREE_CONNECTIONS

--- a/lib/ruby_smb/server/server_client/tree_connect.rb
+++ b/lib/ruby_smb/server/server_client/tree_connect.rb
@@ -75,6 +75,8 @@ module RubySMB
           session.tree_connect_table[tree_id] = share_processor = share_provider.new_processor(self, session)
           response.maximal_access = share_processor.maximal_access
 
+          @smb2_related_operations_state[:tree_id] = tree_id
+
           response
         end
 


### PR DESCRIPTION
This adds handling for compound SMB2 requests as defined here: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/46dd4182-62d3-4e30-9fe5-e2ec124edca1

I ran into this while working on an exploit that triggered a load over a UNC path from a Python app running on a Windows Server 2022 host. In this case, there was a create request followed by another request whose `#file_id` attribute was not populated leading the higher level read operation to fail.