### PR TITLE
Add GetKeySecurity and SetKeySecurity MS-RRP structures (DCERPC)

### DIFF
--- a/examples/registry_key_security_descriptor.rb
+++ b/examples/registry_key_security_descriptor.rb
@@ -1,0 +1,109 @@
+#!/usr/bin/ruby
+
+# This example script is used for testing the Winreg registry key security descriptor functionalities.
+# It will attempt to connect to a host and reads (or writes) the security descriptor of a specified registry key.
+#
+# Example usage:
+# - read:
+# ruby examples/read_registry_key_security.rb --username msfadmin --password msfadmin -i 7 -o r 192.168.172.138 'HKLM\SECURITY\Policy\PolEKList'
+# This will try to connect to \\192.168.172.138 with the msfadmin:msfadmin
+# credentialas and read the security descriptor of the
+# `HKLM\SECURITY\Policy\PolEKList` registry key with the security information 7
+# (OWNER_SECURITY_INFORMATION | GROUP_SECURITY_INFORMATION |
+# DACL_SECURITY_INFORMATION).
+#
+# - write:
+# ruby examples/read_registry_key_security.rb --username msfadmin --password msfadmin -i 4 --sd 01000480000000000000000000000000140000000200340002000000000214003f000f00010100000000000512000000000218000000060001020000000000052000000020020000 -o w 192.168.172.138 'HKLM\SECURITY\Policy\PolEKList'
+# This will try to connect to \\192.168.172.138 with the msfadmin:msfadmin
+# credentialas and write the given security descriptor to the
+# `HKLM\SECURITY\Policy\PolEKList` registry key with the security information 4
+# (DACL_SECURITY_INFORMATION).
+
+require 'bundler/setup'
+require 'optparse'
+require 'ruby_smb'
+
+OPERATIONS = %w{read write}
+OPERATION_ALIASES = { "r" => "read", "w" => "write" }
+
+args = ARGV.dup
+options = {
+  domain: '.',
+  username: '',
+  password: '',
+  smbv1: true,
+  smbv2: true,
+  smbv3: true,
+  target: nil,
+  key: nil,
+  operation: 'read',
+  info: RubySMB::Field::SecurityDescriptor::OWNER_SECURITY_INFORMATION | RubySMB::Field::SecurityDescriptor::GROUP_SECURITY_INFORMATION | RubySMB::Field::SecurityDescriptor::DACL_SECURITY_INFORMATION,
+  sd: nil
+}
+options[:key] = args.pop
+options[:target ] = args.pop
+optparser = OptionParser.new do |opts|
+  opts.banner = "Usage: #{File.basename(__FILE__)} [options] target reg_key"
+  opts.on('--[no-]smbv1', "Enable or disable SMBv1 (default: #{options[:smbv1] ? 'Enabled' : 'Disabled'})") do |smbv1|
+    options[:smbv1] = smbv1
+  end
+  opts.on('--[no-]smbv2', "Enable or disable SMBv2 (default: #{options[:smbv2] ? 'Enabled' : 'Disabled'})") do |smbv2|
+    options[:smbv2] = smbv2
+  end
+  opts.on('--[no-]smbv3', "Enable or disable SMBv3 (default: #{options[:smbv3] ? 'Enabled' : 'Disabled'})") do |smbv3|
+    options[:smbv3] = smbv3
+  end
+  opts.on('-u', '--username [USERNAME]', "The account's username (default: #{options[:username]})") do |username|
+    if username.include?('\\')
+      options[:domain], options[:username] = username.split('\\', 2)
+    else
+      options[:username] = username
+    end
+  end
+  opts.on('-p', '--password [PASSWORD]', "The account's password (default: #{options[:password]})") do |password|
+    options[:password] = password
+  end
+  operation_list = (OPERATION_ALIASES.keys + OPERATIONS).join(', ')
+  opts.on('-o', '--operation OPERATION', OPERATIONS, OPERATION_ALIASES, "The operation to perform on the registry key (default: #{options[:operation]})", "(#{operation_list})") do |operation|
+    options[:operation] = operation
+  end
+  opts.on('-i', '--info [SECURITY INFORMATION]', Integer, "The security information value (default: #{options[:info]})") do |password|
+    options[:info] = password
+  end
+  opts.on('-s', '--sd [SECURITY DESCRIPTOR]', "The security descriptor to write as an hex string") do |sd|
+    options[:sd] = sd
+  end
+end
+optparser.parse!(args)
+
+if options[:target].nil? || options[:key].nil?
+  abort(optparser.help)
+end
+
+sock = TCPSocket.new options[:target], 445
+dispatcher = RubySMB::Dispatcher::Socket.new(sock)
+
+client = RubySMB::Client.new(dispatcher, smb1: options[:smbv1], smb2: options[:smbv2], smb3: options[:smbv3], username: options[:username], password: options[:password], domain: options[:domain])
+protocol = client.negotiate
+status = client.authenticate
+
+puts "#{protocol}: #{status}"
+
+case options[:operation]
+when 'read', 'r'
+  puts "Read registry key #{options[:key]} security descriptor with security information #{options[:info]}"
+  security_descriptor = client.get_key_security_descriptor(options[:target], options[:key], options[:info])
+  puts "Security descriptor: #{security_descriptor.b.bytes.map {|c| "%02x" % c.ord}.join}"
+when 'write', 'w'
+  unless options[:sd] && !options[:sd].empty?
+    puts "Security descriptor missing"
+    abort(optparser.help)
+  end
+  puts "Write security descriptor #{options[:sd]} to registry key #{options[:key]} with security information #{options[:info]}"
+  sd = options[:sd].chars.each_slice(2).map {|c| c.join.to_i(16).chr}.join
+  status = client.set_key_security_descriptor(options[:target], options[:key], sd, options[:info])
+  puts "Success!"
+end
+
+client.disconnect!
+

