### PR TITLE
Add #set_unix_link to the SMB1 tree

### DIFF
--- a/lib/ruby_smb/smb1/packet/trans2.rb
+++ b/lib/ruby_smb/smb1/packet/trans2.rb
@@ -7,6 +7,8 @@ module RubySMB
         require 'ruby_smb/smb1/packet/trans2/find_information_level'
         require 'ruby_smb/smb1/packet/trans2/query_information_level'
         require 'ruby_smb/smb1/packet/trans2/query_fs_information_level'
+        require 'ruby_smb/smb1/packet/trans2/set_information_level'
+        require 'ruby_smb/smb1/packet/trans2/set_fs_information_level'
         require 'ruby_smb/smb1/packet/trans2/data_block'
         require 'ruby_smb/smb1/packet/trans2/win9x_framing'
         require 'ruby_smb/smb1/packet/trans2/subcommands'
@@ -23,6 +25,12 @@ module RubySMB
         require 'ruby_smb/smb1/packet/trans2/set_file_information_response'
         require 'ruby_smb/smb1/packet/trans2/query_path_information_request'
         require 'ruby_smb/smb1/packet/trans2/query_path_information_response'
+        require 'ruby_smb/smb1/packet/trans2/set_path_information_request'
+        require 'ruby_smb/smb1/packet/trans2/set_path_information_response'
+        require 'ruby_smb/smb1/packet/trans2/query_fs_information_request'
+        require 'ruby_smb/smb1/packet/trans2/query_fs_information_response'
+        require 'ruby_smb/smb1/packet/trans2/set_fs_information_request'
+        require 'ruby_smb/smb1/packet/trans2/set_fs_information_response'
       end
     end
   end

--- a/lib/ruby_smb/smb1/packet/trans2/query_fs_information_level.rb
+++ b/lib/ruby_smb/smb1/packet/trans2/query_fs_information_level.rb
@@ -28,11 +28,15 @@ module RubySMB
           # [NT LANMAN] Query file system attributes.
           SMB_QUERY_FS_ATTRIBUTE_INFO       = 0x0105 # 261
 
+          # [CIFS UNIX Extensions] Query server UNIX extension capabilities.
+          SMB_QUERY_CIFS_UNIX_INFO          = 0x0200 # 512
+
           def self.name(value)
             constants.select { |c| c.upcase == c }.find { |c| const_get(c) == value }
           end
 
           require 'ruby_smb/smb1/packet/trans2/query_fs_information_level/query_fs_attribute_info'
+          require 'ruby_smb/smb1/packet/trans2/query_fs_information_level/query_fs_cifs_unix_info'
         end
       end
     end

--- a/lib/ruby_smb/smb1/packet/trans2/query_fs_information_level/query_fs_cifs_unix_info.rb
+++ b/lib/ruby_smb/smb1/packet/trans2/query_fs_information_level/query_fs_cifs_unix_info.rb
@@ -1,0 +1,21 @@
+module RubySMB
+  module SMB1
+    module Packet
+      module Trans2
+        module QueryFsInformationLevel
+          # Response data for SMB_QUERY_CIFS_UNIX_INFO (0x0200) from the
+          # CIFS UNIX Extensions. 12 bytes: major/minor version pair plus
+          # a 64-bit capability bitfield that the client echoes back in
+          # SMB_SET_CIFS_UNIX_INFO to enable UNIX extensions for the session.
+          class QueryFsCifsUnixInfo < BinData::Record
+            endian :little
+
+            uint16 :major_version, label: 'Major Version'
+            uint16 :minor_version, label: 'Minor Version'
+            uint64 :capabilities,  label: 'Capabilities'
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby_smb/smb1/packet/trans2/query_fs_information_level/query_fs_cifs_unix_info.rb
+++ b/lib/ruby_smb/smb1/packet/trans2/query_fs_information_level/query_fs_cifs_unix_info.rb
@@ -7,6 +7,13 @@ module RubySMB
           # CIFS UNIX Extensions. 12 bytes: major/minor version pair plus
           # a 64-bit capability bitfield that the client echoes back in
           # SMB_SET_CIFS_UNIX_INFO to enable UNIX extensions for the session.
+          #
+          # Outside of MS-CIFS; wire format defined by the CIFS UNIX
+          # Extensions draft maintained by the Samba team. The parent
+          # subcommand is documented at
+          # [MS-CIFS 2.2.6.4 TRANS2_QUERY_FS_INFORMATION (0x0003)](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/a96c1c03-cade-4a4a-81a9-b00674d23d93);
+          # the CIFS UNIX Info layout is implemented in
+          # [source3/smbd/smb1_trans2.c](https://github.com/samba-team/samba/blob/master/source3/smbd/smb1_trans2.c).
           class QueryFsCifsUnixInfo < BinData::Record
             endian :little
 

--- a/lib/ruby_smb/smb1/packet/trans2/query_fs_information_level/query_fs_cifs_unix_info.rb
+++ b/lib/ruby_smb/smb1/packet/trans2/query_fs_information_level/query_fs_cifs_unix_info.rb
@@ -11,9 +11,12 @@ module RubySMB
           # Outside of MS-CIFS; wire format defined by the CIFS UNIX
           # Extensions draft maintained by the Samba team. The parent
           # subcommand is documented at
-          # [MS-CIFS 2.2.6.4 TRANS2_QUERY_FS_INFORMATION (0x0003)](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/a96c1c03-cade-4a4a-81a9-b00674d23d93);
-          # the CIFS UNIX Info layout is implemented in
-          # [source3/smbd/smb1_trans2.c](https://github.com/samba-team/samba/blob/master/source3/smbd/smb1_trans2.c).
+          # [MS-CIFS 2.2.6.4 TRANS2_QUERY_FS_INFORMATION (0x0003)](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/a96c1c03-cade-4a4a-81a9-b00674d23d93).
+          # The on-disk layout matches Samba's server-side `unix_info`
+          # struct at
+          # [source3/smbd/globals.h:419-424](https://github.com/samba-team/samba/blob/33f516c06756e12a9d11f50e2bf309171cdf5c88/source3/smbd/globals.h#L419-L424),
+          # populated by `call_trans2qfsinfo` at
+          # [source3/smbd/smb1_trans2.c:1633-1703](https://github.com/samba-team/samba/blob/33f516c06756e12a9d11f50e2bf309171cdf5c88/source3/smbd/smb1_trans2.c#L1633-L1703).
           class QueryFsCifsUnixInfo < BinData::Record
             endian :little
 

--- a/lib/ruby_smb/smb1/packet/trans2/query_fs_information_request.rb
+++ b/lib/ruby_smb/smb1/packet/trans2/query_fs_information_request.rb
@@ -2,7 +2,9 @@ module RubySMB
   module SMB1
     module Packet
       module Trans2
-        # The Trans2 Parameter Block for this particular Subcommand
+        # The Trans2 Parameter Block for a QUERY_FS_INFORMATION request as
+        # defined in
+        # [MS-CIFS 2.2.6.4.1 Request](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/cfa23a11-0e80-43bd-bbd4-e9cfb99b5dce).
         class QueryFsInformationRequestTrans2Parameters < BinData::Record
           endian :little
 
@@ -15,7 +17,8 @@ module RubySMB
           end
         end
 
-        # The {RubySMB::SMB1::DataBlock} specific to this packet type.
+        # The {RubySMB::SMB1::DataBlock} specific to this packet type. See
+        # [MS-CIFS 2.2.6.4.1 Request](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/cfa23a11-0e80-43bd-bbd4-e9cfb99b5dce).
         # The request carries no Trans2 data payload, but the generic
         # DataBlock padding helpers require a :trans2_data accessor, so
         # we expose a zero-length string.
@@ -27,7 +30,9 @@ module RubySMB
         end
 
         # A Trans2 QUERY_FS_INFORMATION Request Packet as defined in
-        # [2.2.6.4.1](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/cfa23a11-0e80-43bd-bbd4-e9cfb99b5dce)
+        # [MS-CIFS 2.2.6.4.1 Request](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/cfa23a11-0e80-43bd-bbd4-e9cfb99b5dce).
+        # See also the subcommand overview at
+        # [MS-CIFS 2.2.6.4 TRANS2_QUERY_FS_INFORMATION (0x0003)](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/a96c1c03-cade-4a4a-81a9-b00674d23d93).
         class QueryFsInformationRequest < RubySMB::GenericPacket
           COMMAND = RubySMB::SMB1::Commands::SMB_COM_TRANSACTION2
 

--- a/lib/ruby_smb/smb1/packet/trans2/query_fs_information_request.rb
+++ b/lib/ruby_smb/smb1/packet/trans2/query_fs_information_request.rb
@@ -16,11 +16,14 @@ module RubySMB
         end
 
         # The {RubySMB::SMB1::DataBlock} specific to this packet type.
