### PR TITLE
Refactor EPM Functionality

### DIFF
--- a/examples/epm_client.rb
+++ b/examples/epm_client.rb
@@ -1,0 +1,65 @@
+#!/usr/bin/ruby
+
+require 'bundler/setup'
+require 'ruby_smb'
+
+require 'optparse'
+require 'pp'
+
+options = {
+  major_version: 1,
+  minor_version: 0,
+  max_towers: 1,
+}
+
+parser = OptionParser.new do |opts|
+  opts.banner = "Usage: script.rb [options] TARGET PROTOCOL UUID"
+
+  opts.on("--major-version N", Integer, "Specify major version number (default: #{options[:major_version]})") do |v|
+    options[:major_version] = v
+  end
+
+  opts.on("--minor-version N", Integer, "Specify minor version number ((default: #{options[:minor_version]})") do |v|
+    options[:minor_version] = v
+  end
+
+  opts.on("--max-towers N", Integer, "Set the maximum number of towers (default: #{options[:max_towers]})") do |v|
+    options[:max_towers] = v
+  end
+
+  opts.on("-h", "--help", "Prints this help") do
+    puts opts
+    exit
+  end
+end
+
+# Parse and extract positional arguments
+begin
+  parser.order!(ARGV)
+  if ARGV.size != 3
+    raise OptionParser::MissingArgument, "TARGET, PROTOCOL, and UUID are required"
+  end
+
+  options[:target], options[:protocol], options[:uuid] = ARGV
+rescue OptionParser::ParseError => e
+  puts e.message
+  puts parser
+  exit 1
+end
+
+dcerpc_client = RubySMB::Dcerpc::Client.new(options[:target], RubySMB::Dcerpc::Epm)
+dcerpc_client.connect
+dcerpc_client.bind
+dcerpc_client.ept_map(
+  uuid: options[:uuid],
+  maj_ver: options[:major_version],
+  min_ver: options[:minor_version],
+  protocol: options[:protocol].to_sym,
+  max_towers: options[:max_towers]
+).each do |tower|
+  puts "Tower: #{tower[:endpoint]}"
+  tower.each do |key, value|
+    next if key == :endpoint
+    puts "  #{key}: #{value}"
+  end
+end

--- a/lib/ruby_smb/dcerpc.rb
+++ b/lib/ruby_smb/dcerpc.rb
@@ -28,6 +28,7 @@ module RubySMB
     DCE_C_AUTHZ_DCE  = 2
 
     require 'windows_error/win32'
+    require 'ruby_smb/dcerpc/client'
     require 'ruby_smb/dcerpc/error'
     require 'ruby_smb/dcerpc/fault'
     require 'ruby_smb/dcerpc/uuid'
@@ -189,6 +190,8 @@ module RubySMB
     # @raise [ArgumentError] if `:auth_type` is unknown
     # @raise [NotImplementedError] if `:auth_type` is not implemented (yet)
     def bind(options={})
+      options = options.merge(endpoint: @endpoint) if !options[:endpoint] && defined?(:@endpoint) && @endpoint
+
       @call_id ||= 1
       bind_req = Bind.new(options)
       bind_req.pdu_header.call_id = @call_id

--- a/lib/ruby_smb/dcerpc/client.rb
+++ b/lib/ruby_smb/dcerpc/client.rb
@@ -152,8 +152,8 @@ module RubySMB
           else
             epm_client = Client.new(@host, Epm, read_timeout: @read_timeout)
             epm_client.connect
-            epm_client.bind
             begin
+              epm_client.bind
               towers = epm_client.ept_map_endpoint(@endpoint)
             rescue RubySMB::Dcerpc::Error::DcerpcError => e
               e.message.prepend(
@@ -162,6 +162,8 @@ module RubySMB
                 "EPM port resolution. Error: "
               )
               raise e
+            ensure
+              epm_client.close
             end
 
             port = towers.first[:port]

--- a/lib/ruby_smb/dcerpc/epm.rb
+++ b/lib/ruby_smb/dcerpc/epm.rb
@@ -13,33 +13,26 @@ module RubySMB
       require 'ruby_smb/dcerpc/epm/epm_ept_map_request'
       require 'ruby_smb/dcerpc/epm/epm_ept_map_response'
 