--- a/lib/ruby_smb/client/winreg.rb
+++ b/lib/ruby_smb/client/winreg.rb
@@ -40,6 +40,18 @@ module RubySMB
         end
       end
 
+      def get_key_security_descriptor(host, key, security_information = RubySMB::Field::SecurityDescriptor::OWNER_SECURITY_INFORMATION)
+        connect_to_winreg(host) do |named_pipe|
+          named_pipe.get_key_security_descriptor(key, security_information)
+        end
+      end
+
+      def set_key_security_descriptor(host, key, security_descriptor, security_information = RubySMB::Field::SecurityDescriptor::OWNER_SECURITY_INFORMATION)
+        connect_to_winreg(host) do |named_pipe|
+          named_pipe.set_key_security_descriptor(key, security_descriptor, security_information)
+        end
+      end
+
     end
   end
 end

--- a/lib/ruby_smb/dcerpc/ndr.rb
+++ b/lib/ruby_smb/dcerpc/ndr.rb
@@ -563,8 +563,11 @@ module RubySMB::Dcerpc::Ndr
     def get_max_count(val)
       if is_a?(BinData::Stringz)
         max_count = val.to_s.strip.length
-        # Only count the terminating NULL byte if the string is not empty
-        max_count += 1 if max_count > 0
+        # Add one to count the terminator. According to
+        # https://pubs.opengroup.org/onlinepubs/9629399/chap14.htm#tagcjh_19_03_04_02,
+        # the NDR String must contain at least one element, the terminator. So,
+        # add one even if it is an empty string.
+        max_count += 1
         return max_count
       else
         return val.to_s.length
@@ -618,8 +621,11 @@ module RubySMB::Dcerpc::Ndr
     def update_actual_count(val)
       if is_a?(BinData::Stringz)
         @actual_count = val.to_s.strip.length
-        # Only count the terminating NULL byte if the string is not empty
-        @actual_count += 1 if @actual_count > 0
+        # Add one to count the terminator. According to
+        # https://pubs.opengroup.org/onlinepubs/9629399/chap14.htm#tagcjh_19_03_04,
+        # the NDR String must contain at least one element, the terminator. So,
+        # add one even if it is an empty string.
+        @actual_count += 1
       else
         @actual_count = val.to_s.length
       end

--- a/lib/ruby_smb/dcerpc/request.rb
+++ b/lib/ruby_smb/dcerpc/request.rb
@@ -18,22 +18,24 @@ module RubySMB
       choice :stub, label: 'Stub', selection: -> { @obj.parent.get_parameter(:endpoint) || '' } do
         string 'Encrypted'
         choice 'Winreg', selection: -> { opnum } do