+        # The request carries no Trans2 data payload, but the generic
+        # DataBlock padding helpers require a :trans2_data accessor, so
+        # we expose a zero-length string.
         class QueryFsInformationRequestDataBlock < RubySMB::SMB1::Packet::Trans2::DataBlock
           uint8                                           :name,               label: 'Name', initial_value: 0x00
           string                                          :pad1,               length: -> { pad1_length }
           query_fs_information_request_trans2_parameters  :trans2_parameters,  label: 'Trans2 Parameters'
-          # trans2_data: No data is sent by this message.
+          string                                          :trans2_data,        length: 0, label: 'Trans2 Data'
         end
 
         # A Trans2 QUERY_FS_INFORMATION Request Packet as defined in

--- a/lib/ruby_smb/smb1/packet/trans2/set_fs_information_level.rb
+++ b/lib/ruby_smb/smb1/packet/trans2/set_fs_information_level.rb
@@ -1,0 +1,21 @@
+module RubySMB
+  module SMB1
+    module Packet
+      module Trans2
+        # SET_FS Information Levels used in TRANS2_SET_FS_INFORMATION.
+        # These are not defined in [MS-CIFS] because they were added
+        # through the CIFS UNIX Extensions draft maintained by the
+        # Samba team. See [SNIA CIFS Technical Reference, Appendix F].
+        module SetFsInformationLevel
+          # Client advertises / negotiates CIFS UNIX Extensions support.
+          # Data block: major:u16, minor:u16, capabilities:u64.
+          SMB_SET_CIFS_UNIX_INFO = 0x0200
+
+          def self.name(value)
+            constants.select { |c| c.upcase == c }.find { |c| const_get(c) == value }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby_smb/smb1/packet/trans2/set_fs_information_level.rb
+++ b/lib/ruby_smb/smb1/packet/trans2/set_fs_information_level.rb
@@ -3,9 +3,16 @@ module RubySMB
     module Packet
       module Trans2
         # SET_FS Information Levels used in TRANS2_SET_FS_INFORMATION.
-        # These are not defined in [MS-CIFS] because they were added
-        # through the CIFS UNIX Extensions draft maintained by the
-        # Samba team. See [SNIA CIFS Technical Reference, Appendix F].
+        #
+        # MS-CIFS marks the parent subcommand
+        # [TRANS2_SET_FS_INFORMATION (0x0004)](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/ac4b00db-6015-416a-89a1-bf5da2503bc3)
+        # as "reserved but not implemented" — the info level codes below are
+        # defined by the CIFS UNIX Extensions draft maintained by the Samba
+        # team and implemented in
+        # [source3/smbd/smb1_trans2.c](https://github.com/samba-team/samba/blob/master/source3/smbd/smb1_trans2.c).
+        # They sit in the 0x0200–0x02FF range reserved by
+        # [MS-CIFS 2.2.2.3 Information Level Codes](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/03c10ab9-d723-4368-b9a6-c72de3244c77)
+        # for third-party extensions.
         module SetFsInformationLevel
           # Client advertises / negotiates CIFS UNIX Extensions support.
           # Data block: major:u16, minor:u16, capabilities:u64.

--- a/lib/ruby_smb/smb1/packet/trans2/set_fs_information_level.rb
+++ b/lib/ruby_smb/smb1/packet/trans2/set_fs_information_level.rb
@@ -9,7 +9,7 @@ module RubySMB
         # as "reserved but not implemented" — the info level codes below are
         # defined by the CIFS UNIX Extensions draft maintained by the Samba
         # team and implemented in
-        # [source3/smbd/smb1_trans2.c](https://github.com/samba-team/samba/blob/master/source3/smbd/smb1_trans2.c).
+        # [source3/smbd/smb1_trans2.c:1706-1915 (`call_trans2setfsinfo`)](https://github.com/samba-team/samba/blob/33f516c06756e12a9d11f50e2bf309171cdf5c88/source3/smbd/smb1_trans2.c#L1706-L1915).
         # They sit in the 0x0200–0x02FF range reserved by
         # [MS-CIFS 2.2.2.3 Information Level Codes](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/03c10ab9-d723-4368-b9a6-c72de3244c77)
         # for third-party extensions.

--- a/lib/ruby_smb/smb1/packet/trans2/set_fs_information_request.rb
+++ b/lib/ruby_smb/smb1/packet/trans2/set_fs_information_request.rb
@@ -5,6 +5,13 @@ module RubySMB
         # The Trans2 Parameter Block for TRANS2_SET_FS_INFORMATION.
         # Observed on the wire (and required by Samba) as a 4-byte block
         # containing a placeholder file handle plus the information level.
+        #
+        # The parent subcommand
+        # [MS-CIFS 2.2.6.5 TRANS2_SET_FS_INFORMATION (0x0004)](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/ac4b00db-6015-416a-89a1-bf5da2503bc3)
+        # is marked "reserved but not implemented"; the on-the-wire format
+        # used here is defined by the CIFS UNIX Extensions draft and
+        # implemented in
+        # [source3/smbd/smb1_trans2.c](https://github.com/samba-team/samba/blob/master/source3/smbd/smb1_trans2.c).
         class SetFsInformationRequestTrans2Parameters < BinData::Record
           endian :little
 
@@ -24,6 +31,12 @@ module RubySMB
         # block carries an opaque byte buffer that the caller fills in for
         # the target info level. SMB_SET_CIFS_UNIX_INFO (0x0200) for example
         # carries a QueryFsCifsUnixInfo-shaped record (major/minor/caps).
+        #
+        # Not documented in
+        # [MS-CIFS 2.2.6.5 TRANS2_SET_FS_INFORMATION (0x0004)](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/ac4b00db-6015-416a-89a1-bf5da2503bc3);
+        # per-level layouts are defined by the CIFS UNIX Extensions draft
+        # and implemented in
+        # [source3/smbd/smb1_trans2.c](https://github.com/samba-team/samba/blob/master/source3/smbd/smb1_trans2.c).
         class SetFsInformationRequestTrans2Data < BinData::Record
           string :buffer, read_length: -> { parent.buffer_read_length }
 
@@ -34,7 +47,12 @@ module RubySMB
           end
         end
 
-        # The {RubySMB::SMB1::DataBlock} specific to this packet type.
+        # The {RubySMB::SMB1::DataBlock} specific to this packet type. The
+        # parent subcommand
+        # [MS-CIFS 2.2.6.5 TRANS2_SET_FS_INFORMATION (0x0004)](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/ac4b00db-6015-416a-89a1-bf5da2503bc3)
+        # is documented as "reserved but not implemented"; this data block
+        # is structured for the CIFS UNIX Extensions use in
+        # [source3/smbd/smb1_trans2.c](https://github.com/samba-team/samba/blob/master/source3/smbd/smb1_trans2.c).
         class SetFsInformationRequestDataBlock < RubySMB::SMB1::Packet::Trans2::DataBlock
           uint8                                         :name,               label: 'Name', initial_value: 0x00
           string                                        :pad1,               length: -> { pad1_length }
@@ -44,9 +62,13 @@ module RubySMB
         end
 
         # A Trans2 SET_FS_INFORMATION Request Packet. The on-disk layout
-        # described by [MS-CIFS] does not document the CIFS UNIX Extensions
-        # info levels; their wire format is defined by the [SNIA CIFS UNIX
-        # Extensions] draft and matched by Samba's {call_trans2setfsinfo}.
+        # described by
+        # [MS-CIFS 2.2.6.5 TRANS2_SET_FS_INFORMATION (0x0004)](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/ac4b00db-6015-416a-89a1-bf5da2503bc3)
+        # is marked "reserved but not implemented" and does not document the
+        # CIFS UNIX Extensions info levels; their wire format is defined by
+        # the CIFS UNIX Extensions draft and matched by Samba's
+        # `call_trans2setfsinfo` in
+        # [source3/smbd/smb1_trans2.c](https://github.com/samba-team/samba/blob/master/source3/smbd/smb1_trans2.c).
         class SetFsInformationRequest < RubySMB::GenericPacket
           COMMAND = RubySMB::SMB1::Commands::SMB_COM_TRANSACTION2
 

