### PR TITLE
Adding dsrgetdcnameex2 implementation

### DIFF
--- a/lib/ruby_smb/dcerpc/netlogon.rb
+++ b/lib/ruby_smb/dcerpc/netlogon.rb
@@ -11,6 +11,7 @@ module RubySMB
       NETR_SERVER_REQ_CHALLENGE = 4
       NETR_SERVER_AUTHENTICATE3 = 26
       NETR_SERVER_PASSWORD_SET2 = 30
+      DSR_GET_DC_NAME_EX2 = 34
 
       # see: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-nrpc/3b224201-b531-43e2-8c79-b61f6dea8640
       class LogonsrvHandle < Ndr::NdrWideStringzPtr; end
@@ -65,6 +66,7 @@ module RubySMB
       require 'ruby_smb/dcerpc/netlogon/netr_server_password_set2_response'
       require 'ruby_smb/dcerpc/netlogon/netr_server_req_challenge_request'
       require 'ruby_smb/dcerpc/netlogon/netr_server_req_challenge_response'
+      require 'ruby_smb/dcerpc/netlogon/dsr_get_dc_name_ex2_request'
 
       # Calculate the netlogon session key from the provided shared secret and
       # challenges. The shared secret is an NTLM hash.

--- a/lib/ruby_smb/dcerpc/netlogon.rb
+++ b/lib/ruby_smb/dcerpc/netlogon.rb
@@ -67,6 +67,7 @@ module RubySMB
       require 'ruby_smb/dcerpc/netlogon/netr_server_req_challenge_request'
       require 'ruby_smb/dcerpc/netlogon/netr_server_req_challenge_response'
       require 'ruby_smb/dcerpc/netlogon/dsr_get_dc_name_ex2_request'
+      require 'ruby_smb/dcerpc/netlogon/dsr_get_dc_name_ex2_response'
 
       # Calculate the netlogon session key from the provided shared secret and
       # challenges. The shared secret is an NTLM hash.

--- a/lib/ruby_smb/dcerpc/netlogon/domain_controller_infow.rb
+++ b/lib/ruby_smb/dcerpc/netlogon/domain_controller_infow.rb
@@ -1,0 +1,28 @@
+require 'ruby_smb/dcerpc/ndr'
+
+module RubySMB
+  module Dcerpc
+    module Netlogon
+
+      # [2.2.1.2.1 DOMAIN_CONTROLLER_INFOW](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-nrpc/9b85a7a4-8d34-4b9e-9500-bf8644ebfc06)
+      class DomainControllerInfoW < Ndr::NdrStruct
+        default_parameters byte_align: 4
+        endian :little
+
+        ndr_wide_stringz_ptr :domain_controller_name
+        ndr_wide_stringz_ptr :domain_controller_address
+        ndr_uint32           :domain_controller_address_type
+        uuid                 :domain_guid
+        ndr_wide_stringz_ptr :domain_name
+        ndr_wide_stringz_ptr :dns_forest_name
+        ndr_uint32           :flags
+        ndr_wide_stringz_ptr :dc_site_name
+        ndr_wide_stringz_ptr :client_site_name
+      end
+
+      class DomainControllerInfoWPtr < DomainControllerInfoW
+        extend Ndr::PointerClassPlugin
+      end
+    end
+  end
+end