-          open_root_key_request  Winreg::OPEN_HKCR, opnum: Winreg::OPEN_HKCR
-          open_root_key_request  Winreg::OPEN_HKCU, opnum: Winreg::OPEN_HKCU
-          open_root_key_request  Winreg::OPEN_HKLM, opnum: Winreg::OPEN_HKLM
-          open_root_key_request  Winreg::OPEN_HKPD, opnum: Winreg::OPEN_HKPD
-          open_root_key_request  Winreg::OPEN_HKU,  opnum: Winreg::OPEN_HKU
-          open_root_key_request  Winreg::OPEN_HKCC, opnum: Winreg::OPEN_HKCC
-          open_root_key_request  Winreg::OPEN_HKPT, opnum: Winreg::OPEN_HKPT
-          open_root_key_request  Winreg::OPEN_HKPN, opnum: Winreg::OPEN_HKPN
-          close_key_request      Winreg::REG_CLOSE_KEY
-          enum_key_request       Winreg::REG_ENUM_KEY
-          enum_value_request     Winreg::REG_ENUM_VALUE
-          open_key_request       Winreg::REG_OPEN_KEY
-          query_info_key_request Winreg::REG_QUERY_INFO_KEY
-          query_value_request    Winreg::REG_QUERY_VALUE
-          create_key_request     Winreg::REG_CREATE_KEY
-          save_key_request       Winreg::REG_SAVE_KEY
+          open_root_key_request     Winreg::OPEN_HKCR, opnum: Winreg::OPEN_HKCR
+          open_root_key_request     Winreg::OPEN_HKCU, opnum: Winreg::OPEN_HKCU
+          open_root_key_request     Winreg::OPEN_HKLM, opnum: Winreg::OPEN_HKLM
+          open_root_key_request     Winreg::OPEN_HKPD, opnum: Winreg::OPEN_HKPD
+          open_root_key_request     Winreg::OPEN_HKU,  opnum: Winreg::OPEN_HKU
+          open_root_key_request     Winreg::OPEN_HKCC, opnum: Winreg::OPEN_HKCC
+          open_root_key_request     Winreg::OPEN_HKPT, opnum: Winreg::OPEN_HKPT
+          open_root_key_request     Winreg::OPEN_HKPN, opnum: Winreg::OPEN_HKPN
+          close_key_request         Winreg::REG_CLOSE_KEY
+          enum_key_request          Winreg::REG_ENUM_KEY
+          enum_value_request        Winreg::REG_ENUM_VALUE
+          open_key_request          Winreg::REG_OPEN_KEY
+          query_info_key_request    Winreg::REG_QUERY_INFO_KEY
+          query_value_request       Winreg::REG_QUERY_VALUE
+          create_key_request        Winreg::REG_CREATE_KEY
+          save_key_request          Winreg::REG_SAVE_KEY
+          get_key_security_request  Winreg::REG_GET_KEY_SECURITY
+          set_key_security_request  Winreg::REG_SET_KEY_SECURITY
           string                 :default
         end
         choice 'Netlogon', selection: -> { opnum } do

--- a/lib/ruby_smb/dcerpc/rrp_rpc_unicode_string.rb
+++ b/lib/ruby_smb/dcerpc/rrp_rpc_unicode_string.rb
@@ -20,7 +20,7 @@ module RubySMB
         when BinData::Stringz, BinData::String, String
           self.buffer = val.to_s
           val_length = val.strip.length
-          val_length += 1 unless val == ''
+          val_length += 1
           self.buffer_length = val_length * 2
           self.maximum_length = val_length * 2
         else

--- a/lib/ruby_smb/dcerpc/winreg/get_key_security_request.rb
+++ b/lib/ruby_smb/dcerpc/winreg/get_key_security_request.rb
@@ -1,0 +1,26 @@
+module RubySMB
+  module Dcerpc
+    module Winreg
+
+      # This class represents a GetKeySecurity Request Packet as defined in
+      # [3.1.5.13 BaseRegGetKeySecurity (Opnum 12)](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rrp/b0e1868c-f4fd-4b43-959f-c0f0cac3ee26)
+      class GetKeySecurityRequest < BinData::Record
+        attr_reader :opnum
+
+        endian :little
+
+        rpc_hkey                :hkey
+        uint32                  :security_information
+        rpc_security_descriptor :prpc_security_descriptor_in
+
+        def initialize_instance
+          super
+          @opnum = REG_GET_KEY_SECURITY
+        end
+      end
+
+    end
+  end
+end
+
+