--- a/lib/ruby_smb/smb1/packet/trans2/set_fs_information_request.rb
+++ b/lib/ruby_smb/smb1/packet/trans2/set_fs_information_request.rb
@@ -1,0 +1,68 @@
+module RubySMB
+  module SMB1
+    module Packet
+      module Trans2
+        # The Trans2 Parameter Block for TRANS2_SET_FS_INFORMATION.
+        # Observed on the wire (and required by Samba) as a 4-byte block
+        # containing a placeholder file handle plus the information level.
+        class SetFsInformationRequestTrans2Parameters < BinData::Record
+          endian :little
+
+          uint16 :fid,               label: 'File ID'
+          uint16 :information_level, label: 'Information Level'
+
+          # Returns the length of the Trans2Parameters struct
+          # in number of bytes
+          def length
+            do_num_bytes
+          end
+        end
+
+        # The Trans2 Data Block for TRANS2_SET_FS_INFORMATION.
+        #
+        # The data layout depends on the Information Level being set, so the
+        # block carries an opaque byte buffer that the caller fills in for
+        # the target info level. SMB_SET_CIFS_UNIX_INFO (0x0200) for example
+        # carries a QueryFsCifsUnixInfo-shaped record (major/minor/caps).
+        class SetFsInformationRequestTrans2Data < BinData::Record
+          string :buffer, read_length: -> { parent.buffer_read_length }
+
+          # Returns the length of the Trans2Data struct
+          # in number of bytes
+          def length
+            do_num_bytes
+          end
+        end
+
+        # The {RubySMB::SMB1::DataBlock} specific to this packet type.
+        class SetFsInformationRequestDataBlock < RubySMB::SMB1::Packet::Trans2::DataBlock
+          uint8                                         :name,               label: 'Name', initial_value: 0x00
+          string                                        :pad1,               length: -> { pad1_length }
+          set_fs_information_request_trans2_parameters  :trans2_parameters,  label: 'Trans2 Parameters'
+          string                                        :pad2,               length: -> { pad2_length }
+          set_fs_information_request_trans2_data        :trans2_data,        label: 'Trans2 Data'
+        end
+
+        # A Trans2 SET_FS_INFORMATION Request Packet. The on-disk layout
+        # described by [MS-CIFS] does not document the CIFS UNIX Extensions
+        # info levels; their wire format is defined by the [SNIA CIFS UNIX
+        # Extensions] draft and matched by Samba's {call_trans2setfsinfo}.
+        class SetFsInformationRequest < RubySMB::GenericPacket
+          COMMAND = RubySMB::SMB1::Commands::SMB_COM_TRANSACTION2
+
+          class ParameterBlock < RubySMB::SMB1::Packet::Trans2::Request::ParameterBlock
+          end
+
+          smb_header                             :smb_header
+          parameter_block                        :parameter_block
+          set_fs_information_request_data_block  :data_block
+
+          def initialize_instance
+            super
+            parameter_block.setup << RubySMB::SMB1::Packet::Trans2::Subcommands::SET_FS_INFORMATION
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby_smb/smb1/packet/trans2/set_fs_information_request.rb
+++ b/lib/ruby_smb/smb1/packet/trans2/set_fs_information_request.rb
@@ -11,7 +11,7 @@ module RubySMB
         # is marked "reserved but not implemented"; the on-the-wire format
         # used here is defined by the CIFS UNIX Extensions draft and
         # implemented in
-        # [source3/smbd/smb1_trans2.c](https://github.com/samba-team/samba/blob/master/source3/smbd/smb1_trans2.c).
+        # [source3/smbd/smb1_trans2.c:1706-1915 (`call_trans2setfsinfo`)](https://github.com/samba-team/samba/blob/33f516c06756e12a9d11f50e2bf309171cdf5c88/source3/smbd/smb1_trans2.c#L1706-L1915).
         class SetFsInformationRequestTrans2Parameters < BinData::Record
           endian :little
 
@@ -36,7 +36,7 @@ module RubySMB
         # [MS-CIFS 2.2.6.5 TRANS2_SET_FS_INFORMATION (0x0004)](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/ac4b00db-6015-416a-89a1-bf5da2503bc3);
         # per-level layouts are defined by the CIFS UNIX Extensions draft
         # and implemented in
-        # [source3/smbd/smb1_trans2.c](https://github.com/samba-team/samba/blob/master/source3/smbd/smb1_trans2.c).
+        # [source3/smbd/smb1_trans2.c:1706-1915 (`call_trans2setfsinfo`)](https://github.com/samba-team/samba/blob/33f516c06756e12a9d11f50e2bf309171cdf5c88/source3/smbd/smb1_trans2.c#L1706-L1915).
         class SetFsInformationRequestTrans2Data < BinData::Record
           string :buffer, read_length: -> { parent.buffer_read_length }
 
@@ -52,7 +52,7 @@ module RubySMB
         # [MS-CIFS 2.2.6.5 TRANS2_SET_FS_INFORMATION (0x0004)](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/ac4b00db-6015-416a-89a1-bf5da2503bc3)
         # is documented as "reserved but not implemented"; this data block
         # is structured for the CIFS UNIX Extensions use in
-        # [source3/smbd/smb1_trans2.c](https://github.com/samba-team/samba/blob/master/source3/smbd/smb1_trans2.c).
+        # [source3/smbd/smb1_trans2.c:1706-1915 (`call_trans2setfsinfo`)](https://github.com/samba-team/samba/blob/33f516c06756e12a9d11f50e2bf309171cdf5c88/source3/smbd/smb1_trans2.c#L1706-L1915).
         class SetFsInformationRequestDataBlock < RubySMB::SMB1::Packet::Trans2::DataBlock
           uint8                                         :name,               label: 'Name', initial_value: 0x00
           string                                        :pad1,               length: -> { pad1_length }
@@ -68,7 +68,7 @@ module RubySMB
         # CIFS UNIX Extensions info levels; their wire format is defined by
         # the CIFS UNIX Extensions draft and matched by Samba's
         # `call_trans2setfsinfo` in
-        # [source3/smbd/smb1_trans2.c](https://github.com/samba-team/samba/blob/master/source3/smbd/smb1_trans2.c).
+        # [source3/smbd/smb1_trans2.c:1706-1915 (`call_trans2setfsinfo`)](https://github.com/samba-team/samba/blob/33f516c06756e12a9d11f50e2bf309171cdf5c88/source3/smbd/smb1_trans2.c#L1706-L1915).
         class SetFsInformationRequest < RubySMB::GenericPacket
           COMMAND = RubySMB::SMB1::Commands::SMB_COM_TRANSACTION2
 

--- a/lib/ruby_smb/smb1/packet/trans2/set_fs_information_response.rb
+++ b/lib/ruby_smb/smb1/packet/trans2/set_fs_information_response.rb
@@ -5,6 +5,12 @@ module RubySMB
         # The Trans2 Parameter Block for a TRANS2_SET_FS_INFORMATION response.
         # The field is intentionally empty — servers return only an NT status
         # in the SMB header to acknowledge the SET.
+        #
+        # Parent subcommand:
+        # [MS-CIFS 2.2.6.5 TRANS2_SET_FS_INFORMATION (0x0004)](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/ac4b00db-6015-416a-89a1-bf5da2503bc3)
+        # ("reserved but not implemented"). Response shape observed in the
+        # CIFS UNIX Extensions implementation in
+        # [source3/smbd/smb1_trans2.c](https://github.com/samba-team/samba/blob/master/source3/smbd/smb1_trans2.c).
         class SetFsInformationResponseTrans2Parameters < BinData::Record
           def length
             do_num_bytes
@@ -12,13 +18,22 @@ module RubySMB
         end
 
         # The {RubySMB::SMB1::DataBlock} specific to this packet type.
+        # Parent subcommand:
+        # [MS-CIFS 2.2.6.5 TRANS2_SET_FS_INFORMATION (0x0004)](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/ac4b00db-6015-416a-89a1-bf5da2503bc3)
+        # ("reserved but not implemented"); actual shape used by the CIFS
+        # UNIX Extensions implementation in
+        # [source3/smbd/smb1_trans2.c](https://github.com/samba-team/samba/blob/master/source3/smbd/smb1_trans2.c).
         class SetFsInformationResponseDataBlock < RubySMB::SMB1::Packet::Trans2::DataBlock
           uint8                                          :name,              label: 'Name', initial_value: 0x00
           string                                         :pad1,              length: -> { pad1_length }
           set_fs_information_response_trans2_parameters  :trans2_parameters, label: 'Trans2 Parameters'
         end
 
-        # A Trans2 SET_FS_INFORMATION Response Packet.
+        # A Trans2 SET_FS_INFORMATION Response Packet. Parent subcommand:
+        # [MS-CIFS 2.2.6.5 TRANS2_SET_FS_INFORMATION (0x0004)](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/ac4b00db-6015-416a-89a1-bf5da2503bc3)
+        # ("reserved but not implemented"). Response shape is defined by the
+        # CIFS UNIX Extensions implementation in
+        # [source3/smbd/smb1_trans2.c](https://github.com/samba-team/samba/blob/master/source3/smbd/smb1_trans2.c).
         class SetFsInformationResponse < RubySMB::GenericPacket
           COMMAND = RubySMB::SMB1::Commands::SMB_COM_TRANSACTION2
 

