### PR TITLE
Reauth after STATUS_NETWORK_SESSION_EXPIRED 

### DIFF
--- a/lib/ruby_smb/client.rb
+++ b/lib/ruby_smb/client.rb
@@ -520,9 +520,13 @@ module RubySMB
       # Handle STATUS_NETWORK_SESSION_EXPIRED. The 'net use' client upon receiving this error will automatically attempt
       # to re-authenticate, which makes relaying ntlm authentication to multiple targets possible. This block ensures
       # ruby_smb behaves in the same manner as 'net use'.
-      if smb2_header && smb2_header.nt_status == WindowsError::NTStatus::STATUS_NETWORK_SESSION_EXPIRED
-        session_setup(self.username, self.password, self.domain, local_workstation: self.local_workstation, ntlm_flags: NTLM::DEFAULT_CLIENT_FLAGS)
-        raw_response = send_recv(packet, encrypt: encrypt) # Retry the request after re-authentication
+      if smb2_header && smb2_header.nt_status == WindowsError::NTStatus::STATUS_NETWORK_SESSION_EXPIRED && !@mech_type.nil?
+        if @mech_type == :ntlm || @mech_type == :anonymous
+          session_setup(self.username, self.password, self.domain, local_workstation: self.local_workstation, ntlm_flags: NTLM::DEFAULT_CLIENT_FLAGS)
+          raw_response = send_recv(packet, encrypt: encrypt) # Retry the request after re-authentication
+        elsif  @mech_type == :kerberos
+          raise RubySMB::Error::RubySMBError, 'WindowsError::NTStatus::STATUS_NETWORK_SESSION_EXPIRED received, but kerberos authentication is being used, so automatic re-authentication cannot be attempted.'
+        end
       end
 
       self.sequence_counter += 1 if signing_required && !session_key.empty?

--- a/lib/ruby_smb/client.rb
+++ b/lib/ruby_smb/client.rb
@@ -517,6 +517,14 @@ module RubySMB
         break
       end unless version == 'SMB1'
 
+      # Handle STATUS_NETWORK_SESSION_EXPIRED. The 'net use' client upon receiving this error will automatically attempt
+      # to re-authenticate, which makes relaying ntlm authentication to multiple targets possible. This block ensures
+      # ruby_smb behaves in the same manner as 'net use'.
+      if smb2_header && smb2_header.nt_status == WindowsError::NTStatus::STATUS_NETWORK_SESSION_EXPIRED
+        session_setup(self.username, self.password, self.domain, local_workstation: self.local_workstation, ntlm_flags: NTLM::DEFAULT_CLIENT_FLAGS)
+        raw_response = send_recv(packet, encrypt: encrypt) # Retry the request after re-authentication
+      end
+
       self.sequence_counter += 1 if signing_required && !session_key.empty?
       # update the SMB2 message ID according to the received Credit Charged
       self.smb2_message_id += smb2_header.credit_charge - 1 if smb2_header && self.server_supports_multi_credit

--- a/lib/ruby_smb/client/authentication.rb
+++ b/lib/ruby_smb/client/authentication.rb
@@ -31,6 +31,7 @@ module RubySMB
       #
       # @return [WindowsError::ErrorCode] the status code the server returned
       def smb1_anonymous_auth
+        @mech_type = :anonymous
         request       = smb1_anonymous_auth_request
         raw_response  = send_recv(request)
         response      = smb1_anonymous_auth_response(raw_response)
@@ -73,6 +74,7 @@ module RubySMB
       # Handles the SMB1 NTLMSSP 4-way handshake for Authentication and store
       # information about the peer/server.
       def smb1_authenticate
+        @mech_type = :ntlm
         response = smb1_ntlmssp_negotiate
         challenge_packet = smb1_ntlmssp_challenge_packet(response)
 
@@ -205,6 +207,7 @@ module RubySMB
       # Handles the SMB2 NTLMSSP 4-way handshake for Authentication and store
       # information about the peer/server.
       def smb2_authenticate
+        @mech_type = :ntlm
         response = smb2_ntlmssp_negotiate
         challenge_packet = smb2_ntlmssp_challenge_packet(response)
         if @dialect == '0x0311'


### PR DESCRIPTION
This PR makes a small change  to attempt to re-authenticate when the client receives the `STATUS_NETWORK_SESSION_EXPIRED` error. This is how Window's `net use` client responds to the error. 
https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb/6ab6ca20-b404-41fd-b91a-2ed39e3762ea

The `smb_relay` Metasploit module makes it possible relay an authentication request to multiple targets, by making use of the SMB error `STATUS_NETWORK_SESSION_EXPIRED`. The relay server first tricks the client into thinking it's authentication attempt was successful, and then throws the error code `STATUS_NETWORK_SESSION_EXPIRED` which forces the client to re-authenticate and allows the relay server to relay to as many targets as it would like by sending that error code repeatedly. 

It seems like this minor detail was never implemented in ruby_smb, nor was it implemented in python's smbprotocol implementation as seen here [python smb issue](https://github.com/jborean93/smbprotocol/issues/90). This is why the `smb_relay` could never relay authentication from any client other than `net use`. 


## Testing
See the metasploit-framework PR for testing instructions