--- a/lib/ruby_smb/dcerpc/winreg/get_key_security_response.rb
+++ b/lib/ruby_smb/dcerpc/winreg/get_key_security_response.rb
@@ -1,0 +1,26 @@
+module RubySMB
+  module Dcerpc
+    module Winreg
+
+      # This class represents a GetKeySecurity Response Packet as defined in
+      # [3.1.5.13 BaseRegGetKeySecurity (Opnum 12)](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rrp/b0e1868c-f4fd-4b43-959f-c0f0cac3ee26)
+      class GetKeySecurityResponse < BinData::Record
+        attr_reader :opnum
+
+        endian :little
+
+        rpc_security_descriptor :prpc_security_descriptor_out
+        ndr_uint32              :error_status
+
+        def initialize_instance
+          super
+          @opnum = REG_GET_KEY_SECURITY
+        end
+      end
+
+    end
+  end
+end
+
+
+

--- a/lib/ruby_smb/dcerpc/winreg/query_value_response.rb
+++ b/lib/ruby_smb/dcerpc/winreg/query_value_response.rb
@@ -25,9 +25,11 @@ module RubySMB
         def data
           bytes = lp_data.to_a.pack('C*')
           case lp_type
+          when 0 # 0 is undefined type, let's consider an array of bytes
+            bytes
           when 1,2
             bytes.force_encoding('utf-16le').strip
-          when 0,3 # 0 is undefined type, let's consider an array of bytes
+          when 3
             bytes
           when 4
             bytes.unpack('V').first

--- a/lib/ruby_smb/dcerpc/winreg/query_value_response.rb
+++ b/lib/ruby_smb/dcerpc/winreg/query_value_response.rb
@@ -27,7 +27,7 @@ module RubySMB
           case lp_type
           when 1,2
             bytes.force_encoding('utf-16le').strip
-          when 3
+          when 0,3 # 0 is undefined type, let's consider an array of bytes
             bytes
           when 4
             bytes.unpack('V').first

--- a/lib/ruby_smb/dcerpc/winreg/set_key_security_request.rb
+++ b/lib/ruby_smb/dcerpc/winreg/set_key_security_request.rb
@@ -1,0 +1,26 @@
+module RubySMB
+  module Dcerpc
+    module Winreg
+
+      # This class represents a SetKeySecurity Request Packet as defined in
+      # [3.1.5.21 BaseRegSetKeySecurity (Opnum 21)](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rrp/da18856c-8a6d-4217-8e93-3625865e562c)
+      class SetKeySecurityRequest < BinData::Record
+        attr_reader :opnum
+
+        endian :little
+
+        rpc_hkey                :hkey
+        uint32                  :security_information
+        rpc_security_descriptor :prpc_security_descriptor
+
+        def initialize_instance
+          super
+          @opnum = REG_SET_KEY_SECURITY
+        end
+      end
+
+    end
+  end
+end
+
+

--- a/lib/ruby_smb/dcerpc/winreg/set_key_security_response.rb
+++ b/lib/ruby_smb/dcerpc/winreg/set_key_security_response.rb
@@ -1,0 +1,25 @@
+module RubySMB
+  module Dcerpc
+    module Winreg
+
+      # This class represents a SetKeySecurity Response Packet as defined in
+      # [3.1.5.21 BaseRegSetKeySecurity (Opnum 21)](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rrp/da18856c-8a6d-4217-8e93-3625865e562c)
+      class SetKeySecurityResponse < BinData::Record
+        attr_reader :opnum
+
+        endian :little
+
+        ndr_uint32 :error_status
+
+        def initialize_instance
+          super
+          @opnum = REG_SET_KEY_SECURITY
+        end
+      end
+
+    end
+  end
+end
+
+
+

