### PR TITLE
Fix an issue with the UserProperties structure

### DIFF
--- a/lib/ruby_smb/dcerpc/samr.rb
+++ b/lib/ruby_smb/dcerpc/samr.rb
@@ -453,12 +453,7 @@ module RubySMB
         uint8  :reserved5
 
         def display_user_properties?
-          bytes_remaining > 1 || user_properties.size > 0
-        end
-
-        def do_read(io)
-          super
-          bytes_remaining.clear
+          (bytes_remaining > 1 && reading?) || user_properties.size > 0
         end
       end
 

--- a/lib/ruby_smb/dcerpc/samr.rb
+++ b/lib/ruby_smb/dcerpc/samr.rb
@@ -436,16 +436,30 @@ module RubySMB
       # [2.2.10.1 USER_PROPERTIES](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/8263e7ab-aba9-43d2-8a36-3a9cb2dd3dad)
       class UserProperties < BinData::Record
         endian :little
+        hide   :bytes_remaining
 
         uint32 :reserved1
-        uint32 :struct_length, initial_value: -> { num_bytes - 12 }
+        # Length, in bytes, of the entire structure, starting from the :reserved4 field (offset 12):
+        uint32 :struct_length, value: -> { num_bytes - 12}
         uint16 :reserved2
         uint16 :reserved3
         string :reserved4, length: 96
         uint16 :property_signature, initial_value: 0x50
-        uint16 :property_count, initial_value: -> { user_properties.size }, onlyif: -> { struct_length > 111 }
-        array  :user_properties, type: :user_property, initial_length: :property_count, onlyif: :property_count?
+        count_bytes_remaining :bytes_remaining
+        # When there are zero `user_property` elements in the `:user_properties` field, this field MUST be omitted;
+        # the resultant `UserProperties` structure has a constant size of 0x6F bytes.
+        uint16 :property_count, value: -> { user_properties.size }, onlyif: :display_user_properties?
+        array  :user_properties, type: :user_property, read_until: -> { array.size == property_count }, onlyif: :display_user_properties?
         uint8  :reserved5
+
+        def display_user_properties?
+          bytes_remaining > 1 || user_properties.size > 0
+        end
+
+        def do_read(io)
+          super
+          bytes_remaining.clear
+        end
       end
 
       # [2.2.10.7 KERB_KEY_DATA_NEW](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/447520a5-e1cc-48cc-8fdc-b90db57f7eac)


### PR DESCRIPTION
The last [changes](https://github.com/rapid7/ruby_smb/pull/280) of the `SAMR` DCERPC structures introduced an unexpected bug in the `UserProperties` structure when instantiating a new object. This PR fixes the issue, but it is still a workaround, there might be a simpler solution.


## Without this fix
```
> pry -r ruby_smb
[1] pry(main)> RubySMB::Dcerpc::Samr::UserProperties.new
<it crashes pry with a giant stacktrace>
```

## With this fix
```
pry -r ruby_smb
[1] pry(main)> RubySMB::Dcerpc::Samr::UserProperties.new
=> {:reserved1=>0,
 :struct_length=>99,
 :reserved2=>0,
 :reserved3=>0,
 :reserved4=>
  "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00",
 :property_signature=>80,
 :reserved5=>0}
```

## Scenarios

It has been tested locally with `pry` to make sure it follows the rules defined in the MS [doc](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/8263e7ab-aba9-43d2-8a36-3a9cb2dd3dad):
- Instantiation and adding/removing `UserProperty` entries:
```
[3] pry(main)> ups = RubySMB::Dcerpc::Samr::UserProperties.new
=> {:reserved1=>0,
 :struct_length=>99,
 :reserved2=>0,
 :reserved3=>0,
 :reserved4=>
  "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00",
 :property_signature=>80,
 :reserved5=>0}
[4] pry(main)> userprop1 = RubySMB::Dcerpc::Samr::UserProperty.new({property_name:"h", property_value:"b"})
=> {:name_length=>2, :value_length=>1, :reserved=>0, :property_name=>"h", :property_value=>"b"}
[5] pry(main)> ups.user_properties << userprop1
=> [{:name_length=>2, :value_length=>1, :reserved=>0, :property_name=>"h", :property_value=>"b"}]
[6] pry(main)> ups
=> {:reserved1=>0,
 :struct_length=>110,
 :reserved2=>0,
 :reserved3=>0,
 :reserved4=>
  "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00",
 :property_signature=>80,
 :property_count=>1,
 :user_properties=>[{:name_length=>2, :value_length=>1, :reserved=>0, :property_name=>"h", :property_value=>"b"}],
 :reserved5=>0}
[7] pry(main)> ups.user_properties << userprop1
=> [{:name_length=>2, :value_length=>1, :reserved=>0, :property_name=>"h", :property_value=>"b"},
 {:name_length=>2, :value_length=>1, :reserved=>0, :property_name=>"h", :property_value=>"b"}]
[8] pry(main)> ups
=> {:reserved1=>0,
 :struct_length=>119,
 :reserved2=>0,
 :reserved3=>0,
 :reserved4=>
  "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00",
 :property_signature=>80,
 :property_count=>2,
 :user_properties=>
  [{:name_length=>2, :value_length=>1, :reserved=>0, :property_name=>"h", :property_value=>"b"},
   {:name_length=>2, :value_length=>1, :reserved=>0, :property_name=>"h", :property_value=>"b"}],
 :reserved5=>0}
[9] pry(main)> ups.user_properties = []
=> []
[10] pry(main)> ups
=> {:reserved1=>0,
 :struct_length=>99,
 :reserved2=>0,
 :reserved3=>0,
 :reserved4=>
  "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00",
 :property_signature=>80,
 :reserved5=>0}
```
- Reading a binary stream:
```
[11] pry(main)> ups = RubySMB::Dcerpc::Samr::UserProperties.read("\x00\x00\x00\x00c\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00P\x00\x00")
=> {:reserved1=>0,
 :struct_length=>99,
 :reserved2=>0,
 :reserved3=>0,
 :reserved4=>
  "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00",
 :property_signature=>80,
 :reserved5=>0}
[12] pry(main)> ups.user_properties << userprop1
=> [{:name_length=>2, :value_length=>1, :reserved=>0, :property_name=>"h", :property_value=>"b"}]
[13] pry(main)> ups
=> {:reserved1=>0,
 :struct_length=>110,
 :reserved2=>0,
 :reserved3=>0,
 :reserved4=>
  "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00",
 :property_signature=>80,
 :property_count=>1,
 :user_properties=>[{:name_length=>2, :value_length=>1, :reserved=>0, :property_name=>"h", :property_value=>"b"}],
 :reserved5=>0}
```
```
[14] pry(main)> ups = RubySMB::Dcerpc::Samr::UserProperties.read("\x00\x00\x00\x00n\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00P\x00\x01\x00\x02\x00\x01\x00\x00\x00h\x00f\x00")
=> {:reserved1=>0,
 :struct_length=>110,
 :reserved2=>0,
 :reserved3=>0,
 :reserved4=>
  "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00",
 :property_signature=>80,
 :property_count=>1,
 :user_properties=>[{:name_length=>2, :value_length=>1, :reserved=>0, :property_name=>"h", :property_value=>"f"}],
 :reserved5=>0}
```

This has also been tested with the Metasploit `gather/windows_secrets_dump` to make sure it still fixes the original [issue](https://github.com/rapid7/metasploit-framework/pull/19665).

## TODO
Write specs or these new structures.