--- a/lib/ruby_smb/smb1/packet/trans2/set_fs_information_response.rb
+++ b/lib/ruby_smb/smb1/packet/trans2/set_fs_information_response.rb
@@ -1,0 +1,41 @@
+module RubySMB
+  module SMB1
+    module Packet
+      module Trans2
+        # The Trans2 Parameter Block for a TRANS2_SET_FS_INFORMATION response.
+        # The field is intentionally empty — servers return only an NT status
+        # in the SMB header to acknowledge the SET.
+        class SetFsInformationResponseTrans2Parameters < BinData::Record
+          def length
+            do_num_bytes
+          end
+        end
+
+        # The {RubySMB::SMB1::DataBlock} specific to this packet type.
+        class SetFsInformationResponseDataBlock < RubySMB::SMB1::Packet::Trans2::DataBlock
+          uint8                                          :name,              label: 'Name', initial_value: 0x00
+          string                                         :pad1,              length: -> { pad1_length }
+          set_fs_information_response_trans2_parameters  :trans2_parameters, label: 'Trans2 Parameters'
+        end
+
+        # A Trans2 SET_FS_INFORMATION Response Packet.
+        class SetFsInformationResponse < RubySMB::GenericPacket
+          COMMAND = RubySMB::SMB1::Commands::SMB_COM_TRANSACTION2
+
+          class ParameterBlock < RubySMB::SMB1::Packet::Trans2::Response::ParameterBlock
+          end
+
+          smb_header                              :smb_header
+          parameter_block                         :parameter_block
+          set_fs_information_response_data_block  :data_block
+
+          def initialize_instance
+            super
+            parameter_block.setup << RubySMB::SMB1::Packet::Trans2::Subcommands::SET_FS_INFORMATION
+            smb_header.flags.reply = 1
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby_smb/smb1/packet/trans2/set_fs_information_response.rb
+++ b/lib/ruby_smb/smb1/packet/trans2/set_fs_information_response.rb
@@ -10,7 +10,7 @@ module RubySMB
         # [MS-CIFS 2.2.6.5 TRANS2_SET_FS_INFORMATION (0x0004)](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/ac4b00db-6015-416a-89a1-bf5da2503bc3)
         # ("reserved but not implemented"). Response shape observed in the
         # CIFS UNIX Extensions implementation in
-        # [source3/smbd/smb1_trans2.c](https://github.com/samba-team/samba/blob/master/source3/smbd/smb1_trans2.c).
+        # [source3/smbd/smb1_trans2.c:1706-1915 (`call_trans2setfsinfo`)](https://github.com/samba-team/samba/blob/33f516c06756e12a9d11f50e2bf309171cdf5c88/source3/smbd/smb1_trans2.c#L1706-L1915).
         class SetFsInformationResponseTrans2Parameters < BinData::Record
           def length
             do_num_bytes
@@ -22,7 +22,7 @@ module RubySMB
         # [MS-CIFS 2.2.6.5 TRANS2_SET_FS_INFORMATION (0x0004)](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/ac4b00db-6015-416a-89a1-bf5da2503bc3)
         # ("reserved but not implemented"); actual shape used by the CIFS
         # UNIX Extensions implementation in
-        # [source3/smbd/smb1_trans2.c](https://github.com/samba-team/samba/blob/master/source3/smbd/smb1_trans2.c).
+        # [source3/smbd/smb1_trans2.c:1706-1915 (`call_trans2setfsinfo`)](https://github.com/samba-team/samba/blob/33f516c06756e12a9d11f50e2bf309171cdf5c88/source3/smbd/smb1_trans2.c#L1706-L1915).
         class SetFsInformationResponseDataBlock < RubySMB::SMB1::Packet::Trans2::DataBlock
           uint8                                          :name,              label: 'Name', initial_value: 0x00
           string                                         :pad1,              length: -> { pad1_length }
@@ -33,7 +33,7 @@ module RubySMB
         # [MS-CIFS 2.2.6.5 TRANS2_SET_FS_INFORMATION (0x0004)](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/ac4b00db-6015-416a-89a1-bf5da2503bc3)
         # ("reserved but not implemented"). Response shape is defined by the
         # CIFS UNIX Extensions implementation in
-        # [source3/smbd/smb1_trans2.c](https://github.com/samba-team/samba/blob/master/source3/smbd/smb1_trans2.c).
+        # [source3/smbd/smb1_trans2.c:1706-1915 (`call_trans2setfsinfo`)](https://github.com/samba-team/samba/blob/33f516c06756e12a9d11f50e2bf309171cdf5c88/source3/smbd/smb1_trans2.c#L1706-L1915).
         class SetFsInformationResponse < RubySMB::GenericPacket
           COMMAND = RubySMB::SMB1::Commands::SMB_COM_TRANSACTION2
 

--- a/lib/ruby_smb/smb1/packet/trans2/set_information_level.rb
+++ b/lib/ruby_smb/smb1/packet/trans2/set_information_level.rb
@@ -3,16 +3,17 @@ module RubySMB
     module Packet
       module Trans2
         # Information Level codes valid for Trans2 SET_PATH_INFORMATION and
-        # SET_FILE_INFORMATION requests.
+        # SET_FILE_INFORMATION requests. See
+        # [MS-CIFS 2.2.2.3.4 SET Information Level Codes](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/0321265e-312a-4721-90fa-cd40a443ed86).
         #
         # FSCC pass-through levels are defined in
         # {RubySMB::Fscc::FileInformation} and require
         # `SMB_INFO_PASSTHROUGH` to be added. The constants defined here are
         # the CIFS UNIX Extensions info levels used by Samba servers that
-        # advertise UNIX extensions support in their negotiate response.
-        #
-        # See [SNIA CIFS Technical Reference, Appendix F: CIFS UNIX Extensions]
-        # (https://www.snia.org/sites/default/files/CIFS-TR-1p00_FINAL.pdf).
+        # advertise UNIX extensions support in their negotiate response. These
+        # levels fall outside MS-CIFS; their wire format is defined by the
+        # CIFS UNIX Extensions draft and implemented by Samba — see
+        # [source3/smbd/smb1_trans2.c](https://github.com/samba-team/samba/blob/master/source3/smbd/smb1_trans2.c).
         module SetInformationLevel
           # Set the symbolic link target for a file. The Trans2 parameters
           # block carries the path being created (the symlink itself); the

--- a/lib/ruby_smb/smb1/packet/trans2/set_information_level.rb
+++ b/lib/ruby_smb/smb1/packet/trans2/set_information_level.rb
@@ -1,0 +1,33 @@
+module RubySMB
+  module SMB1
+    module Packet
+      module Trans2
+        # Information Level codes valid for Trans2 SET_PATH_INFORMATION and
+        # SET_FILE_INFORMATION requests.
+        #
+        # FSCC pass-through levels are defined in
+        # {RubySMB::Fscc::FileInformation} and require
+        # `SMB_INFO_PASSTHROUGH` to be added. The constants defined here are
+        # the CIFS UNIX Extensions info levels used by Samba servers that
+        # advertise UNIX extensions support in their negotiate response.
+        #
+        # See [SNIA CIFS Technical Reference, Appendix F: CIFS UNIX Extensions]
+        # (https://www.snia.org/sites/default/files/CIFS-TR-1p00_FINAL.pdf).
+        module SetInformationLevel
+          # Set the symbolic link target for a file. The Trans2 parameters
+          # block carries the path being created (the symlink itself); the
+          # Trans2 data block carries the target path as a null-terminated
+          # string.
+          SMB_SET_FILE_UNIX_LINK = 0x0201
+
+          # Create a hard link. Data block carries the existing file path.
+          SMB_SET_FILE_UNIX_HLINK = 0x0203
+
+          def self.name(value)
+            constants.select { |c| c.upcase == c }.find { |c| const_get(c) == value }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby_smb/smb1/packet/trans2/set_information_level.rb
+++ b/lib/ruby_smb/smb1/packet/trans2/set_information_level.rb
@@ -12,8 +12,9 @@ module RubySMB
         # the CIFS UNIX Extensions info levels used by Samba servers that
         # advertise UNIX extensions support in their negotiate response. These
         # levels fall outside MS-CIFS; their wire format is defined by the
-        # CIFS UNIX Extensions draft and implemented by Samba — see
-        # [source3/smbd/smb1_trans2.c](https://github.com/samba-team/samba/blob/master/source3/smbd/smb1_trans2.c).
+        # CIFS UNIX Extensions draft and implemented by Samba's
+        # `smb_set_file_unix_link` handler at
+        # [source3/smbd/smb1_trans2.c:3643-3712](https://github.com/samba-team/samba/blob/33f516c06756e12a9d11f50e2bf309171cdf5c88/source3/smbd/smb1_trans2.c#L3643-L3712).
         module SetInformationLevel
           # Set the symbolic link target for a file. The Trans2 parameters
           # block carries the path being created (the symlink itself); the