--- a/lib/ruby_smb/field/security_descriptor.rb
+++ b/lib/ruby_smb/field/security_descriptor.rb
@@ -3,6 +3,23 @@ module RubySMB
     # Class representing a SECURITY_DESCRIPTOR as defined in
     # [2.4.6 SECURITY_DESCRIPTOR](https://msdn.microsoft.com/en-us/library/cc230366.aspx)
     class SecurityDescriptor < BinData::Record
+
+      # Security Information as defined in
+      # [2.4.7 SECURITY_INFORMATION](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/23e75ca3-98fd-4396-84e5-86cd9d40d343)
+      OWNER_SECURITY_INFORMATION               = 0x00000001
+      GROUP_SECURITY_INFORMATION               = 0x00000002
+      DACL_SECURITY_INFORMATION                = 0x00000004
+      SACL_SECURITY_INFORMATION                = 0x00000008
+      LABEL_SECURITY_INFORMATION               = 0x00000010
+      UNPROTECTED_SACL_SECURITY_INFORMATION    = 0x10000000
+      UNPROTECTED_DACL_SECURITY_INFORMATION    = 0x20000000
+      PROTECTED_SACL_SECURITY_INFORMATION      = 0x40000000
+      PROTECTED_DACL_SECURITY_INFORMATION      = 0x80000000
+      ATTRIBUTE_SECURITY_INFORMATION           = 0x00000020
+      SCOPE_SECURITY_INFORMATION               = 0x00000040
+      PROCESS_TRUST_LABEL_SECURITY_INFORMATION = 0x00000080
+      BACKUP_SECURITY_INFORMATION              = 0x00010000
+
       endian  :little
       uint8   :revision,  label: 'Revision', initial_value: 0x01
       uint8   :sbz1,      label: 'Resource Manager Control Bits'

--- a/spec/lib/ruby_smb/dcerpc/ndr_spec.rb
+++ b/spec/lib/ruby_smb/dcerpc/ndr_spec.rb
@@ -1352,6 +1352,15 @@ RSpec.describe RubySMB::Dcerpc::Ndr::NdrVarString do
     }
     let(:value) { 'ABCD' }
   end
+  context 'with an empty string' do
+    it_behaves_like 'a NDR String', conformant: false, char_size: 1, null_terminated: false do
+      let(:binary_stream) {
+        "\x00\x00\x00\x00"\
+        "\x00\x00\x00\x00".b
+      }
+      let(:value) { '' }
+    end
+  end
 end
 
 RSpec.describe RubySMB::Dcerpc::Ndr::NdrVarStringz do
@@ -1368,6 +1377,16 @@ RSpec.describe RubySMB::Dcerpc::Ndr::NdrVarStringz do
     }
     let(:value) { 'ABCD' }
   end
+  context 'with an empty string' do
+    it_behaves_like 'a NDR String', conformant: false, char_size: 1, null_terminated: true do
+      let(:binary_stream) {
+        "\x00\x00\x00\x00"\
+        "\x01\x00\x00\x00"\
+        "\x00".b
+      }
+      let(:value) { '' }
+    end
+  end
 end
 
 RSpec.describe RubySMB::Dcerpc::Ndr::NdrVarWideString do
@@ -1383,6 +1402,15 @@ RSpec.describe RubySMB::Dcerpc::Ndr::NdrVarWideString do
     }
     let(:value) { 'ABCD'.encode('utf-16le') }
   end
+  context 'with an empty string' do
+    it_behaves_like 'a NDR String', conformant: false, char_size: 2, null_terminated: false do
+      let(:binary_stream) {
+        "\x00\x00\x00\x00"\
+        "\x00\x00\x00\x00".b
+      }
+      let(:value) { '' }
+    end
+  end
 end
 
 RSpec.describe RubySMB::Dcerpc::Ndr::NdrVarWideStringz do
@@ -1397,6 +1425,16 @@ RSpec.describe RubySMB::Dcerpc::Ndr::NdrVarWideStringz do
       "\x41\x00\x42\x00\x43\x00\x44\x00\x00\x00".b
     }
     let(:value) { 'ABCD'.encode('utf-16le') }
+  end
+  context 'with an empty string' do
+    it_behaves_like 'a NDR String', conformant: false, char_size: 2, null_terminated: true do
+      let(:binary_stream) {
+        "\x00\x00\x00\x00"\
+        "\x01\x00\x00\x00"\
+        "\x00\x00".b
+      }
+      let(:value) { '' }
+    end
   end
 end
 
