### PR TITLE
Use the final SessionSetup UID in SMB1 NTLMSSP authentication (fixes Tree Connect against Samba)

### DIFF
--- a/lib/ruby_smb/client/authentication.rb
+++ b/lib/ruby_smb/client/authentication.rb
@@ -99,7 +99,8 @@ module RubySMB
         response = smb1_ntlmssp_final_packet(raw)
         response_code = response.status_code
 
-        @user_id = user_id if response_code == WindowsError::NTStatus::STATUS_SUCCESS
+        # Use the UID from the final response (some servers, e.g. Samba, reassign it on success).
+        @user_id = response.smb_header.uid if response_code == WindowsError::NTStatus::STATUS_SUCCESS
 
         response_code
       end

--- a/spec/lib/ruby_smb/client_spec.rb
+++ b/spec/lib/ruby_smb/client_spec.rb
@@ -1619,11 +1619,13 @@ RSpec.describe RubySMB::Client do
           expect(smb1_client.os_version).to eq '6.1.7601'
         end
 
-        it 'stores the user ID if the status code is \'STATUS_SUCCESS\'' do
+        it 'stores the user ID from the final response packet if the status code is \'STATUS_SUCCESS\'' do
+          # Session UID must come from the final response, not the challenge (Samba reassigns it on success).
           response_packet.smb_header.uid = user_id
+          final_response_packet.smb_header.uid = user_id + 1
           final_response_packet.smb_header.nt_status = WindowsError::NTStatus::STATUS_SUCCESS.value
           smb1_client.smb1_authenticate
-          expect(smb1_client.user_id).to eq user_id
+          expect(smb1_client.user_id).to eq user_id + 1
         end
 
         it 'does not store the user ID if the status code is not \'STATUS_SUCCESS\'' do


### PR DESCRIPTION
Fixes #301.

SMB1 NTLMSSP `smb1_authenticate` stored the `UID` from the challenge response and reused it as the session UID. Servers that assign a new UID in the final `STATUS_SUCCESS` response, such as Samba, then reject every following request, so the `Tree Connect` fails with `ACCESS_DENIED`. Windows keeps the same UID throughout, so this was invisible there.

This stores the UID from the final response instead.

### Verification

- Reproduced against Samba `3.0.20-Debian` (packet capture in #301): before, the `Tree Connect` is sent with the challenge UID and rejected; after, it uses the final UID and succeeds.
- `bundle exec rspec`: 12334 examples, 0 failures. The updated `#smb1_authenticate` spec fails without this change and passes with it.