--- a/lib/ruby_smb/smb1/packet/trans2/set_path_information_request.rb
+++ b/lib/ruby_smb/smb1/packet/trans2/set_path_information_request.rb
@@ -2,7 +2,9 @@ module RubySMB
   module SMB1
     module Packet
       module Trans2
-        # The Trans2 Parameter Block for this particular Subcommand
+        # The Trans2 Parameter Block for a SET_PATH_INFORMATION request as
+        # defined in
+        # [MS-CIFS 2.2.6.7.1 Request](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/2ca0642a-1cd4-4e72-a16f-9e804a218262).
         class SetPathInformationRequestTrans2Parameters < BinData::Record
           endian :little
 
@@ -20,7 +22,9 @@ module RubySMB
           end
         end
 
-        # The Trans2 Data Block for this particular Subcommand.
+        # The Trans2 Data Block for a SET_PATH_INFORMATION request as defined
+        # in
+        # [MS-CIFS 2.2.6.7.1 Request](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/2ca0642a-1cd4-4e72-a16f-9e804a218262).
         #
         # The data layout depends on the Information Level being set, so the
         # block carries an opaque byte buffer that the caller fills in for the
@@ -36,7 +40,8 @@ module RubySMB
           end
         end
 
-        # The {RubySMB::SMB1::DataBlock} specific to this packet type.
+        # The {RubySMB::SMB1::DataBlock} specific to this packet type. See
+        # [MS-CIFS 2.2.6.7.1 Request](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/2ca0642a-1cd4-4e72-a16f-9e804a218262).
         class SetPathInformationRequestDataBlock < RubySMB::SMB1::Packet::Trans2::DataBlock
           uint8                                           :name,               label: 'Name', initial_value: 0x00
           string                                          :pad1,               length: -> { pad1_length }
@@ -46,7 +51,9 @@ module RubySMB
         end
 
         # A Trans2 SET_PATH_INFORMATION Request Packet as defined in
-        # [2.2.6.8.1 Request](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/45c77fd4-dfbf-43b3-b59d-6c58fdf59b0c)
+        # [MS-CIFS 2.2.6.7.1 Request](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/2ca0642a-1cd4-4e72-a16f-9e804a218262).
+        # See also the subcommand overview at
+        # [MS-CIFS 2.2.6.7 TRANS2_SET_PATH_INFORMATION (0x0006)](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/a23483d9-6543-4aaa-a996-e7c9506f8b94).
         class SetPathInformationRequest < RubySMB::GenericPacket
           COMMAND = RubySMB::SMB1::Commands::SMB_COM_TRANSACTION2
 

--- a/lib/ruby_smb/smb1/packet/trans2/set_path_information_request.rb
+++ b/lib/ruby_smb/smb1/packet/trans2/set_path_information_request.rb
@@ -1,0 +1,68 @@
+module RubySMB
+  module SMB1
+    module Packet
+      module Trans2
+        # The Trans2 Parameter Block for this particular Subcommand
+        class SetPathInformationRequestTrans2Parameters < BinData::Record
+          endian :little
+
+          uint16     :information_level, label: 'Information Level'
+          uint32     :reserved,          label: 'Reserved'
+          choice     :filename, copy_on_change: true, selection: -> { parent.parent.smb_header.flags2.unicode } do
+            stringz16 1, label: 'FileName'
+            stringz   0, label: 'FileName'
+          end
+
+          # Returns the length of the Trans2Parameters struct
+          # in number of bytes
+          def length
+            do_num_bytes
+          end
+        end
+
+        # The Trans2 Data Block for this particular Subcommand.
+        #
+        # The data layout depends on the Information Level being set, so the
+        # block carries an opaque byte buffer that the caller fills in for the
+        # target info level. SMB_SET_FILE_UNIX_LINK (0x0201) for example
+        # carries the symlink target as a null-terminated string.
+        class SetPathInformationRequestTrans2Data < BinData::Record
+          string :buffer, read_length: -> { parent.buffer_read_length }
+
+          # Returns the length of the Trans2Data struct
+          # in number of bytes
+          def length
+            do_num_bytes
+          end
+        end
+
+        # The {RubySMB::SMB1::DataBlock} specific to this packet type.
+        class SetPathInformationRequestDataBlock < RubySMB::SMB1::Packet::Trans2::DataBlock
+          uint8                                           :name,               label: 'Name', initial_value: 0x00
+          string                                          :pad1,               length: -> { pad1_length }
+          set_path_information_request_trans2_parameters  :trans2_parameters,  label: 'Trans2 Parameters'
+          string                                          :pad2,               length: -> { pad2_length }
+          set_path_information_request_trans2_data        :trans2_data,        label: 'Trans2 Data'
+        end
+
+        # A Trans2 SET_PATH_INFORMATION Request Packet as defined in
+        # [2.2.6.8.1 Request](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/45c77fd4-dfbf-43b3-b59d-6c58fdf59b0c)
+        class SetPathInformationRequest < RubySMB::GenericPacket
+          COMMAND = RubySMB::SMB1::Commands::SMB_COM_TRANSACTION2
+
+          class ParameterBlock < RubySMB::SMB1::Packet::Trans2::Request::ParameterBlock
+          end
+
+          smb_header                               :smb_header
+          parameter_block                          :parameter_block
+          set_path_information_request_data_block  :data_block
+
+          def initialize_instance
+            super
+            parameter_block.setup << RubySMB::SMB1::Packet::Trans2::Subcommands::SET_PATH_INFORMATION
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby_smb/smb1/packet/trans2/set_path_information_response.rb
+++ b/lib/ruby_smb/smb1/packet/trans2/set_path_information_response.rb
@@ -2,7 +2,9 @@ module RubySMB
   module SMB1
     module Packet
       module Trans2
-        # The Trans2 Parameter Block for this particular Subcommand
+        # The Trans2 Parameter Block for a SET_PATH_INFORMATION response as
+        # defined in
+        # [MS-CIFS 2.2.6.7.2 Response](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/cf1cd579-9687-465d-9274-08ebb5944cd3).
         class SetPathInformationResponseTrans2Parameters < BinData::Record
           endian :little
 
@@ -15,7 +17,8 @@ module RubySMB
           end
         end
 
-        # The {RubySMB::SMB1::DataBlock} specific to this packet type.
+        # The {RubySMB::SMB1::DataBlock} specific to this packet type. See
+        # [MS-CIFS 2.2.6.7.2 Response](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/cf1cd579-9687-465d-9274-08ebb5944cd3).
         class SetPathInformationResponseDataBlock < RubySMB::SMB1::Packet::Trans2::DataBlock
           string                                           :pad1,               length: -> { pad1_length }
           set_path_information_response_trans2_parameters  :trans2_parameters,  label: 'Trans2 Parameters'
@@ -23,7 +26,9 @@ module RubySMB
         end
 
         # A Trans2 SET_PATH_INFORMATION Response Packet as defined in
-        # [2.2.6.8.2 Response](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/4b7cc4ce-e3f4-4c47-b9ff-8f6c4cb5e05d)
+        # [MS-CIFS 2.2.6.7.2 Response](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/cf1cd579-9687-465d-9274-08ebb5944cd3).
+        # See also the subcommand overview at
+        # [MS-CIFS 2.2.6.7 TRANS2_SET_PATH_INFORMATION (0x0006)](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/a23483d9-6543-4aaa-a996-e7c9506f8b94).
         class SetPathInformationResponse < RubySMB::GenericPacket
           COMMAND = RubySMB::SMB1::Commands::SMB_COM_TRANSACTION2
 

--- a/lib/ruby_smb/smb1/packet/trans2/set_path_information_response.rb
+++ b/lib/ruby_smb/smb1/packet/trans2/set_path_information_response.rb
@@ -1,0 +1,46 @@
+module RubySMB
+  module SMB1
+    module Packet
+      module Trans2
+        # The Trans2 Parameter Block for this particular Subcommand
+        class SetPathInformationResponseTrans2Parameters < BinData::Record
+          endian :little
+
+          uint16 :ea_error_offset, label: 'Extended Attribute Error Offset'
+
+          # Returns the length of the Trans2Parameters struct
+          # in number of bytes
+          def length
+            do_num_bytes
+          end
+        end
+
+        # The {RubySMB::SMB1::DataBlock} specific to this packet type.
+        class SetPathInformationResponseDataBlock < RubySMB::SMB1::Packet::Trans2::DataBlock
+          string                                           :pad1,               length: -> { pad1_length }
+          set_path_information_response_trans2_parameters  :trans2_parameters,  label: 'Trans2 Parameters'
+          # trans2_data: No data is sent by this message.
+        end
+
+        # A Trans2 SET_PATH_INFORMATION Response Packet as defined in
+        # [2.2.6.8.2 Response](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/4b7cc4ce-e3f4-4c47-b9ff-8f6c4cb5e05d)
+        class SetPathInformationResponse < RubySMB::GenericPacket
+          COMMAND = RubySMB::SMB1::Commands::SMB_COM_TRANSACTION2
+
+          class ParameterBlock < RubySMB::SMB1::Packet::Trans2::Response::ParameterBlock
+          end
+
+          smb_header                                :smb_header
+          parameter_block                           :parameter_block
+          set_path_information_response_data_block  :data_block
+
+          def initialize_instance
+            super
+            parameter_block.setup << RubySMB::SMB1::Packet::Trans2::Subcommands::SET_PATH_INFORMATION
+            smb_header.flags.reply = 1
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby_smb/smb1/tree.rb
+++ b/lib/ruby_smb/smb1/tree.rb
@@ -195,6 +195,66 @@ module RubySMB
         results
       end
 
