### PR TITLE
Ignore inherited methods in BinData field-name guard (#261)

### DIFF
--- a/lib/ruby_smb.rb
+++ b/lib/ruby_smb.rb
@@ -1,4 +1,5 @@
 require 'bindata'
+require 'ruby_smb/compatibility'
 require 'net/ntlm'
 require 'net/ntlm/client'
 require 'openssl'

--- a/lib/ruby_smb/compatibility.rb
+++ b/lib/ruby_smb/compatibility.rb
@@ -1,0 +1,37 @@
+module RubySMB
+  # Compatibility shims for the gems RubySMB builds on.
+  module Compatibility
+  end
+end
+
+# BinData rejects a field name when a method of that name is already defined on
+# the struct class. The check in BinData::DSLMixin::DSLFieldValidator uses
+# Module#method_defined? without the second argument, so it also matches methods
+# inherited from ancestors such as Object, Kernel and Hash.
+#
+# That is too broad in practice. When a test suite loads a mocking library that
+# adds helper methods to Object (rspec-mocks defines #stub on BasicObject when
+# `config.mock_with :rspec` is used, mocha defines #stubs, and so on) before
+# ruby_smb is required, perfectly valid BinData definitions start raising
+#   SyntaxError: field 'stub' shadows an existing method
+# even though no struct field actually shadows a method that the struct itself
+# relies on. See https://github.com/rapid7/ruby_smb/issues/261.
+#
+# Field accessors are installed per instance with define_singleton_method, so an
+# inherited method named like a field never gets in the way at runtime; only a
+# method defined directly on the struct class is a genuine collision. Passing
+# `false` to method_defined? restricts the check to methods defined directly on
+# the class, which is the behaviour the guard is actually meant to enforce.
+# Names that clash with Hash/BinData internals remain covered by the separate
+# BinData::Struct::RESERVED list, so this does not loosen that protection.
+if defined?(BinData::DSLMixin::DSLFieldValidator)
+  module BinData
+    module DSLMixin
+      class DSLFieldValidator
+        def name_shadows_method?(name)
+          @the_class.method_defined?(name, false)
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/ruby_smb/compatibility_spec.rb
+++ b/spec/lib/ruby_smb/compatibility_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+
+RSpec.describe 'BinData field name compatibility (issue #261)' do
+  # Regression coverage for
+  # https://github.com/rapid7/ruby_smb/issues/261
+  #
+  # Loading a mocking library (rspec-mocks via `config.mock_with :rspec`) adds a
+  # #stub helper to Object before ruby_smb is required. BinData's field-name
+  # guard used method_defined? without restricting it to the struct class, so it
+  # picked up that inherited method and refused otherwise-valid field names such
+  # as :stub (RubySMB::Dcerpc::Request actually has a :stub field).
+
+  context 'when an inherited method shares a name with a BinData field' do
+    before do
+      # Simulate what rspec-mocks/mocha do: define a helper method on Object so
+      # that every class, including a fresh BinData struct, inherits it.
+      Object.send(:define_method, :inherited_helper_261) { :from_object }
+    end
+
+    after do
+      Object.send(:remove_method, :inherited_helper_261)
+    end
+
+    it 'allows the field to be defined without raising' do
+      expect(Object.method_defined?(:inherited_helper_261)).to be true
+
+      expect do
+        Class.new(BinData::Record) do
+          uint8 :inherited_helper_261
+        end
+      end.not_to raise_error
+    end
+  end
+
+  context 'when a field name shadows a method defined directly on the struct' do
+    it 'still raises, so the genuine guard is preserved' do
+      expect do
+        Class.new(BinData::Record) do
+          def direct_method_261; end
+          uint8 :direct_method_261
+        end
+      end.to raise_error(/shadows an existing method/)
+    end
+  end
+
+  context 'when a field name collides with a BinData reserved name' do
+    it 'still raises, so the RESERVED guard is preserved' do
+      expect do
+        Class.new(BinData::Record) do
+          uint8 :keys # Hash#keys, part of BinData::Struct::RESERVED
+        end
+      end.to raise_error(/reserved name/)
+    end
+  end
+end


### PR DESCRIPTION
Fixes #261.

## Problem

Loading `ruby_smb` after a mocking library has patched `Object` raises a
`SyntaxError` from BinData while the gem's own struct definitions are being
built:

```
SyntaxError: field 'stub' shadows an existing method in RubySMB::Dcerpc::Request
```

The common trigger is an RSpec suite configured with `config.mock_with :rspec`,
because rspec-mocks adds a `#stub` helper to `BasicObject`/`Object`. If that
happens before `require 'ruby_smb'` (a normal `spec_helper.rb` ordering), the
inherited `#stub` collides with the legitimate `:stub` field on
`RubySMB::Dcerpc::Request`.

The root cause is in BinData's field-name guard
(`BinData::DSLMixin::DSLFieldValidator#name_shadows_method?`), which calls
`@the_class.method_defined?(name)`. Without the second argument,
`method_defined?` also returns `true` for methods inherited from ancestors such
as `Object`, `Kernel` and `Hash`, so any field whose name matches an inherited
helper method is wrongly rejected.

## Fix

This adds a small compatibility shim (`lib/ruby_smb/compatibility.rb`, required
immediately after `require 'bindata'`) that narrows the guard to
`@the_class.method_defined?(name, false)`. The `false` restricts the check to
methods defined directly on the struct class, which is what the guard is meant
to enforce.

Why this does not weaken the guard:

- Field accessors are installed per instance with `define_singleton_method`, so
  an inherited method that happens to share a field's name never gets in the way
  at runtime. Only a method defined directly on the struct class is a genuine
  collision, and that case still raises.
- Names that clash with `Hash` methods or BinData DSL internals are handled by a
  separate, independent check (`name_is_reserved?` against
  `BinData::Struct::RESERVED`). That list is unchanged, so reserved names such as
  `keys` still raise.

This is purely a compatibility/loosening of which field names are accepted. It
does not rename, retype, or otherwise change any BinData data definition, so the
versioning note in CONTRIBUTING.md (minor bump on BinData definition changes)
does not apply here.

## Tests

`spec/lib/ruby_smb/compatibility_spec.rb` covers all three branches:

- an inherited method that shares a field name no longer blocks the field
  (the #261 regression),
- a field that shadows a method defined directly on the struct still raises, and
- a field that collides with a BinData reserved name (`keys`) still raises.

# Verification Steps

- [ ] `bundle install`

## `rake spec`
- [ ] `rake spec`
- [ ] VERIFY no failures

## Manual scenario

```ruby
require 'rspec/mocks/standalone'   # adds Object#stub, as `mock_with :rspec` does
require 'ruby_smb'                  # previously raised "field 'stub' shadows an existing method"
puts 'loaded ruby_smb cleanly'
```