--- a/lib/ruby_smb/dcerpc/netlogon/dsr_get_dc_name_ex2_request.rb
+++ b/lib/ruby_smb/dcerpc/netlogon/dsr_get_dc_name_ex2_request.rb
@@ -1,0 +1,28 @@
+require 'ruby_smb/dcerpc/ndr'
+
+module RubySMB
+  module Dcerpc
+    module Netlogon
+
+      # [3.5.4.3.1 DsrGetDCNameEx2 (Opnum 34)](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-nrpc/fb8e1146-a045-4c31-98d1-c68507ad5620)
+      class DsrGetDCNameEx2Request < BinData::Record
+        attr_reader :opnum
+
+        endian :little
+
+        logonsrv_handle  :computer_name
+        ndr_wide_stringz_ptr :account_name
+        ndr_uint32 :allowable_account_control_bits
+        ndr_wide_stringz_ptr :domain_name
+        uuid_ptr  :domain_guid
+        ndr_wide_stringz_ptr :site_name
+        ndr_uint32 :flags
+
+        def initialize_instance
+          super
+          @opnum = DSR_GET_DC_NAME_EX2
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby_smb/dcerpc/netlogon/dsr_get_dc_name_ex2_response.rb
+++ b/lib/ruby_smb/dcerpc/netlogon/dsr_get_dc_name_ex2_response.rb
@@ -1,22 +1,18 @@
 require 'ruby_smb/dcerpc/ndr'
+require 'ruby_smb/dcerpc/netlogon/domain_controller_infow'
 
 module RubySMB
   module Dcerpc
     module Netlogon
 
       # [3.5.4.3.1 DsrGetDcNameEx2 (Opnum 34)](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-nrpc/fb8e1146-a045-4c31-98d1-c68507ad5620)
-      class DsrGetDcNameEx2Request < BinData::Record
+      class DsrGetDcNameEx2Response < BinData::Record
         attr_reader :opnum
 
         endian :little
 
-        logonsrv_handle       :computer_name
-        ndr_wide_stringz_ptr  :account_name
-        ndr_uint32            :allowable_account_control_bits
-        ndr_wide_stringz_ptr  :domain_name
-        uuid_ptr              :domain_guid
-        ndr_wide_stringz_ptr  :site_name
-        ndr_uint32            :flags
+        domain_controller_info_w_ptr  :domain_controller_info
+        ndr_uint32                    :error_status
 
         def initialize_instance
           super


### PR DESCRIPTION
I need this DCERPC [call](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-nrpc/fb8e1146-a045-4c31-98d1-c68507ad5620) for my Metasploit module. I successfully implemented the request, but when it came to implementing the response, I always encountered problems with fields pointing to incorrect data. For my module, it's sufficient to implement only the request. However, with some assistance from you, perhaps we can also implement the response.
Here is the response's code which should be in file called ```dsr_get_dc_name_ex2_resoponse.rb```:
```require 'ruby_smb/dcerpc/ndr'

module RubySMB
  module Dcerpc
    module Netlogon

      # [3.5.4.3.1 DsrGetDCNameEx2 (Opnum 34)](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-nrpc/fb8e1146-a045-4c31-98d1-c68507ad5620)
      class DsrGetDCNameEx2Response < BinData::Record
        attr_reader :opnum

        endian :little

        pdomain_controller_info_w :domain_info
        ndr_uint32             :error_status

        def initialize_instance
          super
          @opnum =  DSR_GET_DC_NAME_EX2
        end
      end
    end
  end
end
```
Inside ```netlogin.rb``` there is the implementation for this [struct ](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-nrpc/9b85a7a4-8d34-4b9e-9500-bf8644ebfc06):
```
      class DomainControllerInfoW < Ndr::NdrStruct
        default_parameter byte_align: 4
        endian :little

        ndr_wide_stringz_ptr :dc_name
        ndr_wide_stringz_ptr :dc_address
        ndr_uint32 :dc_address_type
        uuid_ptr :domain_guid
        ndr_wide_stringz_ptr :domain_name
        ndr_wide_stringz_ptr :domain_forrest
        ndr_uint32 :flags
        ndr_wide_stringz_ptr :dc_site_name
        ndr_wide_stringz_ptr :client_site_name
      end

      class PdomainControllerInfoW < DomainControllerInfoW
        extend Ndr::PointerClassPlugin
      end
```
If I want to access for example `dc_address` I will get the data that related to `dc_name`
for `dc_name` I will get some non-printable bytes which located some where in the beginning of the response 