+      # Create a UNIX symbolic link on the remote share using the CIFS UNIX
+      # Extensions SMB_SET_FILE_UNIX_LINK information level (0x0201) via a
+      # Trans2 SET_PATH_INFORMATION request.
+      #
+      # @example
+      #   tree = client.tree_connect("\\\\samba\\writable")
+      #   tree.set_unix_link(symlink: 'escape', target: '../../../../etc')
+      #
+      # @param symlink [String] the path, relative to the share, where the
+      #   symbolic link file will be created
+      # @param target [String] the destination the symbolic link points to
+      # @return [WindowsError::ErrorCode] the NTStatus returned by the server
+      # @raise [RubySMB::Error::InvalidPacket] if the response is not a Trans2
+      #   SET_PATH_INFORMATION response
+      # @raise [RubySMB::Error::UnexpectedStatusCode] if the response NTStatus
+      #   is not STATUS_SUCCESS
+      def set_unix_link(symlink:, target:)
+        # Samba gates SMB_SET_FILE_UNIX_LINK behind a per-session CIFS UNIX
+        # Extensions handshake: query server capabilities, then echo them
+        # back via SMB_SET_CIFS_UNIX_INFO. Without this, Samba responds to
+        # the symlink request with STATUS_INVALID_LEVEL even when
+        # `unix extensions = yes` is set server-side.
+        enable_cifs_unix_extensions
+
+        request = RubySMB::SMB1::Packet::Trans2::SetPathInformationRequest.new
+        request = set_header_fields(request)
+        # CIFS UNIX Extensions paths are raw byte strings, not UTF-16. Clear
+        # flags2.unicode so the filename parameter and target data block are
+        # emitted as bytes — Samba rejects the UTF-16 variant with
+        # STATUS_INVALID_LEVEL.
+        request.smb_header.flags2.unicode = 0
+
+        t2_params = request.data_block.trans2_parameters
+        t2_params.information_level = RubySMB::SMB1::Packet::Trans2::SetInformationLevel::SMB_SET_FILE_UNIX_LINK
+        t2_params.filename = symlink
+
+        encoded_target = target.dup.force_encoding(Encoding::ASCII_8BIT)
+        encoded_target << "\x00".b unless encoded_target.end_with?("\x00".b)
+        request.data_block.trans2_data.buffer = encoded_target
+
+        request.parameter_block.total_parameter_count = request.parameter_block.parameter_count
+        request.parameter_block.total_data_count      = request.parameter_block.data_count
+        request.parameter_block.max_parameter_count   = request.parameter_block.parameter_count
+        request.parameter_block.max_data_count        = 0
+
+        raw_response = client.send_recv(request)
+        response = RubySMB::SMB1::Packet::Trans2::SetPathInformationResponse.read(raw_response)
+        unless response.valid?
+          raise RubySMB::Error::InvalidPacket.new(
+            expected_proto: RubySMB::SMB1::SMB_PROTOCOL_ID,
+            expected_cmd:   RubySMB::SMB1::Packet::Trans2::SetPathInformationResponse::COMMAND,
+            packet:         response
+          )
+        end
+        unless response.status_code == WindowsError::NTStatus::STATUS_SUCCESS
+          raise RubySMB::Error::UnexpectedStatusCode, response.status_code
+        end
+        response.status_code
+      end
+
       # Sets a few preset header fields that will always be set the same
       # way for Tree operations. This is, the TreeID and Extended Attributes.
       #
@@ -206,7 +266,71 @@ module RubySMB
         request
       end
 
+      # Perform the CIFS UNIX Extensions handshake on this tree: query the
+      # server's supported extensions (SMB_QUERY_CIFS_UNIX_INFO) and then
+      # echo the version and capability bits back via SMB_SET_CIFS_UNIX_INFO.
+      # Samba requires this round-trip to have completed on the current
+      # session before it will honor UNIX-extension info levels such as
+      # SMB_SET_FILE_UNIX_LINK.
+      #
+      # @return [WindowsError::ErrorCode] NTStatus of the SET reply
+      # @raise [RubySMB::Error::UnexpectedStatusCode] if either leg fails
+      def enable_cifs_unix_extensions
+        major, minor, capabilities = query_cifs_unix_info
+        set_cifs_unix_info(major: major, minor: minor, capabilities: capabilities)
+      end
+
       private
+
+      def query_cifs_unix_info
+        request = RubySMB::SMB1::Packet::Trans2::QueryFsInformationRequest.new
+        request = set_header_fields(request)
+        request.smb_header.flags2.unicode = 0
+        request.data_block.trans2_parameters.information_level =
+          RubySMB::SMB1::Packet::Trans2::QueryFsInformationLevel::SMB_QUERY_CIFS_UNIX_INFO
+        request.parameter_block.total_parameter_count = request.parameter_block.parameter_count
+        request.parameter_block.total_data_count      = 0
+        request.parameter_block.max_parameter_count   = 0
+        request.parameter_block.max_data_count        = 560
+
+        raw_response = client.send_recv(request)
+        response = RubySMB::SMB1::Packet::Trans2::QueryFsInformationResponse.read(raw_response)
+        unless response.status_code == WindowsError::NTStatus::STATUS_SUCCESS
+          raise RubySMB::Error::UnexpectedStatusCode, response.status_code
+        end
+        info = RubySMB::SMB1::Packet::Trans2::QueryFsInformationLevel::QueryFsCifsUnixInfo.read(
+          response.data_block.trans2_data.buffer
+        )
+        [info.major_version.to_i, info.minor_version.to_i, info.capabilities.to_i]
+      end
+
+      def set_cifs_unix_info(major:, minor:, capabilities:)
+        request = RubySMB::SMB1::Packet::Trans2::SetFsInformationRequest.new
+        request = set_header_fields(request)
+        request.smb_header.flags2.unicode = 0
+        request.data_block.trans2_parameters.fid               = 0
+        request.data_block.trans2_parameters.information_level =
+          RubySMB::SMB1::Packet::Trans2::SetFsInformationLevel::SMB_SET_CIFS_UNIX_INFO
+
+        info = RubySMB::SMB1::Packet::Trans2::QueryFsInformationLevel::QueryFsCifsUnixInfo.new
+        info.major_version = major
+        info.minor_version = minor
+        info.capabilities  = capabilities
+        request.data_block.trans2_data.buffer = info.to_binary_s
+
+        request.parameter_block.total_parameter_count = request.parameter_block.parameter_count
+        request.parameter_block.total_data_count      = request.parameter_block.data_count
+        request.parameter_block.max_parameter_count   = request.parameter_block.parameter_count
+        request.parameter_block.max_data_count        = 0
+
+        raw_response = client.send_recv(request)
+        response = RubySMB::SMB1::Packet::Trans2::SetFsInformationResponse.read(raw_response)
+        unless response.status_code == WindowsError::NTStatus::STATUS_SUCCESS
+          raise RubySMB::Error::UnexpectedStatusCode, response.status_code
+        end
+        response.status_code
+      end
+
 
       def _open(filename:, flags: nil, options: nil, disposition: RubySMB::Dispositions::FILE_OPEN,
                 impersonation: RubySMB::ImpersonationLevels::SEC_IMPERSONATE, read: true, write: false, delete: false)

