### PR TITLE
Adds metasploit-frameworks acceptance tests

### DIFF
--- a/.github/workflows/metasploit-framework_acceptance.yml
+++ b/.github/workflows/metasploit-framework_acceptance.yml
@@ -1,0 +1,47 @@
+name: Metasploit Framework Acceptance
+
+# Optional, enabling concurrency limits: https://docs.github.com/en/actions/using-jobs/using-concurrency
+#concurrency:
+#  group: ${{ github.ref }}-${{ github.workflow }}
+#  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
+permissions:
+  actions: none
+  checks: none
+  contents: none
+  deployments: none
+  id-token: none
+  issues: none
+  discussions: none
+  packages: none
+  pages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: none
+
+on:
+  workflow_dispatch:
+    inputs:
+      metasploitFrameworkCommit:
+        description: 'metasploit-framework branch would like to test'
+        required: true
+        default: 'master'
+  push:
+    branches-ignore:
+      - gh-pages
+      - metakitty
+  pull_request:
+    branches:
+      - '*'
+#   Example of running as a cron, to weed out flaky tests
+#  schedule:
+#    - cron: '*/15 * * * *'
+
+jobs:
+  build:
+    uses: rapid7/metasploit-framework/.github/workflows/shared_smb_acceptance.yml@master
+    with:
+      metasploit_framework_commit: ${{ github.event.inputs.metasploitFrameworkCommit }}
+      build_smb: true


### PR DESCRIPTION
This PR adds metasploit-framework's acceptance testing to mettle. This is in the aim of detecting framework breaking changes made in this repository before they reach framework. 

Functionality has also been added to specify a metasploit-framework branch you would like to test. This will allow for running workflows via GitHub actions that will take a metasploit-framework branch as an argument and run the acceptance test against specifically that framework branch.

New label - `metasploit-framework-testing-branch`

# Verification

- [ ] Code changes looks sane
- [ ] Verify acceptance tests flow and work as expected 