-      # Retrieve the service port number given a DCERPC interface UUID
-      # See:
-      # [2.2.1.2.5 ept_map Method](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rpce/ab744583-430e-4055-8901-3c6bc007e791)
-      # [https://pubs.opengroup.org/onlinepubs/9629399/apdxo.htm](https://pubs.opengroup.org/onlinepubs/9629399/apdxo.htm)
-      #
-      # @param uuid [String] The interface UUID
-      # @param maj_ver [Integer] The interface Major version
-      # @param min_ver [Integer] The interface Minor version
-      # @param max_towers [Integer] The maximum number of elements to be returned
-      # @return [Hash] A hash with the host and port
-      # @raise [RubySMB::Dcerpc::Error::InvalidPacket] if the response is not a
-      #   EpmEptMap packet
-      # @raise [RubySMB::Dcerpc::Error::EpmError] if the response error status
-      #   is not STATUS_SUCCESS
-      def get_host_port_from_ept_mapper(uuid:, maj_ver:, min_ver:, max_towers: 1)
-        decoded_tower = EpmDecodedTowerOctetString.new(
-          interface_identifier: {
-            interface: uuid,
-            major_version: maj_ver,
-            minor_version: min_ver
-          },
-          data_representation: {
-            interface: Ndr::UUID,
-            major_version: Ndr::VER_MAJOR,
-            minor_version: Ndr::VER_MINOR
-          }
-        )
+      def ept_map(uuid:, maj_ver:, min_ver:, max_towers: 1, protocol: :ncacn_ip_tcp)
+        case protocol
+        when :ncacn_ip_tcp
+          result_key = :port
+          decoded_tower = EpmDecodedTowerOctetString.new(
+            interface_identifier: {
+              interface: uuid,
+              major_version: maj_ver,
+              minor_version: min_ver
+            },
+            data_representation: {
+              interface: Ndr::UUID,
+              major_version: Ndr::VER_MAJOR,
+              minor_version: Ndr::VER_MINOR
+            }
+          )
+        else
+          raise NotImplementedError, "Unsupported protocol: #{protocol}"
+        end
+
         tower = EpmTwrt.new(decoded_tower)
         ept_map_request = EpmEptMapRequest.new(
           obj: Uuid.new,
@@ -53,21 +46,30 @@ module RubySMB
         rescue IOError
           raise RubySMB::Dcerpc::Error::InvalidPacket, 'Error reading EptMapResponse'
         end
+
         unless ept_map_response.error_status == WindowsError::NTStatus::STATUS_SUCCESS
           raise RubySMB::Dcerpc::Error::EpmError,
             "Error returned with ept_map: "\
             "#{WindowsError::NTStatus.find_by_retval(ept_map_response.error_status.value).join(',')}"
         end
-        tower_binary = ept_map_response.towers[0].tower_octet_string.to_binary_s
-        begin
-          decoded_tower = EpmDecodedTowerOctetString.read(tower_binary)
-        rescue IOError
-          raise RubySMB::Dcerpc::Error::InvalidPacket, 'Error reading EpmDecodedTowerOctetString'
+
+        ept_map_response.towers.map do |tower|
+          tower_binary = tower.tower_octet_string.to_binary_s
+          begin
+            decoded_tower = EpmDecodedTowerOctetString.read(tower_binary)
+          rescue IOError
+            raise RubySMB::Dcerpc::Error::InvalidPacket, 'Error reading EpmDecodedTowerOctetString'
+          end
+
+          {
+            result_key => decoded_tower.pipe_or_port.pipe_or_port.to_i,
+            :host => decoded_tower.host_or_addr.host_or_addr.to_i
+          }
         end
-        {
-          port: decoded_tower.pipe_or_port.pipe_or_port.to_i,
-          host: decoded_tower.host_or_addr.host_or_addr.to_i
-        }
+      end
+
+      def ept_map_endpoint(endpoint, **kwargs)
+        ept_map(uuid: endpoint::UUID, maj_ver: endpoint::VER_MAJOR, min_ver: endpoint::VER_MINOR, **kwargs)
       end
     end
   end

--- a/lib/ruby_smb/dcerpc/epm/epm_twrt.rb
+++ b/lib/ruby_smb/dcerpc/epm/epm_twrt.rb
@@ -27,39 +27,39 @@ module RubySMB
 
         uint16 :lhs_bytecount, byte_align: 1, initial_value: -> {prot_identifier.num_bytes}
         # Protocol Identifiers:
-		# 0x00: "OSI Object Identifier [OID]"
-		# 0x02: "DNA Session Control Phase 4"
-		# 0x03: "DNA Session Control V3 Phase 5"
-		# 0x04: "DNA NSP Transport"
-		# 0x05: "OSI TP4 [T-Selector]"
-		# 0x06: "OSI CLNS [NSAP]"
-		# 0x07: "DOD TCP port"
-		# 0x08: "DOD UDP port"
-		# 0x09: "DOD IP v4 big-endian"
-		# 0x0a: "RPC Connectionless v4"
-		# 0x0b: "RPC Connection-oriented v5"
-		# 0x0c: "MS Named Pipes"
-		# 0x0d: "UUID"
-		# 0x0e: "ncadg_ipx"
-		# 0x0f: "NetBIOS Named Pipes"
-		# 0x10: "MS Named Pipe Name" or "Local InterProcess Communication (LRPC)")
-		# 0x11: "MS NetBIOS"
-		# 0x12: "MS NetBEUI"
-		# 0x13: "Netware SPX"
-		# 0x14: "Netware IPX"
-		# 0x15: "NMP_TOWER_ID"
-		# 0x16: "Appletalk Stream [endpoint]"
-		# 0x17: "Appletalk Datagram [endpoint]"
-		# 0x18: "Appletalk [NBP-style Name]"
-		# 0x19: "NetBIOS [CL on all protocols]"
-		# 0x1a: "VINES SPP"
-		# 0x1b: "VINES IPC"
-		# 0x1c: "StreetTalk [name]"
-		# 0x1d: "MSMQ"
-		# 0x1f: "MS IIS (http)"
-		# 0x20: "Unix Domain socket [pathname]"
-		# 0x21: "null"
-		# 0x22: "NetBIOS name"
+        # 0x00: "OSI Object Identifier [OID]"
+        # 0x02: "DNA Session Control Phase 4"
+        # 0x03: "DNA Session Control V3 Phase 5"
+        # 0x04: "DNA NSP Transport"
+        # 0x05: "OSI TP4 [T-Selector]"
+        # 0x06: "OSI CLNS [NSAP]"
+        # 0x07: "DOD TCP port"
+        # 0x08: "DOD UDP port"
+        # 0x09: "DOD IP v4 big-endian"
+        # 0x0a: "RPC Connectionless v4"
+        # 0x0b: "RPC Connection-oriented v5"
+        # 0x0c: "MS Named Pipes"
+        # 0x0d: "UUID"
+        # 0x0e: "ncadg_ipx"
+        # 0x0f: "NetBIOS Named Pipes"
+        # 0x10: "MS Named Pipe Name" or "Local InterProcess Communication (LRPC)")
+        # 0x11: "MS NetBIOS"
+        # 0x12: "MS NetBEUI"
+        # 0x13: "Netware SPX"
+        # 0x14: "Netware IPX"
+        # 0x15: "NMP_TOWER_ID"
+        # 0x16: "Appletalk Stream [endpoint]"
+        # 0x17: "Appletalk Datagram [endpoint]"
+        # 0x18: "Appletalk [NBP-style Name]"
+        # 0x19: "NetBIOS [CL on all protocols]"
+        # 0x1a: "VINES SPP"
+        # 0x1b: "VINES IPC"
+        # 0x1c: "StreetTalk [name]"
+        # 0x1d: "MSMQ"
+        # 0x1f: "MS IIS (http)"
+        # 0x20: "Unix Domain socket [pathname]"
+        # 0x21: "null"
+        # 0x22: "NetBIOS name"
         uint8  :prot_identifier, byte_align: 1, initial_value: 0x0b
         uint16 :rhs_bytecount, byte_align: 1, initial_value: 2
         uint16 :minor_version, byte_align: 1
@@ -77,7 +77,7 @@ module RubySMB
         # default: Host name
         uint8            :identifier, byte_align: 1
         uint16           :rhs_bytecount, byte_align: 1, initial_value: -> { name.length }
-        ndr_fixed_byte_array :name, initial_length: :rhs_bytecount
+        uint8_array      :name, initial_length: :rhs_bytecount, byte_align: 1
       end
 
       class EpmFloorPipeOrPort < Ndr::NdrStruct
@@ -100,9 +100,9 @@ module RubySMB
         uint8  :identifier, byte_align: 1, initial_value: 0x07
         uint16 :rhs_bytecount, byte_align: 1, initial_value: -> { pipe_or_port.num_bytes }
         choice :pipe_or_port, selection: :identifier, byte_align: 1 do
-          ndr_fixed_byte_array 0x10, initial_length: :rhs_bytecount
-          ndr_fixed_byte_array 0x0c, initial_length: :rhs_bytecount
-          ndr_fixed_byte_array 0x0f, initial_length: :rhs_bytecount
+          uint8_array          0x10, initial_length: :rhs_bytecount, byte_align: 1
+          uint8_array          0x0c, initial_length: :rhs_bytecount, byte_align: 1
+          uint8_array          0x0f, initial_length: :rhs_bytecount, byte_align: 1
           uint16be             0x07
           uint16be             0x08
           uint16be             0x13
@@ -110,7 +110,7 @@ module RubySMB
           uint16be             0x1a
           uint16be             0x1b
           uint16be             0x1f
-          ndr_fixed_byte_array :default, initial_length: :rhs_bytecount
+          uint8_array          :default, initial_length: :rhs_bytecount, byte_align: 1
         end
       end
 
@@ -143,17 +143,17 @@ module RubySMB
         uint8  :identifier, byte_align: 1, initial_value: 0x09
         uint16 :rhs_bytecount, byte_align: 1, initial_value: -> { host_or_addr.num_bytes }
         choice :host_or_addr, selection: :identifier, byte_align: 1 do
-          ndr_fixed_byte_array 0x11, initial_length: :rhs_bytecount
-          ndr_fixed_byte_array 0x12, initial_length: :rhs_bytecount
-          ndr_fixed_byte_array 0x22, initial_length: :rhs_bytecount
+          uint8_array          0x11, initial_length: :rhs_bytecount, byte_align: 1
+          uint8_array          0x12, initial_length: :rhs_bytecount, byte_align: 1
+          uint8_array          0x22, initial_length: :rhs_bytecount, byte_align: 1
           epm_ipv4_address     0x09
           epm_ipx_spx_address  0x13
           epm_ipx_spx_address  0x14
-          choice               0x00, selection: -> {rhs_bytecount.num_bytes} do
-            ndr_fixed_byte_array 16, initial_length: 16
-            ndr_fixed_byte_array :default, initial_length: :rhs_bytecount
+          choice               0x00, selection: -> { rhs_bytecount.num_bytes } do
+            uint8_array          16, initial_length: 16, byte_align: 1
+            uint8_array          :default, initial_length: :rhs_bytecount, byte_align: 1
           end
-          ndr_fixed_byte_array :default, initial_length: :rhs_bytecount
+          uint8_array          :default, initial_length: :rhs_bytecount, byte_align: 1
         end
       end
 


### PR DESCRIPTION
This refactors the endpoint mapping (EPM) functionality defined in MS-RPCE to be more encapsulated, and thus reusable in isolation. An existing DCERPC client will now create a private DCERPC client instance specifically for the EPM service calls needed to map a service to a port for connection. This enables developers to also create their own DCERPC clients specifically for interacting with the EPM service, enabling them to control the exact parameters to the `ept_map` function when resolving services.

This also includes an example script to demonstrate the functionality for the two protocols that are currently supported.

# Demo

In this case, the target system (`192.168.159.10`) is a Windows Server 2019 Domain Controller. The example script is used to resolve the GKDI and SAMR endpoints.

```
ruby examples/epm_client.rb --help
# MS-GKDI
ruby examples/epm_client.rb --max-towers 3 192.168.159.10 ncacn_ip_tcp b9785960-524f-11df-8b6d-83dcded72085
# MS-SAMR
ruby examples/epm_client.rb --max-towers 1 192.168.159.10 ncacn_ip_tcp 12345778-1234-abcd-ef00-0123456789ac
ruby examples/epm_client.rb --max-towers 1 192.168.159.10 ncacn_np     12345778-1234-abcd-ef00-0123456789ac
Usage: script.rb [options] TARGET PROTOCOL UUID
        --major-version N            Specify major version number (default: 1)
        --minor-version N            Specify minor version number ((default: 0)
        --max-towers N               Set the maximum number of towers (default: 1)
    -h, --help                       Prints this help
Tower: ncacn_ip_tcp:192.168.159.10[49673]
  port: 49673
  address: 192.168.159.10
Tower: ncacn_ip_tcp:192.168.159.10[49671]
  port: 49671
  address: 192.168.159.10
Tower: ncacn_ip_tcp:192.168.159.10[49667]
  port: 49667
  address: 192.168.159.10
Tower: ncacn_ip_tcp:192.168.159.10[49671]
  port: 49671
  address: 192.168.159.10
Tower: ncacn_np:\\DC[\pipe\78a0156af3d332e7]
  pipe: \pipe\78a0156af3d332e7
  host: \\DC
```