--- a/spec/lib/ruby_smb/smb1/packet/trans2/set_fs_information_request_spec.rb
+++ b/spec/lib/ruby_smb/smb1/packet/trans2/set_fs_information_request_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+RSpec.describe RubySMB::SMB1::Packet::Trans2::SetFsInformationRequest do
+  subject(:packet) { described_class.new }
+
+  describe '#smb_header' do
+    subject(:header) { packet.smb_header }
+
+    it { is_expected.to be_a RubySMB::SMB1::SMBHeader }
+
+    it 'has the command set to SMB_COM_TRANSACTION2' do
+      expect(header.command).to eq RubySMB::SMB1::Commands::SMB_COM_TRANSACTION2
+    end
+  end
+
+  describe '#parameter_block' do
+    subject(:parameter_block) { packet.parameter_block }
+
+    it { is_expected.to be_a RubySMB::SMB1::Packet::Trans2::Request::ParameterBlock }
+
+    it 'uses the SET_FS_INFORMATION subcommand' do
+      expect(parameter_block.setup[0]).to eq RubySMB::SMB1::Packet::Trans2::Subcommands::SET_FS_INFORMATION
+    end
+  end
+
+  describe '#data_block' do
+    subject(:data_block) { packet.data_block }
+
+    it { is_expected.to respond_to :trans2_parameters }
+    it { is_expected.to respond_to :trans2_data }
+
+    describe '#trans2_parameters' do
+      subject(:parameters) { data_block.trans2_parameters }
+
+      it { is_expected.to respond_to :fid }
+      it { is_expected.to respond_to :information_level }
+
+      it 'is 4 bytes on the wire (fid + information_level)' do
+        parameters.fid = 0
+        parameters.information_level = RubySMB::SMB1::Packet::Trans2::SetFsInformationLevel::SMB_SET_CIFS_UNIX_INFO
+        expect(parameters.to_binary_s.bytesize).to eq 4
+      end
+    end
+
+    describe '#trans2_data' do
+      it 'carries an opaque byte buffer whose contents depend on the information level' do
+        data_block.trans2_data.buffer = "\x01\x00\x00\x00".b + "\x00".b * 8
+        expect(data_block.trans2_data.buffer.bytesize).to eq 12
+      end
+    end
+  end
+end

--- a/spec/lib/ruby_smb/smb1/packet/trans2/set_fs_information_response_spec.rb
+++ b/spec/lib/ruby_smb/smb1/packet/trans2/set_fs_information_response_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+RSpec.describe RubySMB::SMB1::Packet::Trans2::SetFsInformationResponse do
+  subject(:packet) { described_class.new }
+
+  describe '#smb_header' do
+    subject(:header) { packet.smb_header }
+
+    it { is_expected.to be_a RubySMB::SMB1::SMBHeader }
+
+    it 'has the command set to SMB_COM_TRANSACTION2' do
+      expect(header.command).to eq RubySMB::SMB1::Commands::SMB_COM_TRANSACTION2
+    end
+
+    it 'sets the reply flag' do
+      expect(header.flags.reply).to eq 1
+    end
+  end
+
+  describe '#parameter_block' do
+    subject(:parameter_block) { packet.parameter_block }
+
+    it { is_expected.to be_a RubySMB::SMB1::Packet::Trans2::Response::ParameterBlock }
+
+    it 'uses the SET_FS_INFORMATION subcommand' do
+      expect(parameter_block.setup[0]).to eq RubySMB::SMB1::Packet::Trans2::Subcommands::SET_FS_INFORMATION
+    end
+  end
+end

--- a/spec/lib/ruby_smb/smb1/packet/trans2/set_path_information_request_spec.rb
+++ b/spec/lib/ruby_smb/smb1/packet/trans2/set_path_information_request_spec.rb
@@ -1,0 +1,114 @@
+RSpec.describe RubySMB::SMB1::Packet::Trans2::SetPathInformationRequest do
+  subject(:packet) { described_class.new }
+
+  describe '#smb_header' do
+    subject(:header) { packet.smb_header }
+
+    it 'is a standard SMB Header' do
+      expect(header).to be_a RubySMB::SMB1::SMBHeader
+    end
+
+    it 'should have the command set to SMB_COM_TRANSACTION2' do
+      expect(header.command).to eq RubySMB::SMB1::Commands::SMB_COM_TRANSACTION2
+    end
+
+    it 'should not have the response flag set' do
+      expect(header.flags.reply).to eq 0
+    end
+  end
+
+  describe '#parameter_block' do
+    subject(:parameter_block) { packet.parameter_block }
+
+    it 'is a standard ParameterBlock' do
+      expect(parameter_block).to be_a RubySMB::SMB1::Packet::Trans2::Request::ParameterBlock
+    end
+
+    it 'should have the setup set to the SET_PATH_INFORMATION subcommand' do
+      expect(parameter_block.setup).to include RubySMB::SMB1::Packet::Trans2::Subcommands::SET_PATH_INFORMATION
+    end
+  end
+
+  describe '#data_block' do
+    subject(:data_block) { packet.data_block }
+
+    it 'is a standard DataBlock' do
+      expect(data_block).to be_a RubySMB::SMB1::DataBlock
+    end
+
+    it { is_expected.to respond_to :name }
+    it { is_expected.to respond_to :trans2_parameters }
+    it { is_expected.to respond_to :trans2_data }
+
+    it 'should keep #trans2_parameters 4-byte aligned' do
+      expect(data_block.trans2_parameters.abs_offset % 4).to eq 0
+    end
+
+    describe '#trans2_parameters' do
+      subject(:parameters) { data_block.trans2_parameters }
+
+      it { is_expected.to respond_to :information_level }
+      it { is_expected.to respond_to :reserved }
+      it { is_expected.to respond_to :filename }
+
+      describe '#information_level' do
+        it 'is a 16-bit field' do
+          expect(parameters.information_level).to be_a BinData::Uint16le
+        end
+      end
+
+      describe '#reserved' do
+        it 'is a 32-bit field' do
+          expect(parameters.reserved).to be_a BinData::Uint32le
+        end
+      end
+
+      describe '#filename' do
+        it 'is a BinData::Choice' do
+          expect(parameters.filename).to be_a BinData::Choice
+        end
+
+        it 'encodes the filename as OEM when the unicode flag is cleared' do
+          packet.smb_header.flags2.unicode = 0
+          parameters.filename = 'link'
+          expect(parameters.filename.to_binary_s).to eq "link\x00".b
+        end
+
+        it 'encodes the filename as UTF-16LE when the unicode flag is set' do
+          packet.smb_header.flags2.unicode = 1
+          parameters.filename = 'link'
+          expect(parameters.filename.to_binary_s).to eq "link\x00".encode('UTF-16LE').b
+        end
+      end
+    end
+
+    describe '#trans2_data' do
+      subject(:data) { data_block.trans2_data }
+
+      it { is_expected.to respond_to :buffer }
+
+      it 'carries an opaque byte buffer for the info-level-specific payload' do
+        data.buffer = "target\x00"
+        expect(data.buffer.to_binary_s).to eq "target\x00".b
+      end
+    end
+  end
+
+  describe 'encoded bytes for an SMB_SET_FILE_UNIX_LINK request' do
+    it 'encodes the information level, filename and target in the expected positions' do
+      packet.smb_header.flags2.unicode = 1
+      packet.data_block.trans2_parameters.information_level =
+        RubySMB::SMB1::Packet::Trans2::SetInformationLevel::SMB_SET_FILE_UNIX_LINK
+      packet.data_block.trans2_parameters.filename = 'foo'
+      packet.data_block.trans2_data.buffer = "bar\x00".encode('UTF-16LE')
+
+      raw = packet.to_binary_s
+      # Information level (little-endian 0x0201)
+      expect(raw).to include("\x01\x02".b)
+      # Filename in UTF-16LE with null terminator
+      expect(raw).to include("foo\x00".encode('UTF-16LE').b)
+      # Target in UTF-16LE with null terminator
+      expect(raw).to include("bar\x00".encode('UTF-16LE').b)
+    end
+  end
+end

--- a/spec/lib/ruby_smb/smb1/packet/trans2/set_path_information_response_spec.rb
+++ b/spec/lib/ruby_smb/smb1/packet/trans2/set_path_information_response_spec.rb
@@ -1,6 +1,4 @@
-include RubySMB::Fscc::FileInformation
-
-RSpec.describe RubySMB::SMB1::Packet::Trans2::QueryFsInformationRequest do
+RSpec.describe RubySMB::SMB1::Packet::Trans2::SetPathInformationResponse do
   subject(:packet) { described_class.new }
 
   describe '#smb_header' do
@@ -14,20 +12,16 @@ RSpec.describe RubySMB::SMB1::Packet::Trans2::QueryFsInformationRequest do
       expect(header.command).to eq RubySMB::SMB1::Commands::SMB_COM_TRANSACTION2
     end
 
-    it 'should not have the response flag set' do
-      expect(header.flags.reply).to eq 0
+    it 'should have the response flag set' do
+      expect(header.flags.reply).to eq 1
     end
   end
 
   describe '#parameter_block' do
     subject(:parameter_block) { packet.parameter_block }
 
