### PR TITLE
Fix two fields in UserProperties

### DIFF
--- a/lib/ruby_smb/dcerpc/samr.rb
+++ b/lib/ruby_smb/dcerpc/samr.rb
@@ -443,8 +443,8 @@ module RubySMB
         uint16 :reserved3
         string :reserved4, length: 96
         uint16 :property_signature, initial_value: 0x50
-        uint16 :property_count, initial_value: -> { user_properties.size }
-        array  :user_properties, type: :user_property, initial_length: :property_count
+        uint16 :property_count, initial_value: -> { user_properties.size }, onlyif: -> { struct_length > 111 }
+        array  :user_properties, type: :user_property, initial_length: :property_count, onlyif: :property_count?
         uint8  :reserved5
       end
 


### PR DESCRIPTION
This fixes the definition of the `PropertyCount` and `UserProperties` fields that can be omitted. Based on the [docs](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/8263e7ab-aba9-43d2-8a36-3a9cb2dd3dad).

> When there are zero USER_PROPERTY elements in the UserProperties field, this field MUST be omitted; the resultant USER_PROPERTIES structure has a constant size of 0x6F bytes.

This allows the structure to be read correctly even when there are not user properties. Allowing the structure to be read fixes the IOError that's raised when there are no kerberos keys as identified in rapid7/metasploit-framework#19665.