### PR TITLE
Add the ability to query group memberships

### DIFF
--- a/lib/ruby_smb/dcerpc/request.rb
+++ b/lib/ruby_smb/dcerpc/request.rb
@@ -70,6 +70,8 @@ module RubySMB
           samr_close_handle_request                    Samr::SAMR_CLOSE_HANDLE
           samr_get_alias_membership_request            Samr::SAMR_GET_ALIAS_MEMBERSHIP
           samr_open_user_request                       Samr::SAMR_OPEN_USER
+          samr_open_group_request                      Samr::SAMR_OPEN_GROUP
+          samr_get_members_in_group_request            Samr::SAMR_GET_MEMBERS_IN_GROUP
           samr_get_groups_for_user_request             Samr::SAMR_GET_GROUPS_FOR_USER
           samr_enumerate_domains_in_sam_server_request Samr::SAMR_ENUMERATE_DOMAINS_IN_SAM_SERVER
           samr_lookup_names_in_domain_request          Samr::SAMR_LOOKUP_NAMES_IN_DOMAIN

--- a/lib/ruby_smb/dcerpc/samr/samr_get_members_in_group_request.rb
+++ b/lib/ruby_smb/dcerpc/samr/samr_get_members_in_group_request.rb
@@ -1,0 +1,23 @@
+module RubySMB
+  module Dcerpc
+    module Samr
+
+      # [3.1.5.8.3 SamrGetMembersInGroup (Opnum 25)](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/3ed5030d-88a3-42ca-a6e0-8c12aa2fdfbd)
+      class SamrGetMembersInGroupRequest < BinData::Record
+        attr_reader :opnum
+
+        endian :little
+
+        sampr_handle :group_handle
+
+        def initialize_instance
+          super
+          @opnum = SAMR_GET_MEMBERS_IN_GROUP
+        end
+      end
+
+    end
+  end
+end
+
+

--- a/lib/ruby_smb/dcerpc/samr/samr_get_members_in_group_response.rb
+++ b/lib/ruby_smb/dcerpc/samr/samr_get_members_in_group_response.rb
@@ -25,7 +25,7 @@ module RubySMB
 
         def initialize_instance
           super
-          @opnum = SAMR_GET_GROUPS_FOR_USER
+          @opnum = SAMR_GET_MEMBERS_IN_GROUP
         end
       end
     end

--- a/lib/ruby_smb/dcerpc/samr/samr_get_members_in_group_response.rb
+++ b/lib/ruby_smb/dcerpc/samr/samr_get_members_in_group_response.rb
@@ -1,0 +1,34 @@
+module RubySMB
+  module Dcerpc
+    module Samr
+      # [2.2.7.14 SAMPR_GET_MEMBERS_BUFFER](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/225147b1-45b7-4fde-a5bf-bf420e18fa08)
+      class SamprGetMembersBuffer < Ndr::NdrStruct
+        default_parameter byte_align: 4
+
+        ndr_uint32            :member_count
+        ndr_uint32_conf_array_ptr  :members,    type: :ndr_uint32
+        ndr_uint32_conf_array_ptr  :attributes, type: :ndr_uint32 
+      end
+
+      class PsamprGetMembersBuffer < SamprGetMembersBuffer
+        extend Ndr::PointerClassPlugin
+      end
+
+      # [2.1.5.8.3 SamrGetMembersInGroup (Opnum 25)](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/a4adbf20-040f-4416-a960-e5b7917fdae7)
+      class SamrGetMembersInGroupResponse < BinData::Record
+        attr_reader :opnum
+
+        endian :little
+
+        psampr_get_members_buffer :members
+        ndr_uint32               :error_status
+
+        def initialize_instance
+          super
+          @opnum = SAMR_GET_GROUPS_FOR_USER
+        end
+      end
+    end
+  end
+end
+

--- a/lib/ruby_smb/dcerpc/samr/samr_open_group_request.rb
+++ b/lib/ruby_smb/dcerpc/samr/samr_open_group_request.rb
@@ -1,0 +1,26 @@
+module RubySMB
+  module Dcerpc
+    module Samr
+
+      # [3.1.5.1.7 SamrOpenGroup (Opnum 19)](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/d396e6c9-d04a-4729-b0d8-f50f2748f3c8)
+      class SamrOpenGroupRequest < BinData::Record
+        attr_reader :opnum
+
+        endian :little
+
+        sampr_handle :domain_handle
+        # Access control on a server object: bitwise OR of common ACCESS_MASK
+        # and user ACCESS_MASK values (see lib/ruby_smb/dcerpc/samr.rb)
+        ndr_uint32   :desired_access
+        ndr_uint32   :group_id
+
+        def initialize_instance
+          super
+          @opnum = SAMR_OPEN_GROUP
+        end
+      end
+
+    end
+  end
+end
+

--- a/lib/ruby_smb/dcerpc/samr/samr_open_group_response.rb
+++ b/lib/ruby_smb/dcerpc/samr/samr_open_group_response.rb
@@ -1,0 +1,24 @@
+module RubySMB
+  module Dcerpc
+    module Samr
+
+      # [3.1.5.1.7 SamrOpenGroup (Opnum 19)](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/d396e6c9-d04a-4729-b0d8-f50f2748f3c8)
+      class SamrOpenGroupResponse < BinData::Record
+        attr_reader :opnum
+
+        endian :little
+
+        sampr_handle :group_handle
+        ndr_uint32   :error_status
+
+        def initialize_instance
+          super
+          @opnum = SAMR_OPEN_GROUP
+        end
+      end
+
+    end
+  end
+end
+
+


### PR DESCRIPTION
Added two SAMR messages, enabling querying group membership.

Supporting https://github.com/rapid7/metasploit-framework/pull/19643