-    it 'is a standard ParameterBlock' do
-      expect(parameter_block).to be_a RubySMB::SMB1::Packet::Trans2::Request::ParameterBlock
-    end
-
-    it 'should have the setup set to the QUERY_FS_INFORMATION subcommand' do
-      expect(parameter_block.setup).to include RubySMB::SMB1::Packet::Trans2::Subcommands::QUERY_FS_INFORMATION
+    it 'should have the setup set to the SET_PATH_INFORMATION subcommand' do
+      expect(parameter_block.setup).to include RubySMB::SMB1::Packet::Trans2::Subcommands::SET_PATH_INFORMATION
     end
   end
 
@@ -38,14 +32,8 @@ RSpec.describe RubySMB::SMB1::Packet::Trans2::QueryFsInformationRequest do
       expect(data_block).to be_a RubySMB::SMB1::DataBlock
     end
 
-    it { is_expected.to respond_to :name }
     it { is_expected.to respond_to :trans2_parameters }
-    it { is_expected.to respond_to :trans2_data }
-
-    it '#trans2_data is a zero-length placeholder (this request carries no data payload)' do
-      expect(data_block.trans2_data).to be_a BinData::String
-      expect(data_block.trans2_data.num_bytes).to eq 0
-    end
+    it { is_expected.to_not respond_to :trans2_data }
 
     it 'should keep #trans2_parameters 4-byte aligned' do
       expect(data_block.trans2_parameters.abs_offset % 4).to eq 0
@@ -54,14 +42,13 @@ RSpec.describe RubySMB::SMB1::Packet::Trans2::QueryFsInformationRequest do
     describe '#trans2_parameters' do
       subject(:parameters) { data_block.trans2_parameters }
 
-      it { is_expected.to respond_to :information_level }
+      it { is_expected.to respond_to :ea_error_offset }
 
-      describe '#information_level' do
+      describe '#ea_error_offset' do
         it 'is a 16-bit field' do
-          expect(parameters.information_level).to be_a BinData::Uint16le
+          expect(parameters.ea_error_offset).to be_a BinData::Uint16le
         end
       end
     end
   end
 end
-

--- a/spec/lib/ruby_smb/smb1/tree_spec.rb
+++ b/spec/lib/ruby_smb/smb1/tree_spec.rb
@@ -582,6 +582,130 @@ RSpec.describe RubySMB::SMB1::Tree do
     end
   end
 
+  describe '#set_unix_link' do
+    let(:set_path_response) { RubySMB::SMB1::Packet::Trans2::SetPathInformationResponse.new }
+
+    before :each do
+      # Stub out the CIFS UNIX Extensions handshake — covered separately below.
+      allow(tree).to receive(:enable_cifs_unix_extensions)
+      allow(client).to receive(:send_recv)
+      allow(RubySMB::SMB1::Packet::Trans2::SetPathInformationResponse).to receive(:read).and_return(set_path_response)
+    end
+
+    it 'performs the CIFS UNIX Extensions handshake before issuing the symlink request' do
+      call_order = []
+      allow(tree).to receive(:enable_cifs_unix_extensions) { call_order << :handshake }
+      allow(client).to receive(:send_recv) { call_order << :set_path; '' }
+      tree.set_unix_link(symlink: 'escape', target: '../../etc')
+      expect(call_order).to eq([:handshake, :set_path])
+    end
+
+    it 'sends a Trans2 SetPathInformationRequest with the UNIX_LINK info level' do
+      allow(client).to receive(:send_recv) do |request|
+        expect(request).to be_a(RubySMB::SMB1::Packet::Trans2::SetPathInformationRequest)
+        expect(request.data_block.trans2_parameters.information_level).to(
+          eq(RubySMB::SMB1::Packet::Trans2::SetInformationLevel::SMB_SET_FILE_UNIX_LINK)
+        )
+      end
+      tree.set_unix_link(symlink: 'escape', target: '../../etc')
+    end
+
+    it 'sets the Tree ID on the request' do
+      allow(client).to receive(:send_recv) do |request|
+        expect(request.smb_header.tid).to eq(tree.id)
+      end
+      tree.set_unix_link(symlink: 'escape', target: '../../etc')
+    end
+
+    it 'encodes the symlink path and target as raw byte strings (non-unicode)' do
+      allow(client).to receive(:send_recv) do |request|
+        raw = request.to_binary_s
+        expect(request.smb_header.flags2.unicode).to eq(0)
+        expect(raw).to include('escape'.b)
+        expect(raw).to include('../../etc'.b)
+        expect(raw).not_to include('escape'.encode('UTF-16LE').b)
+      end
+      tree.set_unix_link(symlink: 'escape', target: '../../etc')
+    end
+
+    it 'returns STATUS_SUCCESS on a successful response' do
+      expect(tree.set_unix_link(symlink: 'escape', target: '../../etc'))
+        .to eq(WindowsError::NTStatus::STATUS_SUCCESS)
+    end
+
+    context 'when the server returns a non-Trans2 response packet' do
+      it 'raises InvalidPacket' do
+        allow(set_path_response).to receive(:valid?).and_return(false)
+        expect {
+          tree.set_unix_link(symlink: 'escape', target: '../../etc')
+        }.to raise_error(RubySMB::Error::InvalidPacket)
+      end
+    end
+
+    context 'when the response has a non-success status code' do
+      it 'raises UnexpectedStatusCode' do
+        set_path_response.smb_header.nt_status =
+          WindowsError::NTStatus::STATUS_ACCESS_DENIED.value
+        expect {
+          tree.set_unix_link(symlink: 'escape', target: '../../etc')
+        }.to raise_error(RubySMB::Error::UnexpectedStatusCode)
+      end
+    end
+  end
+
+  describe '#enable_cifs_unix_extensions' do
+    let(:query_response) { RubySMB::SMB1::Packet::Trans2::QueryFsInformationResponse.new }
+    let(:set_response)   { RubySMB::SMB1::Packet::Trans2::SetFsInformationResponse.new }
+
+    before :each do
+      # Server advertises major=1, minor=0, caps=0x0000_0000_0000_017B
+      info = RubySMB::SMB1::Packet::Trans2::QueryFsInformationLevel::QueryFsCifsUnixInfo.new
+      info.major_version = 1
+      info.minor_version = 0
+      info.capabilities  = 0x17B
+      query_response.data_block.trans2_data.buffer = info.to_binary_s
+      allow(RubySMB::SMB1::Packet::Trans2::QueryFsInformationResponse).to receive(:read).and_return(query_response)
+      allow(RubySMB::SMB1::Packet::Trans2::SetFsInformationResponse).to receive(:read).and_return(set_response)
+    end
+
+    it 'queries the server for CIFS UNIX info and then echoes the capability bits back via SET_CIFS_UNIX_INFO' do
+      sent = []
+      allow(client).to receive(:send_recv) do |req|
+        sent << req
+        ''
+      end
+      tree.enable_cifs_unix_extensions
+
+      expect(sent[0]).to be_a(RubySMB::SMB1::Packet::Trans2::QueryFsInformationRequest)
+      expect(sent[0].data_block.trans2_parameters.information_level).to(
+        eq(RubySMB::SMB1::Packet::Trans2::QueryFsInformationLevel::SMB_QUERY_CIFS_UNIX_INFO)
+      )
+
+      expect(sent[1]).to be_a(RubySMB::SMB1::Packet::Trans2::SetFsInformationRequest)
+      expect(sent[1].data_block.trans2_parameters.information_level).to(
+        eq(RubySMB::SMB1::Packet::Trans2::SetFsInformationLevel::SMB_SET_CIFS_UNIX_INFO)
+      )
+      echoed = RubySMB::SMB1::Packet::Trans2::QueryFsInformationLevel::QueryFsCifsUnixInfo.read(
+        sent[1].data_block.trans2_data.buffer
+      )
+      expect(echoed.major_version).to eq(1)
+      expect(echoed.minor_version).to eq(0)
+      expect(echoed.capabilities).to eq(0x17B)
+    end
+
+    it 'raises UnexpectedStatusCode when the QUERY leg fails' do
+      query_response.smb_header.nt_status = WindowsError::NTStatus::STATUS_ACCESS_DENIED.value
+      allow(client).to receive(:send_recv).and_return('')
+      expect { tree.enable_cifs_unix_extensions }.to raise_error(RubySMB::Error::UnexpectedStatusCode)
+    end
+
+    it 'raises UnexpectedStatusCode when the SET leg fails' do
+      set_response.smb_header.nt_status = WindowsError::NTStatus::STATUS_INVALID_PARAMETER.value
+      allow(client).to receive(:send_recv).and_return('')
+      expect { tree.enable_cifs_unix_extensions }.to raise_error(RubySMB::Error::UnexpectedStatusCode)
+    end
+  end
+
   describe '#set_header_fields' do
     let(:modified_request) { tree.set_header_fields(disco_req) }
     it 'adds the TreeID to the header' do


### PR DESCRIPTION
This closes a gap with the Rex SMB client. There will be an accompanying PR to Metasploit that leverages it by updating the `auxiliary/smb/samba_symlink_traversal` module.