@@ -1415,6 +1453,16 @@ RSpec.describe RubySMB::Dcerpc::Ndr::NdrConfVarString do
     }
     let(:value) { 'ABCD' }
   end
+  context 'with an empty string' do
+    it_behaves_like 'a NDR String', conformant: true, char_size: 1, null_terminated: false do
+      let(:binary_stream) {
+        "\x00\x00\x00\x00"\
+        "\x00\x00\x00\x00"\
+        "\x00\x00\x00\x00".b
+      }
+      let(:value) { '' }
+    end
+  end
 end
 
 RSpec.describe RubySMB::Dcerpc::Ndr::NdrConfVarStringz do
@@ -1432,6 +1480,17 @@ RSpec.describe RubySMB::Dcerpc::Ndr::NdrConfVarStringz do
     }
     let(:value) { 'ABCD' }
   end
+  context 'with an empty string' do
+    it_behaves_like 'a NDR String', conformant: true, char_size: 1, null_terminated: true do
+      let(:binary_stream) {
+        "\x01\x00\x00\x00"\
+        "\x00\x00\x00\x00"\
+        "\x01\x00\x00\x00"\
+        "\x00".b
+      }
+      let(:value) { '' }
+    end
+  end
 end
 
 RSpec.describe RubySMB::Dcerpc::Ndr::NdrConfVarWideString do
@@ -1448,6 +1507,16 @@ RSpec.describe RubySMB::Dcerpc::Ndr::NdrConfVarWideString do
     }
     let(:value) { 'ABCD'.encode('utf-16le') }
   end
+  context 'with an empty string' do
+    it_behaves_like 'a NDR String', conformant: true, char_size: 2, null_terminated: false do
+      let(:binary_stream) {
+        "\x00\x00\x00\x00"\
+        "\x00\x00\x00\x00"\
+        "\x00\x00\x00\x00".b
+      }
+      let(:value) { '' }
+    end
+  end
 end
 
 RSpec.describe RubySMB::Dcerpc::Ndr::NdrConfVarWideStringz do
@@ -1463,6 +1532,17 @@ RSpec.describe RubySMB::Dcerpc::Ndr::NdrConfVarWideStringz do
       "\x41\x00\x42\x00\x43\x00\x44\x00\x00\x00".b
     }
     let(:value) { 'ABCD'.encode('utf-16le') }
+  end
+  context 'with an empty string' do
+    it_behaves_like 'a NDR String', conformant: true, char_size: 1, null_terminated: true do
+      let(:binary_stream) {
+        "\x01\x00\x00\x00"\
+        "\x00\x00\x00\x00"\
+        "\x01\x00\x00\x00"\
+        "\x00\x00".b
+      }
+      let(:value) { '' }
+    end
   end
 end
 


### PR DESCRIPTION
This adds two new operations to the [[MS-RRP]: Windows Remote Registry Protocol](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rrp/0fa3191d-bb79-490a-81bd-54c2601b7a78) DCERPC implementation.

- [3.1.5.13 BaseRegGetKeySecurity (Opnum 12)](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rrp/b0e1868c-f4fd-4b43-959f-c0f0cac3ee26)
- [3.1.5.21 BaseRegSetKeySecurity (Opnum 21)](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rrp/da18856c-8a6d-4217-8e93-3625865e562c)

This also includes a fix when passing an empty string to DCERPC requests, via RPC unicode strings or standard strings. This was causing NDR fault errors.
Now, it ensures at least one character (the string terminator) is counted. This follows the NDR protocol (see https://pubs.opengroup.org/onlinepubs/9629399/chap14.htm#tagcjh_19_03_04): the NDR String must contain at least one element, the terminator.

As a side note, it makes me wonder if the non-null-terminated NDR structures are relevant. NDR strings seems to always include the terminator. We might want to remove these structures and keep their null-terminated variant (same name but ending with `z`): `NdrVarString`, `NdrVarWideString`, `NdrConfVarString` and `NdrConfVarWideString`. Thta being said, it is too much changes for this PR and should be part of another PR.

### Testing
This includes a new example script `examples/registry_key_security_descriptor.rb` and can be used to test (it is documented in the script itself).

