### PR TITLE
Fix an issue due to updating ruby_ntlm to 0.6.5

### DIFF
--- a/lib/ruby_smb/gss/provider/ntlm.rb
+++ b/lib/ruby_smb/gss/provider/ntlm.rb
@@ -155,9 +155,9 @@ module RubySMB
               their_blob = type3_msg.ntlm_response[digest.digest_length..-1]
 
               ntlmv2_hash = Net::NTLM.ntlmv2_hash(
-                RubySMB::Utils.safe_encode(account.username, 'UTF-16LE'),
-                RubySMB::Utils.safe_encode(account.password, 'UTF-16LE'),
-                RubySMB::Utils.safe_encode(type3_msg.domain, 'UTF-16LE'),  # don't use the account domain because of the special '.' value
+                Net::NTLM::EncodeUtil.encode_utf16le(account.username),
+                Net::NTLM::EncodeUtil.encode_utf16le(account.password),
+                type3_msg.domain.force_encoding('ASCII-8BIT'),  # don't use the account domain because of the special '.' value
                 {client_challenge: their_blob[16...24], unicode: true}
               )
 


### PR DESCRIPTION
There was a PR that changed how strings were being encoded that was added to [ruby_ntlm 0.6.5](https://github.com/WinRb/rubyntlm/releases/tag/v0.6.5) that is causing tests to break.

Tested that `ruby examples/tree_connect.rb --username юзер --password 123456 192.168.159.10 IPC$` continues to work. Things also still work with rubyntlm==0.6.4.