### PR TITLE
MS-CIFS 2.2.4.64.2 vs MS-SMB 2.2.4.9.2 (WC: 34, 42 & 50)

### DIFF
--- a/lib/ruby_smb/smb1/packet/nt_create_andx_response.rb
+++ b/lib/ruby_smb/smb1/packet/nt_create_andx_response.rb
@@ -2,8 +2,8 @@ module RubySMB
   module SMB1
     module Packet
       # A SMB1 SMB_COM_NT_CREATE_ANDX Response Packet as defined in
-      # [2.2.4.64.2 Response](https://msdn.microsoft.com/en-us/library/ee441612.aspx) and
-      # [2.2.4.9.2 Server Response Extensions](https://msdn.microsoft.com/en-us/library/cc246334.aspx)
+      # [MS-CIFS: 2.2.4.64.2 Response](https://msdn.microsoft.com/en-us/library/ee441612.aspx) and
+      # [MS-SMB : 2.2.4.9.2 Server Response Extensions](https://msdn.microsoft.com/en-us/library/cc246334.aspx)
       class NtCreateAndxResponse < RubySMB::GenericPacket
         COMMAND = RubySMB::SMB1::Commands::SMB_COM_NT_CREATE_ANDX
 
@@ -35,15 +35,28 @@ module RubySMB
           end
 
           uint8                   :directory,           label: 'Directory'
-          string                  :volume_guid,         label: 'Volume GUID', length: 16
-          uint64                  :file_id,             label: 'File ID'
+          # MS-CIFS: 2.2.4.64.2 (WC=34)
+          # MS-SMB:  2.2.4.9.2  (WC=42) - VolumeGUID only, per the spec (so we get the right WordCount, WC)
+          # MS-SMB:  2.2.4.9.2  (WC=50) - all four fields as per spec (but then the spec is then wrong for the WC)
+          #                               VolumeGUID, FileId, MaximalAccessRights & GuestMaximalAccessRights
+          # MS-SMB 2.2.4.9.2 (WC=42): VolumeGUID
+          string                  :volume_guid,         label: 'Volume GUID', length: 16,
+                                   onlyif: -> { word_count >= 42 }
 
-          choice :maximal_access_rights, selection: -> { ext_file_attributes.directory } do
+          # MS-SMB 2.2.4.9.2 (WC=50): FileId
+          uint64                  :file_id,             label: 'File ID',
+                                   onlyif: -> { word_count >= 50 }
+
+          # MS-SMB 2.2.4.9.2 (WC=50): MaximalAccessRights
+          choice :maximal_access_rights, selection: -> { ext_file_attributes.directory },
+                                   onlyif: -> { word_count >= 50 } do
             file_access_mask      0, label: 'Maximal Access Rights'
             directory_access_mask 1, label: 'Maximal Access Rights'
           end
 
-          choice :guest_maximal_access_rights, selection: -> { ext_file_attributes.directory } do
+          # MS-SMB 2.2.4.9.2 (WC=50): GuestMaximalAccessRights
+          choice :guest_maximal_access_rights, selection: -> { ext_file_attributes.directory },
+                                   onlyif: -> { word_count >= 50 } do
             file_access_mask      0, label: 'Guest Maximal Access Rights'
             directory_access_mask 1, label: 'Guest Maximal Access Rights'
           end


### PR DESCRIPTION
This came about due to https://github.com/rapid7/metasploit-framework/pull/21345/changes/BASE..e6ae2314cec27286542a830eb813877d1b88c4cc#r3118623808

As a result, no longer have to use `rex` on smb1 (target is Metasploitable 2)

## Before

```console
msf > use auxiliary/scanner/smb/smb_enumshares
[*] New in Metasploit 6.4 - This module can target a SESSION or an RHOST
msf auxiliary(scanner/smb/smb_enumshares) > run
[*] 10.0.0.10:139 - Connecting using SMB v1 via ruby_smb
[-] 10.0.0.10:139 - Invalid packet received when trying to enumerate shares - The response seems to be an SMB1 NtCreateAndxResponse but an error occurs while parsing it. It is probably missing the required extended information.
[*] 10.0.0.10:445 - Connecting using SMB v1/2/3 via rex
[+] 10.0.0.10:445 - print$ - (DISK) Printer Drivers
[+] 10.0.0.10:445 - tmp - (DISK) oh noes!
[+] 10.0.0.10:445 - opt - (DISK)
[+] 10.0.0.10:445 - IPC$ - (IPC) IPC Service (metasploitable server (Samba 3.0.20-Debian))
[+] 10.0.0.10:445 - ADMIN$ - (IPC) IPC Service (metasploitable server (Samba 3.0.20-Debian))
[*] 10.0.0.10: - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/smb/smb_enumshares) >
```

## After

```console
msf > use auxiliary/scanner/smb/smb_enumshares
[*] New in Metasploit 6.4 - This module can target a SESSION or an RHOST
msf auxiliary(scanner/smb/smb_enumshares) > options

Module options (auxiliary/scanner/smb/smb_enumshares):

   Name                    Current Setting                         Required  Description
   ----                    ---------------                         --------  -----------
   HIGHLIGHT_NAME_PATTERN  username|password|user|pass|Groups.xml  yes       PCRE regex of resource names to highlight
   LogSpider               3                                       no        0 = disabled, 1 = CSV, 2 = table (txt), 3 = one liner (txt) (Accepted: 0, 1, 2, 3)
   MaxDepth                999                                     yes       Max number of subdirectories to spider
   Share                                                           no        Show only the specified share
   ShowFiles               false                                   yes       Show detailed information when spidering
   SpiderProfiles          true                                    no        Spider only user profiles when share is a disk share
   SpiderShares            false                                   no        Spider shares recursively


   Used when connecting via an existing SESSION:

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   SESSION                   no        The session to run this module on


   Used when making a new connection via RHOSTS:

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   RHOSTS     10.0.0.10        no        The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   SMBDomain  .                no        The Windows domain to use for authentication
   SMBPass                     no        The password for the specified username
   SMBUser                     no        The username to authenticate as
   THREADS    1                yes       The number of concurrent threads (max one per host)


View the full module info with the info, or info -d command.

msf auxiliary(scanner/smb/smb_enumshares) > run
[*] 10.0.0.10:139 - Connecting using SMB v1 via ruby_smb
[+] 10.0.0.10:139 - print$ - (DISK) Printer Drivers
[+] 10.0.0.10:139 - tmp - (DISK) oh noes!
[+] 10.0.0.10:139 - opt - (DISK)
[+] 10.0.0.10:139 - IPC$ - (IPC) IPC Service (metasploitable server (Samba 3.0.20-Debian))
[+] 10.0.0.10:139 - ADMIN$ - (IPC) IPC Service (metasploitable server (Samba 3.0.20-Debian))
[*] 10.0.0.10: - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/smb/smb_enumshares) >
```